### PR TITLE
GIOLister: ignore system mounts as defined by GIO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,9 @@ endif()
 pkg_check_modules(GLIB REQUIRED glib-2.0)
 pkg_check_modules(GOBJECT REQUIRED gobject-2.0)
 pkg_check_modules(GIO REQUIRED gio-2.0)
+if(UNIX)
+  pkg_check_modules(GIO_UNIX gio-unix-2.0)
+endif()
 pkg_check_modules(LIBCDIO libcdio)
 pkg_check_modules(GSTREAMER gstreamer-1.0)
 pkg_check_modules(GSTREAMER_BASE gstreamer-base-1.0)
@@ -389,6 +392,11 @@ optional_component(UDISKS2 ON "Devices: UDisks2 backend"
 optional_component(GIO ON "Devices: GIO device backend"
   DEPENDS "libgio" GIO_FOUND
   DEPENDS "Unix or Windows" "NOT APPLE"
+)
+
+optional_component(GIO_UNIX ON "Devices: GIO device backend (Unix support)"
+  DEPENDS "libgio-unix" GIO_UNIX_FOUND
+  DEPENDS "Unix" "UNIX"
 )
 
 optional_component(LIBGPOD ON "Devices: iPod classic support"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -986,6 +986,10 @@ if(HAVE_GIO)
   link_directories(${GIO_LIBRARY_DIRS})
 endif()
 
+if(HAVE_GIO_UNIX)
+  link_directories(${GIO_UNIX_LIBRARY_DIRS})
+endif()
+
 if(HAVE_AUDIOCD)
   link_directories(${LIBCDIO_LIBRARY_DIRS})
 endif()
@@ -1111,6 +1115,11 @@ endif()
 if(HAVE_GIO)
   target_include_directories(strawberry_lib SYSTEM PRIVATE ${GIO_INCLUDE_DIRS})
   target_link_libraries(strawberry_lib PRIVATE ${GIO_LIBRARIES})
+endif()
+
+if(HAVE_GIO_UNIX)
+  target_include_directories(strawberry_lib SYSTEM PRIVATE ${GIO_UNIX_INCLUDE_DIRS})
+  target_link_libraries(strawberry_lib PRIVATE ${GIO_UNIX_LIBRARIES})
 endif()
 
 if(HAVE_AUDIOCD)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -7,6 +7,7 @@
 
 #cmakedefine HAVE_BACKTRACE
 #cmakedefine HAVE_GIO
+#cmakedefine HAVE_GIO_UNIX
 #cmakedefine HAVE_DBUS
 #cmakedefine HAVE_X11
 #cmakedefine HAVE_UDISKS2

--- a/src/device/giolister.h
+++ b/src/device/giolister.h
@@ -77,7 +77,7 @@ class GioLister : public DeviceLister {
 
  private:
   struct DeviceInfo {
-    DeviceInfo() : drive_removable(false), filesystem_size(0), filesystem_free(0), invalid_enclosing_mount(false) {}
+    DeviceInfo() : drive_removable(false), filesystem_size(0), filesystem_free(0), invalid_enclosing_mount(false), is_system_internal(false) {}
 
     QString unique_id() const;
     bool is_suitable() const;
@@ -111,6 +111,7 @@ class GioLister : public DeviceLister {
     QString filesystem_type;
 
     bool invalid_enclosing_mount;
+    bool is_system_internal;
   };
 
   void VolumeAdded(GVolume *volume);


### PR DESCRIPTION
Strawberry has some heuristics to exclude things like the root mount, `/boot`, `tmpfs`, etc. from the devices list.

However, it's somewhat incomplete. GIO (GLib component) has more complete definition of "internal system mounts" that should not be presented to the user.

Additionally, don't try to query filesystems free/total size if it's internal, as that triggers automounting for autofs filesystems (#410).