### PR TITLE
Fix test compilation after b5fa401

### DIFF
--- a/tests/src/collectionbackend_test.cpp
+++ b/tests/src/collectionbackend_test.cpp
@@ -83,10 +83,10 @@ TEST_F(CollectionBackendTest, AddDirectory) {
 
   // Check the signal was emitted correctly
   ASSERT_EQ(1, spy.count());
-  CollectionDirectory dir = spy[0][0].value<Directory>();
+  CollectionDirectory dir = spy[0][0].value<CollectionDirectory>();
   EXPECT_EQ(QFileInfo("/tmp").canonicalFilePath(), dir.path);
   EXPECT_EQ(1, dir.id);
-  EXPECT_EQ(0, spy[0][1].value<SubdirectoryList>().size());
+  EXPECT_EQ(0, spy[0][1].value<CollectionSubdirectoryList>().size());
 
 }
 
@@ -105,7 +105,7 @@ TEST_F(CollectionBackendTest, RemoveDirectory) {
 
   // Check the signal was emitted correctly
   ASSERT_EQ(1, spy.count());
-  dir = spy[0][0].value<Directory>();
+  dir = spy[0][0].value<CollectionDirectory>();
   EXPECT_EQ("/tmp", dir.path);
   EXPECT_EQ(1, dir.id);
 


### PR DESCRIPTION
Looks like this file didn't get updated alongside the other find-and-replaces when renaming some of these types.