### PR TITLE
Allow setting blur amount of background image up to 100px

### DIFF
--- a/src/settings/appearancesettingspage.ui
+++ b/src/settings/appearancesettingspage.ui
@@ -420,7 +420,7 @@
               <number>0</number>
              </property>
              <property name="maximum">
-              <number>10</number>
+              <number>100</number>
              </property>
              <property name="orientation">
               <enum>Qt::Horizontal</enum>
@@ -429,7 +429,7 @@
               <enum>QSlider::TicksBelow</enum>
              </property>
              <property name="tickInterval">
-              <number>1</number>
+              <number>10</number>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
Before, blur amount of background image (`Tools -> Settings -> User interface -> Apperance -> Background image ->Blur amount`) was limited to 10 px. This PR increases the limit to 100 px.