### PR TITLE
setRenderHint for play bar and icon instead of just icon

### DIFF
--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -526,13 +526,14 @@ void PlaylistView::drawRow(QPainter *painter, const QStyleOptionViewItem &option
     }
 
     // Draw the bar
+    painter->setRenderHint(QPainter::SmoothPixmapTransform);
     painter->drawPixmap(opt.rect.topLeft(), currenttrack_bar_left_[step]);
     painter->drawPixmap(opt.rect.topRight() - currenttrack_bar_right_[0].rect().topRight(), currenttrack_bar_right_[step]);
     painter->drawPixmap(middle, currenttrack_bar_mid_[step]);
 
     // Draw the play icon
     QPoint play_pos(currenttrack_bar_left_[0].width() / 3 * 2, (row_height - currenttrack_play_.height()) / 2);
-    painter->setRenderHint(QPainter::SmoothPixmapTransform);
+    //painter->setRenderHint(QPainter::SmoothPixmapTransform);
     painter->drawPixmap(opt.rect.topLeft() + play_pos, is_paused ? currenttrack_pause_ : currenttrack_play_);
 
     // Set the font

--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -533,7 +533,6 @@ void PlaylistView::drawRow(QPainter *painter, const QStyleOptionViewItem &option
 
     // Draw the play icon
     QPoint play_pos(currenttrack_bar_left_[0].width() / 3 * 2, (row_height - currenttrack_play_.height()) / 2);
-    //painter->setRenderHint(QPainter::SmoothPixmapTransform);
     painter->drawPixmap(opt.rect.topLeft() + play_pos, is_paused ? currenttrack_pause_ : currenttrack_play_);
 
     // Set the font


### PR DESCRIPTION
Followup to #794.  Moves setRenderHint SmoothTransform earlier to render both play icon and play bar smoothly instead of just the play icon.

Before:
![smooth_before](https://user-images.githubusercontent.com/43704682/140859522-6522d2ab-a385-4a94-bff9-2c3494427a2f.png)

After:
![smooth_after](https://user-images.githubusercontent.com/43704682/140859548-269106d6-c79e-46d9-90a8-b060431f2fc5.png)
