### PR TITLE
subsonic configuration: use the entered password when clicking Test

### DIFF
--- a/src/subsonic/subsonicservice.cpp
+++ b/src/subsonic/subsonicservice.cpp
@@ -171,7 +171,7 @@ void SubsonicService::SendPingWithCredentials(QUrl url, const QString &username,
   else {
     const QString salt = Utilities::CryptographicRandomString(20);
     QCryptographicHash md5(QCryptographicHash::Md5);
-    md5.addData(password_.toUtf8());
+    md5.addData(password.toUtf8());
     md5.addData(salt.toUtf8());
     params << Param("s", salt);
     params << Param("t", md5.result().toHex());


### PR DESCRIPTION
This fixes a bug in which the password used when clicking in Test was the previously saved password, not the one just entered now.