### PR TITLE
Add icon names for missing Tools menu entries

### DIFF
--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -457,11 +457,11 @@ MainWindow::MainWindow(Application *app, std::shared_ptr<SystemTrayIcon> tray_ic
   ui_->action_transcoder->setIcon(IconLoader::Load("tools-wizard"));
   ui_->action_update_collection->setIcon(IconLoader::Load("view-refresh"));
   ui_->action_full_collection_scan->setIcon(IconLoader::Load("view-refresh"));
-  ui_->action_abort_collection_scan->setIcon(IconLoader::Load("process-stop"));
+  ui_->action_abort_collection_scan->setIcon(IconLoader::Load("dialog-error"));
   ui_->action_settings->setIcon(IconLoader::Load("configure"));
   ui_->action_import_data_from_last_fm->setIcon(IconLoader::Load("scrobble"));
-  ui_->action_console->setIcon(IconLoader::Load("window"));
-  ui_->action_toggle_show_sidebar->setIcon(IconLoader::Load("sidebar-collapse"));
+  ui_->action_console->setIcon(IconLoader::Load("keyboard"));
+  ui_->action_toggle_show_sidebar->setIcon(IconLoader::Load("view-choose"));
 
   // Scrobble
 

--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -461,6 +461,7 @@ MainWindow::MainWindow(Application *app, std::shared_ptr<SystemTrayIcon> tray_ic
   ui_->action_settings->setIcon(IconLoader::Load("configure"));
   ui_->action_import_data_from_last_fm->setIcon(IconLoader::Load("scrobble"));
   ui_->action_console->setIcon(IconLoader::Load("window"));
+  ui_->action_toggle_show_sidebar->setIcon(IconLoader::Load("sidebar-collapse"));
 
   // Scrobble
 

--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -457,8 +457,10 @@ MainWindow::MainWindow(Application *app, std::shared_ptr<SystemTrayIcon> tray_ic
   ui_->action_transcoder->setIcon(IconLoader::Load("tools-wizard"));
   ui_->action_update_collection->setIcon(IconLoader::Load("view-refresh"));
   ui_->action_full_collection_scan->setIcon(IconLoader::Load("view-refresh"));
+  ui_->action_abort_collection_scan->setIcon(IconLoader::Load("process-stop"));
   ui_->action_settings->setIcon(IconLoader::Load("configure"));
   ui_->action_import_data_from_last_fm->setIcon(IconLoader::Load("scrobble"));
+  ui_->action_console->setIcon(IconLoader::Load("window"));
 
   // Scrobble
 


### PR DESCRIPTION
I noticed the abort_collection_scan, console and sidebar menu entries were missing matching icons.  This change adds appropriate icons for each action.

![icns2](https://user-images.githubusercontent.com/43704682/139514026-ce3ba1ac-f61e-4208-986f-1ad578211988.png)
