### PR TITLE
Fix HiDPI scaling for glow animation and drag over playlist

### DIFF
--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -215,7 +215,7 @@ PlaylistView::PlaylistView(QWidget *parent)
   dynamic_controls_->hide();
 
   // To proper scale all pixmaps
-  device_pixel_ratio = this->devicePixelRatioF();
+    device_pixel_ratio_ = devicePixelRatioF();
 
   // For fading
   connect(fade_animation_, SIGNAL(valueChanged(qreal)), SLOT(FadePreviousBackgroundImage(qreal)));
@@ -560,8 +560,8 @@ void PlaylistView::UpdateCachedCurrentRowPixmap(QStyleOptionViewItem option, con
   cached_current_row_row_ = idx.row();
 
   option.rect.moveTo(0, 0);
-  cached_current_row_ = QPixmap(option.rect.width() * device_pixel_ratio, option.rect.height() * device_pixel_ratio);
-  cached_current_row_.setDevicePixelRatio(device_pixel_ratio);
+  cached_current_row_ = QPixmap(option.rect.width() * device_pixel_ratio_, option.rect.height() * device_pixel_ratio_);
+  cached_current_row_.setDevicePixelRatio(device_pixel_ratio_);
   cached_current_row_.fill(Qt::transparent);
 
   QPainter p(&cached_current_row_);
@@ -1027,8 +1027,8 @@ void PlaylistView::paintEvent(QPaintEvent *event) {
 
   if (drop_indicator_row_ != -1) {
     if (cached_tree_.isNull()) {
-      cached_tree_ = QPixmap(size().width() * device_pixel_ratio, size().height() * device_pixel_ratio);
-      cached_tree_.setDevicePixelRatio(device_pixel_ratio);
+      cached_tree_ = QPixmap(size().width() * device_pixel_ratio_, size().height() * device_pixel_ratio_);
+      cached_tree_.setDevicePixelRatio(device_pixel_ratio_);
       cached_tree_.fill(Qt::transparent);
 
       QPainter cache_painter(&cached_tree_);

--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -214,6 +214,9 @@ PlaylistView::PlaylistView(QWidget *parent)
 
   dynamic_controls_->hide();
 
+  // To proper scale all pixmaps
+  device_pixel_ratio = this->devicePixelRatioF();
+
   // For fading
   connect(fade_animation_, SIGNAL(valueChanged(qreal)), SLOT(FadePreviousBackgroundImage(qreal)));
   fade_animation_->setDirection(QTimeLine::Backward);  // 1.0 -> 0.0
@@ -557,7 +560,8 @@ void PlaylistView::UpdateCachedCurrentRowPixmap(QStyleOptionViewItem option, con
   cached_current_row_row_ = idx.row();
 
   option.rect.moveTo(0, 0);
-  cached_current_row_ = QPixmap(option.rect.size());
+  cached_current_row_ = QPixmap(option.rect.width() * device_pixel_ratio, option.rect.height() * device_pixel_ratio);
+  cached_current_row_.setDevicePixelRatio(device_pixel_ratio);
   cached_current_row_.fill(Qt::transparent);
 
   QPainter p(&cached_current_row_);
@@ -1023,7 +1027,8 @@ void PlaylistView::paintEvent(QPaintEvent *event) {
 
   if (drop_indicator_row_ != -1) {
     if (cached_tree_.isNull()) {
-      cached_tree_ = QPixmap(size());
+      cached_tree_ = QPixmap(size().width() * device_pixel_ratio, size().height() * device_pixel_ratio);
+      cached_tree_.setDevicePixelRatio(device_pixel_ratio);
       cached_tree_.fill(Qt::transparent);
 
       QPainter cache_painter(&cached_tree_);

--- a/src/playlist/playlistview.h
+++ b/src/playlist/playlistview.h
@@ -220,6 +220,7 @@ class PlaylistView : public QTreeView {
   Playlist *playlist_;
   PlaylistHeader *header_;
 
+  qreal device_pixel_ratio;
   AppearanceSettingsPage::BackgroundImageType background_image_type_;
   QString background_image_filename_;
   AppearanceSettingsPage::BackgroundImagePosition background_image_position_;

--- a/src/playlist/playlistview.h
+++ b/src/playlist/playlistview.h
@@ -220,7 +220,7 @@ class PlaylistView : public QTreeView {
   Playlist *playlist_;
   PlaylistHeader *header_;
 
-  qreal device_pixel_ratio;
+  qreal device_pixel_ratio_;
   AppearanceSettingsPage::BackgroundImageType background_image_type_;
   QString background_image_filename_;
   AppearanceSettingsPage::BackgroundImagePosition background_image_position_;


### PR DESCRIPTION
This set the proper scaling and pixel ratio of QPixmap widgets
used as cached objects, in a effort to solve this following issue:

https://github.com/strawberrymusicplayer/strawberry/issues/515

Most of cached objects uses a custom QPaint instead of the default
painter object from the parent widget. The problem is that, unlike
the painter from the parent object, set by the main application,
and that has DPI and scaling settings from the device, these custom
QPainters don't know about the underlying device, thus uses a
scale of 1 to render artifacts.

When a cached object "edited" by a custom QPaint along his pipeline
where used on a paint or drawrow routine, his stored image is distorted
and burred in a effort to resize it to the display configuration.