### PR TITLE
Simple addition of playlist actions to icon

### DIFF
--- a/dist/unix/org.strawberrymusicplayer.strawberry.desktop
+++ b/dist/unix/org.strawberrymusicplayer.strawberry.desktop
@@ -12,3 +12,28 @@ Categories=AudioVideo;Player;Qt;Audio;
 StartupNotify=false
 MimeType=x-content/audio-player;application/ogg;application/x-ogg;application/x-ogm-audio;audio/flac;audio/ogg;audio/vorbis;audio/aac;audio/mp4;audio/mpeg;audio/mpegurl;audio/vnd.rn-realaudio;audio/x-flac;audio/x-oggflac;audio/x-vorbis;audio/x-vorbis+ogg;audio/x-speex;audio/x-wav;audio/x-wavpack;audio/x-ape;audio/x-mp3;audio/x-mpeg;audio/x-mpegurl;audio/x-ms-wma;audio/x-musepack;audio/x-pn-realaudio;audio/x-scpls;video/x-ms-asf;x-scheme-handler/tidal;
 StartupWMClass=strawberry
+Actions=Play;Pause;Stop;StopAfterCurrent;Previous;Next;
+
+[Desktop Action Play]
+Name=Play
+Exec=strawberry --play
+
+[Desktop Action Pause]
+Name=Pause
+Exec=strawberry --pause
+
+[Desktop Action Stop]
+Name=Stop
+Exec=strawberry --stop
+
+[Desktop Action StopAfterCurrent]
+Name=Stop after this track
+Exec=strawberry --stop-after-current
+
+[Desktop Action Previous]
+Name=Previous
+Exec=strawberry --previous
+
+[Desktop Action Next]
+Name=Next
+Exec=strawberry --next


### PR DESCRIPTION
This is a very simple addition of playlist/playback actions to Strawberry's icon (via the .desktop file). This re-introduces some nice little polish that was present in Clementine's .desktop file. It works, and it allows one to control Strawberry when its main window is minimized, without having to enable the tray icon.