### PR TITLE
Add spacefm support to core/utilities.cpp OpenInFileManager

### DIFF
--- a/src/core/utilities.cpp
+++ b/src/core/utilities.cpp
@@ -405,7 +405,7 @@ void OpenInFileManager(const QString &path, const QUrl &url) {
   else if (command.startsWith("caja")) {
     proc.startDetached(command, QStringList() << command_params << "--no-desktop" << path);
   }
-  else if (command.startsWith("pcmanfm") || command.startsWith("thunar")) {
+  else if (command.startsWith("pcmanfm") || command.startsWith("thunar") || command.startsWith("spacefm")) {
     proc.startDetached(command, QStringList() << command_params << path);
   }
   else {


### PR DESCRIPTION
Fixes #1072 

A simple patch to also check for spacefm and pass the directory as an argument instead of file path. 
I've tested this on my own system and it works. 



