### PR TITLE
Store Tidal MPEG-DASH file in data uri

### DIFF
--- a/src/tidal/tidalstreamurlrequest.cpp
+++ b/src/tidal/tidalstreamurlrequest.cpp
@@ -210,29 +210,10 @@ void TidalStreamURLRequest::StreamURLReceived() {
 
     QXmlStreamReader xml_reader(data_manifest);
     if (xml_reader.readNextStartElement()) {
-
-      QString filepath = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/tidalstreams";
-      QString filename = "tidal-" + QString::number(song_id_) + ".xml";
-      if (!QDir().mkpath(filepath)) {
-        Error(QString("Failed to create directory %1.").arg(filepath), json_obj);
-        emit StreamURLFinished(id_, original_url_, original_url_, Song::FileType_Stream, -1, -1, -1, errors_.first());
-        return;
-      }
-      QUrl url("file://" + filepath + "/" + filename);
-      QFile file(url.toLocalFile());
-      if (file.exists()) {
-        file.remove();
-      }
-      if (!file.open(QIODevice::WriteOnly)) {
-        Error(QString("Failed to open file %1 for writing: %2.").arg(url.toLocalFile(), file.errorString()), json_obj);
-        emit StreamURLFinished(id_, original_url_, original_url_, Song::FileType_Stream, -1, -1, -1, errors_.first());
-        return;
-      }
-      file.write(data_manifest);
-      file.close();
-
+      QUrl url;
+      url.setScheme("data");
+      url.setPath(QString("application/dash+xml;base64,%1").arg(manifest));
       urls << url;
-
     }
 
     else {


### PR DESCRIPTION
Apparently, Clementine and Strawberry can process data URIs just fine, so creating physical files with MPEG-DASH descriptions for Tidal streams can be avoided.

I guess the check for the MPD tag is premature generalization, but that's for y'all to decide.

I'd also like to hear your opinion on whether to use the base64-encoded manifest string, which would get rid of the QByteArray to QString conversion but would force the player to decode the base64 again and use a bit more space than the current percent-encoded path. OTOH, as it stands now, the player would need to do decoding anyway, just not base64 but percent-encoding.

If both of these simplifications were applied, lines 215 to 221 would boil down to a single `url.setPath`.