### PR TITLE
strip directory from OpenInFileManager command

### DIFF
--- a/src/core/utilities.cpp
+++ b/src/core/utilities.cpp
@@ -367,6 +367,10 @@ void OpenInFileManager(const QString &path) {
     command_params.removeAt(command_params.indexOf("%U"));
   }
 
+  if (command.startsWith("/usr/bin/")) {
+    command = command.split("/").last();
+  }
+
   if (command.isEmpty() || command == "exo-open") {
     QFileInfo info(path);
     if (!info.exists()) return;


### PR DESCRIPTION
On my fresh install of Ubuntu MATE 20.04, the value of `command` is `/usr/bin/caja`, causing the lookup to fail. This strips it out so it will be detected properly.

The directory isn't necessary, as it is part of the standard path.