### PR TITLE
Fix filter menu button arrow overlap

### DIFF
--- a/src/collection/collectionfilterwidget.ui
+++ b/src/collection/collectionfilterwidget.ui
@@ -45,7 +45,7 @@
       </size>
      </property>
      <property name="popupMode">
-      <enum>QToolButton::InstantPopup</enum>
+      <enum>QToolButton::MenuButtonPopup</enum>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Change collection filter menu button's popupMode to MenuButtonPopup to prevent arrow overlapping with button icon