### PR TITLE
Use toPercentEncoding for XSPF playlist writer

### DIFF
--- a/src/playlistparsers/xspfparser.cpp
+++ b/src/playlistparsers/xspfparser.cpp
@@ -154,7 +154,7 @@ void XSPFParser::Save(const SongList &songs, QIODevice *device, const QDir &dir,
 
   StreamElement tracklist("trackList", &writer);
   for (const Song &song : songs) {
-    QString filename_or_url = URLOrFilename(song.url(), dir, path_type).toUtf8();
+    QString filename_or_url = QUrl::toPercentEncoding(URLOrFilename(song.url(), dir, path_type));
 
     StreamElement track("track", &writer);
     writer.writeTextElement("location", filename_or_url);


### PR DESCRIPTION
Fix for #821

This change adds percent encoding to the location tag on exported XSPF playlists. Tested encoded XSPF with VLC.

toPercentEncoding has built-in UTF-8 conversion per the docs, so no need to do it twice:
https://doc.qt.io/qt-5/qurl.html#toPercentEncoding