### PR TITLE
Devcontainer image for vscode

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+FROM kdeneon/plasma:developer 
+RUN sudo apt-get update 
+RUN export DEBIAN_FRONTEND=noninteractive
+COPY install_dependencies.sh .
+RUN sudo chown neon install_dependencies.sh
+RUN chmod +x install_dependencies.sh
+RUN ./install_dependencies.sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+}

--- a/.devcontainer/install_dependencies.sh
+++ b/.devcontainer/install_dependencies.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+sudo apt-get install cmake \
+git \
+gcc \
+libgnutls28-dev \
+libprotobuf-dev \
+protobuf-compiler \
+libasound2-dev \
+libdbus-1-dev \
+libsqlite3-dev \
+libqt5x11extras5-dev \
+libtag1-dev \
+libgstreamer-plugins-base1.0-dev -y

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Optional dependencies:
 Either GStreamer or VLC engine is required, but only GStreamer is fully implemented, and works best, it is therefore recommended to use GStreamer.
 You should also install the gstreamer plugins base and good, and optionally bad, ugly and libav.
 
+#### For VSCode users 
+To ease the development, you can use the development container feature of VSCode. Just `Ctrl+Shift+P` and `Remote-Containers: Open Folder In Container`. 
+This should open VSCode inside a develpoment container specified in `./devcontainer` all dependencies are already installed inside this container, and you should be able to launch cmake right away.
+
+
+
 ### :wrench:	Compiling from source
 
 ### Get the code:


### PR DESCRIPTION
This uses the VSCode feature of development container. 
I think this is usefull also for people who want to develop natively on Ubuntu / KDE Neon, so that all the dependencies are listed and they don't have to google for it