### PR TITLE
[Cover manager] Open cover when double clicking

### DIFF
--- a/src/covermanager/albumcovermanager.cpp
+++ b/src/covermanager/albumcovermanager.cpp
@@ -204,7 +204,7 @@ void AlbumCoverManager::Init() {
   connect(ui_->export_covers, SIGNAL(clicked()), SLOT(ExportCovers()));
   connect(cover_fetcher_, SIGNAL(AlbumCoverFetched(quint64, QUrl, QImage, CoverSearchStatistics)), SLOT(AlbumCoverFetched(quint64, QUrl, QImage, CoverSearchStatistics)));
   connect(ui_->action_fetch, SIGNAL(triggered()), SLOT(FetchSingleCover()));
-  connect(ui_->albums, SIGNAL(doubleClicked(QModelIndex)), SLOT(ShowCover()));
+  connect(ui_->albums, SIGNAL(doubleClicked(QModelIndex)), SLOT(AlbumDoubleClicked(QModelIndex)));
   connect(ui_->action_add_to_playlist, SIGNAL(triggered()), SLOT(AddSelectedToPlaylist()));
   connect(ui_->action_load, SIGNAL(triggered()), SLOT(LoadSelectedToPlaylist()));
 
@@ -811,12 +811,10 @@ SongMimeData *AlbumCoverManager::GetMimeDataForAlbums(const QModelIndexList &ind
 
 void AlbumCoverManager::AlbumDoubleClicked(const QModelIndex &index) {
 
-  SongMimeData *mimedata = GetMimeDataForAlbums(QModelIndexList() << index);
-  if (mimedata) {
-    mimedata->from_doubleclick_ = true;
-    emit AddToPlaylist(mimedata);
-  }
-
+  SongList songs = GetSongsInAlbum(index);
+  if (songs.isEmpty()) return;
+  
+  album_cover_choice_controller_->ShowCover(songs.first());
 }
 
 void AlbumCoverManager::AddSelectedToPlaylist() {

--- a/src/covermanager/albumcovermanager.cpp
+++ b/src/covermanager/albumcovermanager.cpp
@@ -204,7 +204,7 @@ void AlbumCoverManager::Init() {
   connect(ui_->export_covers, SIGNAL(clicked()), SLOT(ExportCovers()));
   connect(cover_fetcher_, SIGNAL(AlbumCoverFetched(quint64, QUrl, QImage, CoverSearchStatistics)), SLOT(AlbumCoverFetched(quint64, QUrl, QImage, CoverSearchStatistics)));
   connect(ui_->action_fetch, SIGNAL(triggered()), SLOT(FetchSingleCover()));
-  connect(ui_->albums, SIGNAL(doubleClicked(QModelIndex)), SLOT(AlbumDoubleClicked(QModelIndex)));
+  connect(ui_->albums, SIGNAL(doubleClicked(QModelIndex)), SLOT(ShowCover()));
   connect(ui_->action_add_to_playlist, SIGNAL(triggered()), SLOT(AddSelectedToPlaylist()));
   connect(ui_->action_load, SIGNAL(triggered()), SLOT(LoadSelectedToPlaylist()));
 


### PR DESCRIPTION
This is just a proposed change to fix #612.  
It has not been tested, and it doesn't handle the function `AlbumCoverManager::AlbumDoubleClicked()`. Maybe changing the content of this function would be better, but I'll let you judge that :)