### PR TITLE
Set SmoothPixmapTransform for playing-widget and context album art di…

### DIFF
--- a/src/context/contextalbum.cpp
+++ b/src/context/contextalbum.cpp
@@ -114,6 +114,8 @@ void ContextAlbum::paintEvent(QPaintEvent*) {
 }
 
 void ContextAlbum::DrawImage(QPainter *p) {
+  
+  p->setRenderHint(QPainter::SmoothPixmapTransform);
 
   if (width() != prev_width_) {
     cover_loader_options_.desired_height_ = width() - kWidgetSpacing;

--- a/src/widgets/playingwidget.cpp
+++ b/src/widgets/playingwidget.cpp
@@ -438,6 +438,8 @@ void PlayingWidget::paintEvent(QPaintEvent *e) {
 
 void PlayingWidget::DrawContents(QPainter *p) {
 
+  p->setRenderHint(QPainter::SmoothPixmapTransform);
+
   switch (mode_) {
     case SmallSongDetails:
       // Draw the cover


### PR DESCRIPTION
Cover art pixmaps in the Playing-Widget and Context tab appear jagged or blocky on my desktop (4k monitor, doesn't seem to affect 1080p laptop).  Setting QPainter::SmoothPixmapTransform appears to fix this issue nicely.  There are likely other areas that can benefit from this change but these were the most obvious to me.

See attached screenshots (be sure to zoom in):


![strawberry_playing_before](https://user-images.githubusercontent.com/43704682/134998556-4da1306d-30a9-4709-9b55-3521b2b3c8f9.png)
![strawberry_playing_after](https://user-images.githubusercontent.com/43704682/134998559-f4b85933-1ab4-4066-a9f6-40c20a277c96.png)
![strawberry_context_before](https://user-images.githubusercontent.com/43704682/134998560-6bef694b-8916-45f8-91ac-fe6c6d790b32.png)
![strawberry_context_after](https://user-images.githubusercontent.com/43704682/134998563-70697769-b767-4059-80dd-4f6699d2f565.png)
