### PR TITLE
Revert collection options QToolButton mode

### DIFF
--- a/src/collection/collectionfilterwidget.ui
+++ b/src/collection/collectionfilterwidget.ui
@@ -45,7 +45,7 @@
       </size>
      </property>
      <property name="popupMode">
-      <enum>QToolButton::MenuButtonPopup</enum>
+      <enum>QToolButton::InstantPopup</enum>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Changing this button type fixed the arrow problem but has a side effect of making the button only clickable on the arrow portion.   #795 fixed the issue with styling on QToolButtons and ends up fixing this issue too.  Therefore the change to MenuButtonPopup should be reverted in order to restore the original functionality.