### PR TITLE
Allow album artists to be "Various Artists"

### DIFF
--- a/src/scrobbler/scrobblingapi20.cpp
+++ b/src/scrobbler/scrobblingapi20.cpp
@@ -467,7 +467,7 @@ void ScrobblingAPI20::UpdateNowPlaying(const Song &song) {
     params << Param("album", album);
   }
 
-  if (!prefer_albumartist_ && !song.albumartist().isEmpty() && song.albumartist().compare(Song::kVariousArtists, Qt::CaseInsensitive) != 0) {
+  if (!prefer_albumartist_ && !song.albumartist().isEmpty()) {
     params << Param("albumArtist", song.albumartist());
   }
 


### PR DESCRIPTION
Very simple change and I understand that it might not be consensual (hence the PR, we can discuss this here). I scrobble album artist for albums marked under "various artists", and a lot of people do judging by lastfm history (example: https://www.last.fm/music/Various+Artists ).

Before I start arguing aimlessly, is there any specific reason for this limitation? Any usecase where people wouldn't want to have their various artist albums merged on lastfm? If there isn't we can merge the PR as-is, but otherwise I think adding this as a choice for the user would be a good idea (as like a sub-checkbox under `prefer_albumartist_`.