### PR TITLE
Add icons to the collection menu button

### DIFF
--- a/src/collection/collectionfilterwidget.cpp
+++ b/src/collection/collectionfilterwidget.cpp
@@ -113,6 +113,7 @@ CollectionFilterWidget::CollectionFilterWidget(QWidget *parent)
 
   filter_age_menu_ = new QMenu(tr("Show"), this);
   filter_age_menu_->addActions(filter_age_group->actions());
+  filter_age_menu_->setIcon(IconLoader::Load("view-calendar-week"));
 
   filter_ages_[ui_->filter_age_all] = -1;
   filter_ages_[ui_->filter_age_today] = 60 * 60 * 24;
@@ -122,9 +123,12 @@ CollectionFilterWidget::CollectionFilterWidget(QWidget *parent)
   filter_ages_[ui_->filter_age_year] = 60 * 60 * 24 * 365;
 
   group_by_menu_ = new QMenu(tr("Group by"), this);
+  group_by_menu_->setIcon(IconLoader::Load("object-group"));
 
   QObject::connect(ui_->save_grouping, &QAction::triggered, this, &CollectionFilterWidget::SaveGroupBy);
   QObject::connect(ui_->manage_groupings, &QAction::triggered, this, &CollectionFilterWidget::ShowGroupingManager);
+  ui_->save_grouping->setIcon(IconLoader::Load("document-save"));
+  ui_->manage_groupings->setIcon(IconLoader::Load("document-open"));
 
   // Collection config menu
   collection_menu_ = new QMenu(tr("Display options"), this);

--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -676,6 +676,10 @@ MainWindow::MainWindow(Application *app, std::shared_ptr<SystemTrayIcon> tray_ic
   collection_show_duplicates_->setCheckable(true);
   collection_show_untagged_->setCheckable(true);
   collection_show_all_->setChecked(true);
+  
+  collection_show_all_->setIcon(IconLoader::Load("edit-select-all"));
+  collection_show_duplicates_->setIcon(IconLoader::Load("edit-duplicate"));
+  collection_show_untagged_->setIcon(IconLoader::Load("tag"));
 
   QObject::connect(collection_view_group, &QActionGroup::triggered, this, &MainWindow::ChangeCollectionFilterMode);
 


### PR DESCRIPTION
Adds icons to the menu entries that don't current have one assigned.  Ends up looking like this:

![image](https://user-images.githubusercontent.com/43704682/224510946-20cbc152-0de6-4f79-bdd8-abc3e1e881bb.png)
