### PR TITLE
show icons in fileview

### DIFF
--- a/src/widgets/fileview.cpp
+++ b/src/widgets/fileview.cpp
@@ -268,9 +268,12 @@ void FileView::showEvent(QShowEvent *e) {
   if (model_) return;
 
   model_ = new QFileSystemModel(this);
+  if(!model_->iconProvider() || model_->iconProvider()->icon(QAbstractFileIconProvider::Folder).isNull()) {
+    qLog(Info) << "detected unsuitable iconProvider - try to fix it...";
+    model_->setIconProvider(new QFileIconProvider());
+  }
 
   model_->setNameFilters(filter_list_);
-  model_->setIconProvider(new QFileIconProvider());
   // if an item fails the filter, hide it
   model_->setNameFilterDisables(false);
 

--- a/src/widgets/fileview.cpp
+++ b/src/widgets/fileview.cpp
@@ -21,6 +21,7 @@
 #include <QWidget>
 #include <QUndoStack>
 #include <QDir>
+#include <QFileIconProvider>
 #include <QFileInfo>
 #include <QFileSystemModel>
 #include <QString>
@@ -43,6 +44,7 @@
 #include "ui_fileview.h"
 #include "organize/organizeerrordialog.h"
 #include "settings/appearancesettingspage.h"
+
 
 const char *FileView::kFileFilter =
     "*.wav *.flac *.wv *.ogg *.oga *.opus *.spx *.ape *.mpc "
@@ -268,6 +270,7 @@ void FileView::showEvent(QShowEvent *e) {
   model_ = new QFileSystemModel(this);
 
   model_->setNameFilters(filter_list_);
+  model_->setIconProvider(new QFileIconProvider());
   // if an item fails the filter, hide it
   model_->setNameFilterDisables(false);
 


### PR DESCRIPTION
**Whats new:**
Show icons in FileView (again?)

**Problem description:**
Don't know about other systems, but on mine, there are no icons in the fileview.
OS: **Arch Linux**
QT: **6.3.1**
Strawberry: **1.0.8**
![strawberry_fileview_broken](https://user-images.githubusercontent.com/5657818/187295728-82142f26-6e03-4d0d-90f3-5405c7f6d803.png)

**Wild guesses:**
Don't know if that has been the case in the past.
Maybe the implementation of `QFileSystemModel` changed recently to not have an `IconProvider` by default.

**The fix:**
Just setting a `QFileIconProvider` makes the icons work again:
![strawberry_fileview_fixed](https://user-images.githubusercontent.com/5657818/187296319-69610455-14f4-4830-b27d-15bc9126fa2a.png)

