### PR TITLE
Use new MusicBrainz icon on Edit Track Tag Dialog

### DIFF
--- a/src/dialogs/edittagdialog.cpp
+++ b/src/dialogs/edittagdialog.cpp
@@ -134,7 +134,7 @@ EditTagDialog::EditTagDialog(Application *app, QWidget *parent)
   ui_->loading_label->hide();
   ui_->label_lyrics->hide();
 
-  ui_->fetch_tag->setIcon(QPixmap::fromImage(QImage(":/pictures/musicbrainz.png")));
+  ui_->fetch_tag->setIcon(IconLoader::Load("musicbrainz"));
 #ifdef HAVE_MUSICBRAINZ
   ui_->fetch_tag->setEnabled(true);
 #else

--- a/src/dialogs/edittagdialog.ui
+++ b/src/dialogs/edittagdialog.ui
@@ -842,7 +842,7 @@ p, li { white-space: pre-wrap; }
             </property>
             <property name="icon">
              <iconset resource="../../data/data.qrc">
-              <normaloff>:/pictures/musicbrainz.png</normaloff>:/pictures/musicbrainz.png</iconset>
+              <normaloff>:/icons/32x32/musicbrainz.png</normaloff>:/icons/32x32/musicbrainz.png</iconset>
             </property>
             <property name="iconSize">
              <size>


### PR DESCRIPTION
Currently the Edit Track Information is using the older MusicBrainz icon for the Tag feature.  This PR replaces the icon with the recently added MB icon.

![Screenshot_20211117_161529](https://user-images.githubusercontent.com/43704682/142303582-8508deff-c096-4a2a-9d0f-187aba8cd36c.png)
