### PR TITLE
add type="desktop-application" to appdata.xml

### DIFF
--- a/dist/unix/org.strawberrymusicplayer.strawberry.appdata.xml
+++ b/dist/unix/org.strawberrymusicplayer.strawberry.appdata.xml
@@ -49,4 +49,7 @@
     </screenshot>
   </screenshots>
   <update_contact>eclipseo@fedoraproject.org</update_contact>
+    <releases>
+        <release version="1.0.0" date="2021-10-16"/>
+    </releases>
 </component>


### PR DESCRIPTION
this pr adds `type="desktop-application"` to the component declaration since without this flathub falls back to generic which results in it being tread as a cli/runtime. 