### PR TITLE
Fix 'Show in file browser' for Caja

### DIFF
--- a/src/core/utilities.cpp
+++ b/src/core/utilities.cpp
@@ -379,7 +379,10 @@ void OpenInFileManager(const QString &path) {
     proc.startDetached(command, QStringList() << command_params << "--select" << "--new-window" << path);
   }
   else if (command.startsWith("caja")) {
-    proc.startDetached(command, QStringList() << command_params << "--no-desktop" << path);
+    QFileInfo info(path);
+    if (!info.exists()) return;
+    QString directory = info.dir().path();
+    proc.startDetached(command, QStringList() << command_params << "--no-desktop" << directory);
   }
   else {
     proc.startDetached(command, QStringList() << command_params << path);


### PR DESCRIPTION
This strips out the filename for Caja, which won't handle a file as a parameter.