### PR TITLE
Don't use C-style casts

### DIFF
--- a/src/analyzer/analyzerbase.cpp
+++ b/src/analyzer/analyzerbase.cpp
@@ -98,7 +98,7 @@ void Analyzer::Base::paintEvent(QPaintEvent *e) {
 
       // convert to mono here - our built in analyzers need mono, but the engines provide interleaved pcm
       for (uint x = 0; static_cast<int>(x) < fht_->size(); ++x) {
-        lastscope_[x] = double(thescope[i] + thescope[i + 1]) / (2 * (1 << 15));
+        lastscope_[x] = static_cast<float>(thescope[i] + thescope[i + 1]) / (2 * (1U << 15U));
         i += 2;
       }
 
@@ -178,7 +178,7 @@ void Analyzer::Base::demo(QPainter &p) {
   if (t < 201) {
     Scope s(32);
 
-    const double dt = double(t) / 200;
+    const double dt = static_cast<double>(t) / 200;
     for (uint i = 0; i < s.size(); ++i) {
       s[i] = dt * (sin(M_PI + (i * M_PI) / s.size()) + 1.0);
     }

--- a/src/analyzer/blockanalyzer.cpp
+++ b/src/analyzer/blockanalyzer.cpp
@@ -117,7 +117,7 @@ void BlockAnalyzer::determineStep() {
   // the fall time of 30 is too slow on framerates above 50fps
   const double fallTime = static_cast<double>(timeout() < 20 ? 20 * rows_ : 30 * rows_);
 
-  step_ = double(rows_ * timeout()) / fallTime;
+  step_ = static_cast<double>(rows_ * timeout()) / fallTime;
 
 }
 

--- a/src/analyzer/boomanalyzer.cpp
+++ b/src/analyzer/boomanalyzer.cpp
@@ -81,7 +81,7 @@ void BoomAnalyzer::resizeEvent(QResizeEvent *e) {
   bands_ = qMin(static_cast<int>(static_cast<double>(width() + 1) / (kColumnWidth + 1)) + 1, kMaxBandCount);
   scope_.resize(bands_);
 
-  F_ = double(HEIGHT) / (log10(256) * double(1.1) /*<- max. amplitude*/);
+  F_ = static_cast<double>(HEIGHT) / (log10(256) * static_cast<double>(1.1) /*<- max. amplitude*/);
 
   barPixmap_ = QPixmap(kColumnWidth - 2, HEIGHT);
   canvas_ = QPixmap(size());

--- a/src/analyzer/fht.cpp
+++ b/src/analyzer/fht.cpp
@@ -28,7 +28,7 @@
 #include <QVector>
 #include <QtMath>
 
-FHT::FHT(uint n) : num_((n < 3) ? 0 : 1 << n), exp2_((n < 3) ? int(-1) : int(n)) {
+FHT::FHT(uint n) : num_((n < 3) ? 0 : 1 << n), exp2_((n < 3) ? static_cast<int>(-1) : static_cast<int>(n)) {
 
   if (n > 3) {
     buf_vector_.resize(num_);

--- a/src/collection/collectionbackend.cpp
+++ b/src/collection/collectionbackend.cpp
@@ -853,7 +853,7 @@ void CollectionBackend::MarkSongsUnavailable(const SongList &songs, const bool u
   QSqlDatabase db(db_->Connect());
 
   SqlQuery remove(db);
-  remove.prepare(QString("UPDATE %1 SET unavailable = %2 WHERE ROWID = :id").arg(songs_table_).arg(int(unavailable)));
+  remove.prepare(QString("UPDATE %1 SET unavailable = %2 WHERE ROWID = :id").arg(songs_table_).arg(static_cast<int>(unavailable)));
 
   ScopedTransaction transaction(&db);
   for (const Song &song : songs) {
@@ -1394,7 +1394,7 @@ bool CollectionBackend::UpdateCompilations(const QSqlDatabase &db, SongList &del
   // Update the song
   SqlQuery q(db);
   q.prepare(QString("UPDATE %1 SET compilation_detected = :compilation_detected, compilation_effective = ((compilation OR :compilation_detected OR compilation_on) AND NOT compilation_off) + 0 WHERE (url = :url1 OR url = :url2 OR url = :url3 OR url = :url4) AND unavailable = 0").arg(songs_table_));
-  q.BindValue(":compilation_detected", int(compilation_detected));
+  q.BindValue(":compilation_detected", static_cast<int>(compilation_detected));
   q.BindValue(":url1", url);
   q.BindValue(":url2", url.toString());
   q.BindValue(":url3", url.toString(QUrl::FullyEncoded));

--- a/src/collection/collectionfilterwidget.cpp
+++ b/src/collection/collectionfilterwidget.cpp
@@ -176,9 +176,9 @@ void CollectionFilterWidget::Init(CollectionModel *model) {
     if (s.contains(group_by_version())) version = s.value(group_by_version(), 0).toInt();
     if (version == 1) {
       model_->SetGroupBy(CollectionModel::Grouping(
-          CollectionModel::GroupBy(s.value(group_by(1), int(CollectionModel::GroupBy_AlbumArtist)).toInt()),
-          CollectionModel::GroupBy(s.value(group_by(2), int(CollectionModel::GroupBy_AlbumDisc)).toInt()),
-          CollectionModel::GroupBy(s.value(group_by(3), int(CollectionModel::GroupBy_None)).toInt())));
+          CollectionModel::GroupBy(s.value(group_by(1), static_cast<int>(CollectionModel::GroupBy_AlbumArtist)).toInt()),
+          CollectionModel::GroupBy(s.value(group_by(2), static_cast<int>(CollectionModel::GroupBy_AlbumDisc)).toInt()),
+          CollectionModel::GroupBy(s.value(group_by(3), static_cast<int>(CollectionModel::GroupBy_None)).toInt())));
     }
     else {
       model_->SetGroupBy(CollectionModel::Grouping(CollectionModel::GroupBy_AlbumArtist, CollectionModel::GroupBy_AlbumDisc, CollectionModel::GroupBy_None));
@@ -374,9 +374,9 @@ void CollectionFilterWidget::GroupingChanged(const CollectionModel::Grouping g) 
     QSettings s;
     s.beginGroup(settings_group_);
     s.setValue(group_by_version(), 1);
-    s.setValue(group_by(1), int(g[0]));
-    s.setValue(group_by(2), int(g[1]));
-    s.setValue(group_by(3), int(g[2]));
+    s.setValue(group_by(1), static_cast<int>(g[0]));
+    s.setValue(group_by(2), static_cast<int>(g[1]));
+    s.setValue(group_by(3), static_cast<int>(g[2]));
     s.endGroup();
   }
 

--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -1370,7 +1370,7 @@ void MainWindow::TrackSkipped(PlaylistItemPtr item) {
     Song song = item->Metadata();
     const qint64 position = app_->player()->engine()->position_nanosec();
     const qint64 length = app_->player()->engine()->length_nanosec();
-    const float percentage = (length == 0 ? 1 : float(position) / length);
+    const float percentage = (length == 0 ? 1 : static_cast<float>(position) / static_cast<float>(length));
 
     const qint64 seconds_left = (length - position) / kNsecPerSec;
     const qint64 seconds_total = length / kNsecPerSec;
@@ -1630,7 +1630,7 @@ void MainWindow::Seeked(const qint64 microseconds) {
 
   const qint64 position = microseconds / kUsecPerSec;
   const qint64 length = app_->player()->GetCurrentItem()->Metadata().length_nanosec() / kNsecPerSec;
-  tray_icon_->SetProgress(static_cast<int>(double(position) / length * 100));
+  tray_icon_->SetProgress(static_cast<int>(static_cast<double>(position) / length * 100));
 
 }
 
@@ -1641,10 +1641,10 @@ void MainWindow::UpdateTrackPosition() {
 
   const qint64 length = (item->Metadata().length_nanosec() / kNsecPerSec);
   if (length <= 0) return;
-  const int position = std::floor(float(app_->player()->engine()->position_nanosec()) / kNsecPerSec + 0.5);
+  const int position = std::floor(static_cast<float>(app_->player()->engine()->position_nanosec()) / kNsecPerSec + 0.5);
 
   // Update the tray icon every 10 seconds
-  if (position % 10 == 0) tray_icon_->SetProgress(static_cast<int>(double(position) / length * 100));
+  if (position % 10 == 0) tray_icon_->SetProgress(static_cast<int>(static_cast<double>(position) / length * 100));
 
   // Send Scrobble
   if (app_->scrobbler()->IsEnabled() && item->Metadata().is_metadata_good()) {
@@ -1664,7 +1664,7 @@ void MainWindow::UpdateTrackSliderPosition() {
 
   PlaylistItemPtr item(app_->player()->GetCurrentItem());
 
-  const int slider_position = std::floor(float(app_->player()->engine()->position_nanosec()) / kNsecPerMsec);
+  const int slider_position = std::floor(static_cast<float>(app_->player()->engine()->position_nanosec()) / kNsecPerMsec);
   const int slider_length = static_cast<int>(app_->player()->engine()->length_nanosec() / kNsecPerMsec);
 
   // Update the slider

--- a/src/core/stylehelper.cpp
+++ b/src/core/stylehelper.cpp
@@ -369,7 +369,7 @@ QPixmap StyleHelper::disabledSideBarIcon(const QPixmap &enabledicon) {
     auto scanLine = reinterpret_cast<QRgb*>(im.scanLine(y));
     for (int x=0; x<im.width(); ++x) {
       QRgb pixel = *scanLine;
-      char intensity = char(qGray(pixel));
+      char intensity = static_cast<char>(qGray(pixel));
       *scanLine = qRgba(intensity, intensity, intensity, qAlpha(pixel));
       ++scanLine;
     }

--- a/src/core/systemtrayicon.cpp
+++ b/src/core/systemtrayicon.cpp
@@ -45,7 +45,7 @@ QPixmap SystemTrayIcon::CreateIcon(const QPixmap &icon, const QPixmap &grey_icon
   if (trayicon_progress_) {
     // The angle of the line that's used to cover the icon.
     // Centered on rect.topLeft()
-    double angle = double(100 - song_progress_) / 100.0 * M_PI_2;
+    double angle = static_cast<double>(100 - song_progress_) / 100.0 * M_PI_2;
     double length = sqrt(pow(rect.width(), 2.0) + pow(rect.height(), 2.0));
 
     QPolygon mask;

--- a/src/core/utilities.cpp
+++ b/src/core/utilities.cpp
@@ -191,13 +191,13 @@ QString PrettySize(const quint64 bytes) {
       ret = QString::number(bytes) + " bytes";
     }
     else if (bytes <= 1000 * 1000) {
-      ret = QString::asprintf("%.1f KB", float(bytes) / 1000);
+      ret = QString::asprintf("%.1f KB", static_cast<float>(bytes) / 1000);
     }
     else if (bytes <= 1000 * 1000 * 1000) {
-      ret = QString::asprintf("%.1f MB", float(bytes) / (1000 * 1000));
+      ret = QString::asprintf("%.1f MB", static_cast<float>(bytes) / (1000 * 1000));
     }
     else {
-      ret = QString::asprintf("%.1f GB", float(bytes) / (1000 * 1000 * 1000));
+      ret = QString::asprintf("%.1f GB", static_cast<float>(bytes) / (1000 * 1000 * 1000));
     }
   }
   return ret;
@@ -482,8 +482,8 @@ QByteArray Hmac(const QByteArray &key, const QByteArray &data, const QCryptograp
   const int kBlockSize = 64;  // bytes
   Q_ASSERT(key.length() <= kBlockSize);
 
-  QByteArray inner_padding(kBlockSize, char(0x36));
-  QByteArray outer_padding(kBlockSize, char(0x5c));
+  QByteArray inner_padding(kBlockSize, static_cast<char>(0x36));
+  QByteArray outer_padding(kBlockSize, static_cast<char>(0x5c));
 
   for (int i = 0; i < key.length(); ++i) {
     inner_padding[i] = inner_padding[i] ^ key[i];

--- a/src/core/windows7thumbbar.cpp
+++ b/src/core/windows7thumbbar.cpp
@@ -80,7 +80,7 @@ ITaskbarList3 *Windows7ThumbBar::CreateTaskbarList() {
   static const GUID CLSID_ITaskbarList = { 0x56FDF344,0xFD6D,0x11d0,{0x95,0x8A,0x00,0x60,0x97,0xC9,0xA0,0x90}};
 
   // Create the taskbar list
-  HRESULT hr = CoCreateInstance(CLSID_ITaskbarList, nullptr, CLSCTX_ALL, IID_ITaskbarList3, (void**)&taskbar_list);
+  HRESULT hr = CoCreateInstance(CLSID_ITaskbarList, nullptr, CLSCTX_ALL, IID_ITaskbarList3, reinterpret_cast<void**>(&taskbar_list));
   if (hr != S_OK) {
     qLog(Warning) << "Error creating the ITaskbarList3 interface" << Qt::hex << DWORD (hr);
     return nullptr;

--- a/src/covermanager/albumcoverfetchersearch.cpp
+++ b/src/covermanager/albumcoverfetchersearch.cpp
@@ -377,10 +377,10 @@ float AlbumCoverFetcherSearch::ScoreImage(const QSize size) {
   if (size.width() == 0 || size.height() == 0) return 0.0;
 
   // A 500x500px image scores 1.0, bigger scores higher
-  const float size_score = std::sqrt(float(size.width() * size.height())) / kTargetSize;
+  const float size_score = std::sqrt(static_cast<float>(size.width() * size.height())) / kTargetSize;
 
   // A 1:1 image scores 1.0, anything else scores less
-  const float aspect_score = float(1.0) - float(std::max(size.width(), size.height()) - std::min(size.width(), size.height())) / float(std::max(size.height(), size.width()));
+  const float aspect_score = static_cast<float>(1.0) - static_cast<float>(std::max(size.width(), size.height()) - std::min(size.width(), size.height())) / static_cast<float>(std::max(size.height(), size.width()));
 
   return size_score + aspect_score;
 

--- a/src/covermanager/discogscoverprovider.cpp
+++ b/src/covermanager/discogscoverprovider.cpp
@@ -440,7 +440,7 @@ void DiscogsCoverProvider::HandleReleaseReply(QNetworkReply *reply, const quint6
     int width = obj_image["width"].toInt();
     int height = obj_image["height"].toInt();
     if (width < 300 || height < 300) continue;
-    const float aspect_score = float(1.0) - float(std::max(width, height) - std::min(width, height)) / float(std::max(height, width));
+    const float aspect_score = static_cast<float>(1.0) - static_cast<float>(std::max(width, height) - std::min(width, height)) / static_cast<float>(std::max(height, width));
     if (aspect_score < 0.85) continue;
     CoverProviderSearchResult result;
     result.artist = artist;

--- a/src/device/devicemanager.cpp
+++ b/src/device/devicemanager.cpp
@@ -856,7 +856,7 @@ void DeviceManager::TasksChanged() {
 
     DeviceInfo *info = IndexToItem(idx);
     if (task.progress_max) {
-      info->task_percentage_ = static_cast<int>(float(task.progress) / task.progress_max * 100);
+      info->task_percentage_ = static_cast<int>(static_cast<float>(task.progress) / static_cast<float>(task.progress_max) * 100);
     }
     else {
       info->task_percentage_ = 0;

--- a/src/device/mtpdevice.cpp
+++ b/src/device/mtpdevice.cpp
@@ -155,7 +155,7 @@ bool MtpDevice::StartCopy(QList<Song::FileType> *supported_types) {
 static int ProgressCallback(uint64_t const sent, uint64_t const total, void const *const data) {
 
   const MusicStorage::CopyJob *job = reinterpret_cast<const MusicStorage::CopyJob*>(data);
-  job->progress_(float(sent) / total);
+  job->progress_(static_cast<float>(sent) / total);
 
   return 0;
 

--- a/src/dialogs/deleteconfirmationdialog.cpp
+++ b/src/dialogs/deleteconfirmationdialog.cpp
@@ -93,7 +93,7 @@ DeleteConfirmationDialog::DeleteConfirmationDialog(const QStringList &files, QWi
 #endif
   if (screen) {
     max_width = static_cast<int>(screen->geometry().size().width() / 0.5);
-    max_height = static_cast<int>(float(screen->geometry().size().height()) / float(1.5));
+    max_height = static_cast<int>(static_cast<float>(screen->geometry().size().height()) / static_cast<float>(1.5));
   }
   int min_width = std::min(list->sizeHintForColumn(0) + 100, max_width);
   int min_height = std::min((list->sizeHintForRow(0) * list->count()) + 160, max_height);

--- a/src/engine/gstenginepipeline.cpp
+++ b/src/engine/gstenginepipeline.cpp
@@ -384,7 +384,7 @@ bool GstEnginePipeline::InitAudioBin() {
       g_object_set(G_OBJECT(rgvolume), "album-mode", rg_mode_, nullptr);
       g_object_set(G_OBJECT(rgvolume), "pre-amp", rg_preamp_, nullptr);
       g_object_set(G_OBJECT(rgvolume), "fallback-gain", rg_fallbackgain_, nullptr);
-      g_object_set(G_OBJECT(rglimiter), "enabled", int(rg_compression_), nullptr);
+      g_object_set(G_OBJECT(rglimiter), "enabled", static_cast<int>(rg_compression_), nullptr);
     }
   }
 
@@ -665,7 +665,7 @@ GstPadProbeReturn GstEnginePipeline::HandoffCallback(GstPad *pad, GstPadProbeInf
     int16_t *d = static_cast<int16_t*>(g_malloc(buf16_size));
     memset(d, 0, buf16_size);
     for (int i = 0; i < (samples * channels); ++i) {
-      float sample_float = (s[i] * float(32768.0));
+      float sample_float = (s[i] * static_cast<float>(32768.0));
       d[i] = static_cast<int16_t>(sample_float);
     }
     gst_buffer_unmap(buf, &map_info);
@@ -1142,7 +1142,7 @@ void GstEnginePipeline::SetVolumeModifier(const qreal mod) {
 void GstEnginePipeline::UpdateVolume() {
 
   if (!volume_) return;
-  double vol = double(volume_percent_) * double(0.01) * volume_modifier_;
+  double vol = static_cast<double>(volume_percent_) * static_cast<double>(0.01) * volume_modifier_;
   g_object_set(G_OBJECT(volume_), "volume", vol, nullptr);
 
 }
@@ -1176,7 +1176,7 @@ void GstEnginePipeline::UpdateEqualizer() {
 
   // Update band gains
   for (int i = 0; i < kEqBandCount; ++i) {
-    float gain = eq_enabled_ ? eq_band_gains_[i] : float(0.0);
+    float gain = eq_enabled_ ? eq_band_gains_[i] : static_cast<float>(0.0);
     if (gain < 0) {
       gain *= 0.24;
     }
@@ -1193,7 +1193,7 @@ void GstEnginePipeline::UpdateEqualizer() {
 
   // Update preamp
   float preamp = 1.0;
-  if (eq_enabled_) preamp = float(eq_preamp_ + 100) * float(0.01);  // To scale from 0.0 to 2.0
+  if (eq_enabled_) preamp = static_cast<float>(eq_preamp_ + 100) * static_cast<float>(0.01);  // To scale from 0.0 to 2.0
 
   g_object_set(G_OBJECT(equalizer_preamp_), "volume", preamp, nullptr);
 

--- a/src/engine/mmdevicefinder.cpp
+++ b/src/engine/mmdevicefinder.cpp
@@ -54,7 +54,7 @@ QList<DeviceFinder::Device> MMDeviceFinder::ListDevices() {
   devices.append(default_device);
 
   IMMDeviceEnumerator *enumerator = nullptr;
-  HRESULT hr = CoCreateInstance(CLSID_MMDeviceEnumerator, nullptr, CLSCTX_ALL, IID_IMMDeviceEnumerator, (void**)&enumerator);
+  HRESULT hr = CoCreateInstance(CLSID_MMDeviceEnumerator, nullptr, CLSCTX_ALL, IID_IMMDeviceEnumerator, reinterpret_cast<void**>(&enumerator));
   if (hr == S_OK) {
     IMMDeviceCollection *collection = nullptr;
     hr = enumerator->EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE, &collection);

--- a/src/engine/vlcengine.cpp
+++ b/src/engine/vlcengine.cpp
@@ -182,7 +182,7 @@ void VLCEngine::Seek(const quint64 offset_nanosec) {
   uint len = length();
   if (len == 0) return;
 
-  float pos = float(offset) / len;
+  float pos = static_cast<float>(offset) / len;
 
   libvlc_media_player_set_position(player_, pos);
 

--- a/src/equalizer/equalizerslider.cpp
+++ b/src/equalizer/equalizerslider.cpp
@@ -59,7 +59,7 @@ EqualizerSlider::~EqualizerSlider() {
 void EqualizerSlider::OnValueChanged(int value) {
 
   // Converting % to dB as per GstEnginePipeline::UpdateEqualizer():
-  float gain = (static_cast<int>(value) < 0) ? static_cast<float>(value) * float(0.24) : float(value) * float(0.12);
+  float gain = (static_cast<int>(value) < 0) ? static_cast<float>(value) * static_cast<float>(0.24) : static_cast<float>(value) * static_cast<float>(0.12);
 
   ui_->gain->setText(tr("%1 dB").arg(gain));  // Gain [dB]
   emit ValueChanged(value);

--- a/src/internet/internetsearchview.cpp
+++ b/src/internet/internetsearchview.cpp
@@ -225,7 +225,7 @@ void InternetSearchView::ReloadSettings() {
 
   // Internet search settings
 
-  search_type_ = InternetSearchView::SearchType(s.value("type", int(InternetSearchView::SearchType_Artists)).toInt());
+  search_type_ = InternetSearchView::SearchType(s.value("type", static_cast<int>(InternetSearchView::SearchType_Artists)).toInt());
   switch (search_type_) {
     case InternetSearchView::SearchType_Artists:
       ui_->radiobutton_search_artists->setChecked(true);
@@ -241,9 +241,9 @@ void InternetSearchView::ReloadSettings() {
   int group_by_version = s.value("search_group_by_version", 0).toInt();
   if (group_by_version == 1 && s.contains("search_group_by1") && s.contains("search_group_by2") && s.contains("search_group_by3")) {
     SetGroupBy(CollectionModel::Grouping(
-        CollectionModel::GroupBy(s.value("search_group_by1", int(CollectionModel::GroupBy_AlbumArtist)).toInt()),
-        CollectionModel::GroupBy(s.value("search_group_by2", int(CollectionModel::GroupBy_AlbumDisc)).toInt()),
-        CollectionModel::GroupBy(s.value("search_group_by3", int(CollectionModel::GroupBy_None)).toInt())));
+        CollectionModel::GroupBy(s.value("search_group_by1", static_cast<int>(CollectionModel::GroupBy_AlbumArtist)).toInt()),
+        CollectionModel::GroupBy(s.value("search_group_by2", static_cast<int>(CollectionModel::GroupBy_AlbumDisc)).toInt()),
+        CollectionModel::GroupBy(s.value("search_group_by3", static_cast<int>(CollectionModel::GroupBy_None)).toInt())));
   }
   else {
     SetGroupBy(CollectionModel::Grouping(CollectionModel::GroupBy(CollectionModel::GroupBy_AlbumArtist), CollectionModel::GroupBy(CollectionModel::GroupBy_AlbumDisc), CollectionModel::GroupBy(CollectionModel::GroupBy_None)));
@@ -713,9 +713,9 @@ void InternetSearchView::SetGroupBy(const CollectionModel::Grouping g) {
   QSettings s;
   s.beginGroup(service_->settings_group());
   s.setValue("search_group_by_version", 1);
-  s.setValue("search_group_by1", int(g.first));
-  s.setValue("search_group_by2", int(g.second));
-  s.setValue("search_group_by3", int(g.third));
+  s.setValue("search_group_by1", static_cast<int>(g.first));
+  s.setValue("search_group_by2", static_cast<int>(g.second));
+  s.setValue("search_group_by3", static_cast<int>(g.third));
   s.endGroup();
 
   // Make sure the correct action is checked.
@@ -752,7 +752,7 @@ void InternetSearchView::SetSearchType(const InternetSearchView::SearchType type
 
   QSettings s;
   s.beginGroup(service_->settings_group());
-  s.setValue("type", int(search_type_));
+  s.setValue("type", static_cast<int>(search_type_));
   s.endGroup();
 
   TextEdited(ui_->search->text());

--- a/src/moodbar/moodbarbuilder.cpp
+++ b/src/moodbar/moodbarbuilder.cpp
@@ -187,9 +187,9 @@ QByteArray MoodbarBuilder::Finish(int width) {
 
     const int n = end - start;
 
-    *(data++) = char(rgb.r / n);
-    *(data++) = char(rgb.g / n);
-    *(data++) = char(rgb.b / n);
+    *(data++) = static_cast<char>(rgb.r / n);
+    *(data++) = static_cast<char>(rgb.g / n);
+    *(data++) = static_cast<char>(rgb.b / n);
 
   }
   return ret;

--- a/src/moodbar/moodbarrenderer.cpp
+++ b/src/moodbar/moodbarrenderer.cpp
@@ -77,9 +77,9 @@ ColorVector MoodbarRenderer::Colors(const QByteArray &data, const MoodbarStyle s
   // Read the colors, keeping track of some histograms
   for (int i = 0; i < samples; ++i) {
     QColor color;
-    color.setRed(int(*data_p++));
-    color.setGreen(int(*data_p++));
-    color.setBlue(int(*data_p++));
+    color.setRed(static_cast<int>(*data_p++));
+    color.setGreen(static_cast<int>(*data_p++));
+    color.setBlue(static_cast<int>(*data_p++));
 
     colors << color;
 
@@ -141,12 +141,12 @@ void MoodbarRenderer::Render(const ColorVector &colors, QPainter *p, const QRect
     screen_colors[x].getHsv(&h, &s, &v);
 
     for (int y = 0; y <= rect.height() / 2; ++y) {
-      float coeff = float(y) / float(rect.height() / 2);  // NOLINT(bugprone-integer-division)
+      float coeff = static_cast<float>(y) / static_cast<float>(rect.height() / 2);  // NOLINT(bugprone-integer-division)
       float coeff2 = 1.0F - ((1.0F - coeff) * (1.0F - coeff));
       coeff = 1.0F - (1.0F - coeff) / 2.0F;
       coeff2 = 1.F - (1.F - coeff2) / 2.0F;
 
-      p->setPen(QColor::fromHsv(h, qBound(0, int(float(s) * coeff), 255), qBound(0, int(255.F - (255.F - float(v)) * coeff2), 255)));
+      p->setPen(QColor::fromHsv(h, qBound(0, static_cast<int>(static_cast<float>(s) * coeff), 255), qBound(0, static_cast<int>(255.F - (255.F - static_cast<float>(v)) * coeff2), 255)));
 
       p->drawPoint(rect.left() + x, rect.top() + y);
       p->drawPoint(rect.left() + x, rect.top() + rect.height() - 1 - y);

--- a/src/organize/organize.cpp
+++ b/src/organize/organize.cpp
@@ -315,7 +315,7 @@ Song::FileType Organize::CheckTranscode(Song::FileType original_type) const {
 void Organize::SetSongProgress(float progress, bool transcoded) {
 
   const int max = transcoded ? 50 : 100;
-  current_copy_progress_ = (transcoded ? 50 : 0) + qBound(0, static_cast<int>(progress * float(max)), max - 1);
+  current_copy_progress_ = (transcoded ? 50 : 0) + qBound(0, static_cast<int>(progress * static_cast<float>(max)), max - 1);
   UpdateProgress();
 
 }

--- a/src/organize/organizedialog.cpp
+++ b/src/organize/organizedialog.cpp
@@ -259,8 +259,8 @@ void OrganizeDialog::AdjustSize() {
   int max_width = 0;
   int max_height = 0;
   if (screen) {
-    max_width = static_cast<int>(float(screen->geometry().size().width()) / float(0.5));
-    max_height = static_cast<int>(float(screen->geometry().size().height()) / float(1.5));
+    max_width = static_cast<int>(static_cast<float>(screen->geometry().size().width()) / static_cast<float>(0.5));
+    max_height = static_cast<int>(static_cast<float>(screen->geometry().size().height()) / static_cast<float>(1.5));
   }
 
   int min_width = 0;

--- a/src/osd/osddbus.cpp
+++ b/src/osd/osddbus.cpp
@@ -68,8 +68,8 @@ QDBusArgument &operator<<(QDBusArgument &arg, const QImage &image) {
   // ABGR -> GBAR
   QImage i(scaled.size(), scaled.format());
   for (int y = 0; y < i.height(); ++y) {
-    QRgb *p = (QRgb*)scaled.scanLine(y);
-    QRgb *q = (QRgb*)i.scanLine(y);
+    QRgb *p = reinterpret_cast<QRgb*>(scaled.scanLine(y));
+    QRgb *q = reinterpret_cast<QRgb*>(i.scanLine(y));
     QRgb *end = p + scaled.width();
     while (p < end) {
       *q = qRgba(qGreen(*p), qBlue(*p), qAlpha(*p), qRed(*p));

--- a/src/playlist/playlistdelegates.cpp
+++ b/src/playlist/playlistdelegates.cpp
@@ -100,7 +100,7 @@ void QueuedItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
     if (ok && queue_pos != -1) {
       float opacity = static_cast<float>(kQueueOpacitySteps - qMin(kQueueOpacitySteps, queue_pos));
       opacity /= kQueueOpacitySteps;
-      opacity *= float(1.0) - float(kQueueOpacityLowerBound);
+      opacity *= static_cast<float>(1.0) - static_cast<float>(kQueueOpacityLowerBound);
       opacity += kQueueOpacityLowerBound;
       DrawBox(painter, option.rect, option.font, QString::number(queue_pos + 1), kQueueBoxLength, opacity);
     }
@@ -541,7 +541,7 @@ QString RatingItemDelegate::displayText(const QVariant &value, const QLocale&) c
   if (value.isNull() || value.toDouble() <= 0) return QString();
 
   // Round to the nearest 0.5
-  const double rating = double(lround(value.toDouble() * RatingPainter::kStarCount * 2)) / 2;
+  const double rating = static_cast<double>(lround(value.toDouble() * RatingPainter::kStarCount * 2)) / 2;
 
   return QString::number(rating, 'f', 1);
 

--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -475,7 +475,7 @@ QList<QPixmap> PlaylistView::LoadBarPixmap(const QString &filename) {
     QImage step(image.copy());
     p.begin(&step);
     p.setCompositionMode(QPainter::CompositionMode_SourceAtop);
-    p.setOpacity(0.4 - 0.6 * sin(float(i) / kGlowIntensitySteps * (M_PI / 2)));
+    p.setOpacity(0.4 - 0.6 * sin(static_cast<float>(i) / kGlowIntensitySteps * (M_PI / 2)));
     p.fillRect(step.rect(), Qt::white);
     p.end();
     ret << QPixmap::fromImage(step);

--- a/src/settings/backendsettingspage.cpp
+++ b/src/settings/backendsettingspage.cpp
@@ -466,8 +466,8 @@ void BackendSettingsPage::Save() {
 
   s.setValue("rgenabled", ui_->checkbox_replaygain->isChecked());
   s.setValue("rgmode", ui_->combobox_replaygainmode->currentIndex());
-  s.setValue("rgpreamp", double(ui_->stickyslider_replaygainpreamp->value()) / 10 - 60);
-  s.setValue("rgfallbackgain", double(ui_->stickyslider_replaygainfallbackgain->value()) / 10 - 60);
+  s.setValue("rgpreamp", static_cast<double>(ui_->stickyslider_replaygainpreamp->value()) / 10 - 60);
+  s.setValue("rgfallbackgain", static_cast<double>(ui_->stickyslider_replaygainfallbackgain->value()) / 10 - 60);
   s.setValue("rgcompression", ui_->checkbox_replaygaincompression->isChecked());
 
   s.setValue("FadeoutEnabled", ui_->checkbox_fadeout_stop->isChecked());
@@ -626,7 +626,7 @@ void BackendSettingsPage::DeviceStringChanged() {
 
 void BackendSettingsPage::RgPreampChanged(const int value) {
 
-  double db = double(value) / 10 - 60;
+  double db = static_cast<double>(value) / 10 - 60;
   QString db_str = QString::asprintf("%+.1f dB", db);
   ui_->label_replaygainpreamp->setText(db_str);
 
@@ -634,7 +634,7 @@ void BackendSettingsPage::RgPreampChanged(const int value) {
 
 void BackendSettingsPage::RgFallbackGainChanged(const int value) {
 
-  double db = double(value) / 10 - 60;
+  double db = static_cast<double>(value) / 10 - 60;
   QString db_str = QString::asprintf("%+.1f dB", db);
   ui_->label_replaygainfallbackgain->setText(db_str);
 

--- a/src/settings/behavioursettingspage.cpp
+++ b/src/settings/behavioursettingspage.cpp
@@ -249,7 +249,7 @@ void BehaviourSettingsPage::Save() {
   if (ui_->radiobutton_hide->isChecked()) behaviour = Startup_Hide;
   if (ui_->radiobutton_show_maximized->isChecked()) behaviour = Startup_ShowMaximized;
   if (ui_->radiobutton_show_minimized->isChecked()) behaviour = Startup_ShowMinimized;
-  s.setValue("startupbehaviour", int(behaviour));
+  s.setValue("startupbehaviour", static_cast<int>(behaviour));
 
   s.setValue("language", language_map_.contains(ui_->combobox_language->currentText()) ? language_map_[ui_->combobox_language->currentText()] : QString());
 

--- a/src/settings/collectionsettingspage.cpp
+++ b/src/settings/collectionsettingspage.cpp
@@ -252,12 +252,12 @@ void CollectionSettingsPage::Save() {
   if (ui_->radiobutton_save_albumcover_cache->isChecked()) save_cover_type = SaveCoverType_Cache;
   else if (ui_->radiobutton_save_albumcover_albumdir->isChecked()) save_cover_type = SaveCoverType_Album;
   else if (ui_->radiobutton_save_albumcover_embedded->isChecked()) save_cover_type = SaveCoverType_Embedded;
-  s.setValue("save_cover_type", int(save_cover_type));
+  s.setValue("save_cover_type", static_cast<int>(save_cover_type));
 
   SaveCoverFilename save_cover_filename = SaveCoverFilename_Hash;
   if (ui_->radiobutton_cover_hash->isChecked()) save_cover_filename = SaveCoverFilename_Hash;
   else if (ui_->radiobutton_cover_pattern->isChecked()) save_cover_filename = SaveCoverFilename_Pattern;
-  s.setValue("save_cover_filename", int(save_cover_filename));
+  s.setValue("save_cover_filename", static_cast<int>(save_cover_filename));
 
   s.setValue("cover_pattern", ui_->lineedit_cover_pattern->text());
   s.setValue("cover_overwrite", ui_->checkbox_cover_overwrite->isChecked());

--- a/src/settings/notificationssettingspage.cpp
+++ b/src/settings/notificationssettingspage.cpp
@@ -225,7 +225,7 @@ void NotificationsSettingsPage::Save() {
   else if (ui_->notifications_pretty->isChecked()) osd_behaviour = OSDBase::Pretty;
 
   s.beginGroup(OSDBase::kSettingsGroup);
-  s.setValue("Behaviour", int(osd_behaviour));
+  s.setValue("Behaviour", static_cast<int>(osd_behaviour));
   s.setValue("Timeout", ui_->notifications_duration->value() * 1000);
   s.setValue("ShowOnVolumeChange", ui_->notifications_volume->isChecked());
   s.setValue("ShowOnPlayModeChange", ui_->notifications_play_mode->isChecked());

--- a/src/smartplaylists/smartplaylistsearchtermwidget.cpp
+++ b/src/smartplaylists/smartplaylistsearchtermwidget.cpp
@@ -313,7 +313,7 @@ void SmartPlaylistSearchTermWidget::set_overlay_opacity(float opacity) {
 }
 
 float SmartPlaylistSearchTermWidget::overlay_opacity() const {
-  return overlay_ ? overlay_->opacity() : float(0.0);
+  return overlay_ ? overlay_->opacity() : static_cast<float>(0.0);
 }
 
 void SmartPlaylistSearchTermWidget::SetTerm(const SmartPlaylistSearchTerm &term) {

--- a/src/transcoder/transcodedialog.cpp
+++ b/src/transcoder/transcodedialog.cpp
@@ -296,7 +296,7 @@ void TranscodeDialog::UpdateProgress() {
   QMap<QString, float> current_jobs = transcoder_->GetProgress();
   QList<float> values = current_jobs.values();
   for (const float value : values) {
-    progress += qBound(0, int(value * 100), 99);
+    progress += qBound(0, static_cast<int>(value * 100), 99);
   }
 
   ui_->progress_bar->setValue(progress);

--- a/src/transcoder/transcoder.cpp
+++ b/src/transcoder/transcoder.cpp
@@ -552,7 +552,7 @@ QMap<QString, float> Transcoder::GetProgress() const {
     gst_element_query_position(state->pipeline_, GST_FORMAT_TIME, &position);
     gst_element_query_duration(state->pipeline_, GST_FORMAT_TIME, &duration);
 
-    ret[state->job_.input] = float(position) / duration;
+    ret[state->job_.input] = static_cast<float>(position) / duration;
   }
 
   return ret;

--- a/src/transcoder/transcoderoptionsmp3.cpp
+++ b/src/transcoder/transcoderoptionsmp3.cpp
@@ -88,7 +88,7 @@ void TranscoderOptionsMP3::Save() {
 }
 
 void TranscoderOptionsMP3::QualitySliderChanged(int value) {
-  ui_->quality_spinbox->setValue(float(value) / 100);
+  ui_->quality_spinbox->setValue(static_cast<float>(value) / 100);
 }
 
 void TranscoderOptionsMP3::QualitySpinboxChanged(double value) {

--- a/src/transcoder/transcoderoptionsvorbis.cpp
+++ b/src/transcoder/transcoderoptionsvorbis.cpp
@@ -80,7 +80,7 @@ void TranscoderOptionsVorbis::Save() {
   GET_BITRATE(max_bitrate, ui_->max_bitrate_slider);
 #undef GET_BITRATE
 
-  s.setValue("quality", double(ui_->quality_slider->value()) / 10);
+  s.setValue("quality", static_cast<double>(ui_->quality_slider->value()) / 10);
   s.setValue("managed", ui_->managed->isChecked());
   s.setValue("bitrate", bitrate);
   s.setValue("min-bitrate", min_bitrate);

--- a/src/widgets/freespacebar.cpp
+++ b/src/widgets/freespacebar.cpp
@@ -126,7 +126,7 @@ void FreeSpaceBar::DrawBar(QPainter *p, const QRect r) {
   p->setRenderHint(QPainter::Antialiasing, true);
 
   QRect bar_rect(r);
-  bar_rect.setWidth(static_cast<int>(float(bar_rect.width()) * (float(total_ - free_) / total_)));
+  bar_rect.setWidth(static_cast<int>(static_cast<float>(bar_rect.width()) * (static_cast<float>(total_ - free_) / static_cast<float>(total_))));
 
   QLinearGradient background_gradient(r.topLeft(), r.bottomLeft());
   background_gradient.setColorAt(0, kColorBg1);
@@ -150,7 +150,7 @@ void FreeSpaceBar::DrawBar(QPainter *p, const QRect r) {
   if (additional_ > 0) {
     QRect additional_rect(bar_rect);
     additional_rect.setLeft(bar_rect.right());
-    additional_rect.setWidth(static_cast<int>(float(r.width()) * (float(qMin(free_, additional_)) / total_) + 1));
+    additional_rect.setWidth(static_cast<int>(static_cast<float>(r.width()) * (static_cast<float>(qMin(free_, additional_)) / total_) + 1));
 
     QLinearGradient additional_gradient(additional_rect.topLeft(), additional_rect.bottomLeft());
     additional_gradient.setColorAt(0, kColorAdd1);

--- a/src/widgets/multiloadingindicator.cpp
+++ b/src/widgets/multiloadingindicator.cpp
@@ -82,7 +82,7 @@ void MultiLoadingIndicator::UpdateText() {
     task_text[0] = task_text[0].toLower();
 
     if (task.progress_max > 0) {
-      int percentage = static_cast<int>(float(task.progress) / task.progress_max * 100);
+      int percentage = static_cast<int>(static_cast<float>(task.progress) / task.progress_max * 100);
       task_text += QString(" %1%").arg(percentage);
     }
 

--- a/src/widgets/ratingwidget.cpp
+++ b/src/widgets/ratingwidget.cpp
@@ -44,7 +44,7 @@ RatingPainter::RatingPainter() {
 
   // Generate the 10 states, better to do it now than on the fly
   for (int i = 0; i < kStarCount * 2 + 1; ++i) {
-    const double rating = double(i) / double(2.0);
+    const double rating = static_cast<double>(i) / static_cast<double>(2.0);
 
     // Clear the pixmap
     stars_[i] = QPixmap(kStarSize * kStarCount, kStarSize);
@@ -86,14 +86,14 @@ QRect RatingPainter::Contents(const QRect rect) {
 double RatingPainter::RatingForPos(const QPoint pos, const QRect rect) {
 
   const QRect contents = Contents(rect);
-  const double raw = double(pos.x() - contents.left()) / contents.width();
+  const double raw = static_cast<double>(pos.x() - contents.left()) / contents.width();
 
   // Check if the position was to the right or left of the rectangle.
   if (raw < 0) return 0;
   if (raw > 1) return 1;
 
   // Round to the nearest 0.1
-  return double(lround(raw * kStarCount * 2)) / (kStarCount * 2);
+  return static_cast<double>(lround(raw * kStarCount * 2)) / (kStarCount * 2);
 
 }
 

--- a/src/widgets/volumeslider.cpp
+++ b/src/widgets/volumeslider.cpp
@@ -328,7 +328,7 @@ void VolumeSlider::paintEvent(QPaintEvent*) {
   QPainter p(this);
 
   const int padding = 7;
-  const int offset = int(double((width() - 2 * padding) * value()) / maximum());
+  const int offset = static_cast<int>(static_cast<double>((width() - 2 * padding) * value()) / maximum());
 
   // If theme changed since last paintEvent, redraw the volume pixmap with new theme colors
   if (previous_theme_text_color_ != palette().color(QPalette::WindowText)) {


### PR DESCRIPTION
Hi, you most likely know this but C-style casts in C++ are basically a wrapper around {const,static,reinterpret}_cast, so it won't hurt to be more explicit. I also fixed several narrowing conversions I spotted, but there may be more.