### PR TITLE
Fix 'Show in file browser' not working on Linux

### DIFF
--- a/src/core/utilities.cpp
+++ b/src/core/utilities.cpp
@@ -331,63 +331,6 @@ QString ColorToRgba(const QColor &c) {
 
 }
 
-#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-void OpenInFileManager(const QString &path) {
-
-  QProcess proc;
-  proc.start("xdg-mime", QStringList() << "query" << "default" << "inode/directory");
-  proc.waitForFinished();
-  QString desktop_file = proc.readLine().simplified();
-  QStringList data_dirs = QString(getenv("XDG_DATA_DIRS")).split(":");
-
-  QString command;
-  QStringList command_params;
-  for (const QString &data_dir : data_dirs) {
-    QString desktop_file_path = QString("%1/applications/%2").arg(data_dir, desktop_file);
-    if (!QFile::exists(desktop_file_path)) continue;
-    QSettings setting(desktop_file_path, QSettings::IniFormat);
-    setting.beginGroup("Desktop Entry");
-    if (setting.contains("Exec")) {
-      QString cmd = setting.value("Exec").toString();
-      if (cmd.isEmpty()) break;
-      command_params = cmd.split(' ');
-      command = command_params.first();
-      command_params.removeFirst();
-    }
-    setting.endGroup();
-    if (!command.isEmpty()) break;
-  }
-
-  if (command_params.contains("%u")) {
-    command_params.removeAt(command_params.indexOf("%u"));
-  }
-  if (command_params.contains("%U")) {
-    command_params.removeAt(command_params.indexOf("%U"));
-  }
-
-  if (command.isEmpty() || command == "exo-open") {
-    QFileInfo info(path);
-    if (!info.exists()) return;
-    QString directory = info.dir().path();
-    if (directory.isEmpty()) return;
-    QDesktopServices::openUrl(QUrl::fromLocalFile(directory));
-  }
-  else if (command.startsWith("nautilus")) {
-    proc.startDetached(command, QStringList() << command_params << "--select" << path);
-  }
-  else if (command.startsWith("dolphin") || command.startsWith("konqueror") || command.startsWith("kfmclient")) {
-    proc.startDetached(command, QStringList() << command_params << "--select" << "--new-window" << path);
-  }
-  else if (command.startsWith("caja")) {
-    proc.startDetached(command, QStringList() << command_params << "--no-desktop" << path);
-  }
-  else {
-    proc.startDetached(command, QStringList() << command_params << path);
-  }
-
-}
-#endif
-
 #ifdef Q_OS_MACOS
 // Better than openUrl(dirname(path)) - also highlights file at path
 void RevealFileInFinder(QString const &path) {
@@ -437,7 +380,7 @@ void OpenInFileBrowser(const QList<QUrl> &urls) {
     dirs.insert(directory);
 
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
-    OpenInFileManager(path);
+    QDesktopServices::openUrl(QUrl::fromLocalFile(directory));
 #elif defined(Q_OS_MACOS)
     // Revealing multiple files in the finder only opens one window, so it also makes sense to reveal at most one per directory
     RevealFileInFinder(path);


### PR DESCRIPTION
Ubuntu MATE 19.10 with Caja, clicking 'Show in file browser' results in a Caja showing an error `'/path/to/file.mp3' is not a directory`.
Replacing the current code with Clementine's one-liner works for me.