### PR TITLE
SubsonicRequest: create cover directory if it doesn't exist

### DIFF
--- a/src/subsonic/subsonicrequest.cpp
+++ b/src/subsonic/subsonicrequest.cpp
@@ -22,6 +22,7 @@
 #include <memory>
 
 #include <QObject>
+#include <QDir>
 #include <QMimeType>
 #include <QMimeDatabase>
 #include <QByteArray>
@@ -695,10 +696,14 @@ void SubsonicRequest::AddAlbumCoverRequest(Song &song) {
     return;
   }
 
+  QString cover_path = Song::ImageCacheDir(Song::Source_Subsonic);
+  QDir dir(cover_path);
+  if (!dir.exists()) dir.mkpath(cover_path);
+
   AlbumCoverRequest request;
   request.album_id = song.album_id();
   request.url = cover_url;
-  request.filename = Song::ImageCacheDir(Song::Source_Subsonic) + "/" + cover_url_query.queryItemValue("id");
+  request.filename = cover_path + "/" + cover_url_query.queryItemValue("id");
   if (request.filename.isEmpty()) return;
 
   album_covers_requests_sent_.insert(cover_url, &song);


### PR DESCRIPTION
When starting with a clean installation (`~/.local/share/strawberry` doesn't exist yet), SubsonicRequest tries to write to `~/.local/share/strawberry/strawberry/subsonicalbumcovers` without creating it first.

Steps to reproduce:
* install for the first time, or delete `~/.local/share/strawberry`
* start strawberry
* add subsonic server with "fetch album covers" enabled
* click "Refresh catalogue" in Subsonic tab

This leads to spam of these messages:
```
SubsonicRequest:865              Subsonic: "Error saving image data to /home/ubuntu/.local/share/strawberry/strawberry/subsonicalbumcovers/al-2.png."
```

The directory wasn't created:
```
ubuntu@2c07229f4833:~$ ls /home/ubuntu/.local/share/strawberry/strawberry
strawberry.db  strawberry.db.bak
ubuntu@2c07229f4833:~$
```

All the other song sources seem to use `app_->album_cover_loader()->CoverFilePath()` which checks for existence of the directory. But the Subsonic backend has its own code path to stitch the filename together.