### PR TITLE
Fix album art rendering on High DPI displays

### DIFF
--- a/src/context/contextalbum.cpp
+++ b/src/context/contextalbum.cpp
@@ -63,7 +63,7 @@ ContextAlbum::ContextAlbum(QWidget *parent)
   cover_loader_options_.desired_height_ = width();
   cover_loader_options_.pad_output_image_ = true;
   cover_loader_options_.scale_output_image_ = true;
-  QImage image = ImageUtils::ScaleAndPad(image_strawberry_, cover_loader_options_.scale_output_image_, cover_loader_options_.pad_output_image_, cover_loader_options_.desired_height_);
+  QImage image = ImageUtils::ScaleAndPad(image_strawberry_, cover_loader_options_.scale_output_image_, cover_loader_options_.pad_output_image_, cover_loader_options_.desired_height_, this->devicePixelRatioF());
   if (!image.isNull()) {
     pixmap_current_ = QPixmap::fromImage(image);
   }
@@ -235,7 +235,7 @@ void ContextAlbum::FadePreviousCoverFinished(std::shared_ptr<PreviousCover> prev
 
 void ContextAlbum::ScaleCover() {
 
-  QImage image = ImageUtils::ScaleAndPad(image_original_, cover_loader_options_.scale_output_image_, cover_loader_options_.pad_output_image_, cover_loader_options_.desired_height_);
+  QImage image = ImageUtils::ScaleAndPad(image_original_, cover_loader_options_.scale_output_image_, cover_loader_options_.pad_output_image_, cover_loader_options_.desired_height_, this->devicePixelRatioF());
   if (image.isNull()) {
     pixmap_current_ = QPixmap();
   }
@@ -248,7 +248,7 @@ void ContextAlbum::ScaleCover() {
 void ContextAlbum::ScalePreviousCovers() {
 
   for (std::shared_ptr<PreviousCover> previous_cover : previous_covers_) {
-    QImage image = ImageUtils::ScaleAndPad(previous_cover->image, cover_loader_options_.scale_output_image_, cover_loader_options_.pad_output_image_, cover_loader_options_.desired_height_);
+    QImage image = ImageUtils::ScaleAndPad(previous_cover->image, cover_loader_options_.scale_output_image_, cover_loader_options_.pad_output_image_, cover_loader_options_.desired_height_, this->devicePixelRatioF());
     if (image.isNull()) {
       previous_cover->pixmap = QPixmap();
     }

--- a/src/context/contextalbum.cpp
+++ b/src/context/contextalbum.cpp
@@ -63,7 +63,7 @@ ContextAlbum::ContextAlbum(QWidget *parent)
   cover_loader_options_.desired_height_ = width();
   cover_loader_options_.pad_output_image_ = true;
   cover_loader_options_.scale_output_image_ = true;
-  QImage image = ImageUtils::ScaleAndPad(image_strawberry_, cover_loader_options_.scale_output_image_, cover_loader_options_.pad_output_image_, cover_loader_options_.desired_height_, this->devicePixelRatioF());
+  QImage image = ImageUtils::ScaleAndPad(image_strawberry_, cover_loader_options_.scale_output_image_, cover_loader_options_.pad_output_image_, cover_loader_options_.desired_height_, devicePixelRatioF());
   if (!image.isNull()) {
     pixmap_current_ = QPixmap::fromImage(image);
   }
@@ -235,7 +235,7 @@ void ContextAlbum::FadePreviousCoverFinished(std::shared_ptr<PreviousCover> prev
 
 void ContextAlbum::ScaleCover() {
 
-  QImage image = ImageUtils::ScaleAndPad(image_original_, cover_loader_options_.scale_output_image_, cover_loader_options_.pad_output_image_, cover_loader_options_.desired_height_, this->devicePixelRatioF());
+  QImage image = ImageUtils::ScaleAndPad(image_original_, cover_loader_options_.scale_output_image_, cover_loader_options_.pad_output_image_, cover_loader_options_.desired_height_, devicePixelRatioF());
   if (image.isNull()) {
     pixmap_current_ = QPixmap();
   }
@@ -248,7 +248,7 @@ void ContextAlbum::ScaleCover() {
 void ContextAlbum::ScalePreviousCovers() {
 
   for (std::shared_ptr<PreviousCover> previous_cover : previous_covers_) {
-    QImage image = ImageUtils::ScaleAndPad(previous_cover->image, cover_loader_options_.scale_output_image_, cover_loader_options_.pad_output_image_, cover_loader_options_.desired_height_, this->devicePixelRatioF());
+    QImage image = ImageUtils::ScaleAndPad(previous_cover->image, cover_loader_options_.scale_output_image_, cover_loader_options_.pad_output_image_, cover_loader_options_.desired_height_, devicePixelRatioF());
     if (image.isNull()) {
       previous_cover->pixmap = QPixmap();
     }

--- a/src/covermanager/albumcoverchoicecontroller.cpp
+++ b/src/covermanager/albumcoverchoicecontroller.cpp
@@ -443,7 +443,7 @@ void AlbumCoverChoiceController::ShowCover(const Song &song, const QImage &image
     ) {
       QPixmap pixmap = ImageUtils::TryLoadPixmap(song.art_automatic(), song.art_manual(), song.url());
       if (!pixmap.isNull()) {
-          pixmap.setDevicePixelRatio(this->devicePixelRatioF());
+          pixmap.setDevicePixelRatio(devicePixelRatioF());
           ShowCover(song, pixmap);
       }
     }
@@ -451,7 +451,7 @@ void AlbumCoverChoiceController::ShowCover(const Song &song, const QImage &image
   else {
     QPixmap pixmap = QPixmap::fromImage(image);
     if (!pixmap.isNull()) {
-        pixmap.setDevicePixelRatio(this->devicePixelRatioF());
+        pixmap.setDevicePixelRatio(devicePixelRatioF());
         ShowCover(song, pixmap);
     }
   }

--- a/src/covermanager/albumcoverchoicecontroller.cpp
+++ b/src/covermanager/albumcoverchoicecontroller.cpp
@@ -442,12 +442,18 @@ void AlbumCoverChoiceController::ShowCover(const Song &song, const QImage &image
         song.has_embedded_cover()
     ) {
       QPixmap pixmap = ImageUtils::TryLoadPixmap(song.art_automatic(), song.art_manual(), song.url());
-      if (!pixmap.isNull()) ShowCover(song, pixmap);
+      if (!pixmap.isNull()) {
+          pixmap.setDevicePixelRatio(this->devicePixelRatioF());
+          ShowCover(song, pixmap);
+      }
     }
   }
   else {
     QPixmap pixmap = QPixmap::fromImage(image);
-    if (!pixmap.isNull()) ShowCover(song, pixmap);
+    if (!pixmap.isNull()) {
+        pixmap.setDevicePixelRatio(this->devicePixelRatioF());
+        ShowCover(song, pixmap);
+    }
   }
 
 }
@@ -481,21 +487,21 @@ void AlbumCoverChoiceController::ShowCover(const Song &song, const QPixmap &pixm
   if (desktop_width < desktop_height) {
     const int new_width = static_cast<int>(static_cast<double>(desktop_width) * 0.95);
     if (new_width < pixmap.width()) {
-      label->setPixmap(pixmap.scaledToWidth(new_width, Qt::SmoothTransformation));
+      label->setPixmap(pixmap.scaledToWidth(new_width * pixmap.devicePixelRatioF(), Qt::SmoothTransformation));
     }
   }
   else {
     const int new_height = static_cast<int>(static_cast<double>(desktop_height) * 0.85);
     if (new_height < pixmap.height()) {
-      label->setPixmap(pixmap.scaledToHeight(new_height, Qt::SmoothTransformation));
+      label->setPixmap(pixmap.scaledToHeight(new_height * pixmap.devicePixelRatioF(), Qt::SmoothTransformation));
     }
   }
 
   dialog->setWindowTitle(title_text);
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
-  dialog->setFixedSize(label->pixmap(Qt::ReturnByValue).size());
+  dialog->setFixedSize(label->pixmap(Qt::ReturnByValue).size() / pixmap.devicePixelRatioF());
 #else
-  dialog->setFixedSize(label->pixmap()->size());
+  dialog->setFixedSize(label->pixmap()->size() / pixmap.devicePixelRatioF());
 #endif
   dialog->show();
 

--- a/src/utilities/imageutils.cpp
+++ b/src/utilities/imageutils.cpp
@@ -138,14 +138,16 @@ QByteArray ImageUtils::FileToJpegData(const QString &filename) {
 
 }
 
-QImage ImageUtils::ScaleAndPad(const QImage &image, const bool scale, const bool pad, const int desired_height) {
+QImage ImageUtils::ScaleAndPad(const QImage &image, const bool scale, const bool pad, const int desired_height, const qreal device_pixel_ratio) {
 
   if (image.isNull()) return image;
+
+  const int scaled_height = desired_height * device_pixel_ratio;
 
   // Scale the image down
   QImage image_scaled;
   if (scale) {
-    image_scaled = image.scaled(QSize(desired_height, desired_height), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    image_scaled = image.scaled(QSize(scaled_height, scaled_height), Qt::KeepAspectRatio, Qt::SmoothTransformation);
   }
   else {
     image_scaled = image;
@@ -153,11 +155,11 @@ QImage ImageUtils::ScaleAndPad(const QImage &image, const bool scale, const bool
 
   // Pad the image to height x height
   if (pad) {
-    QImage image_padded(desired_height, desired_height, QImage::Format_ARGB32);
+    QImage image_padded(scaled_height, scaled_height, QImage::Format_ARGB32);
     image_padded.fill(0);
 
     QPainter p(&image_padded);
-    p.drawImage((desired_height - image_scaled.width()) / 2, (desired_height - image_scaled.height()) / 2, image_scaled);
+    p.drawImage((scaled_height - image_scaled.width()) / 2, (scaled_height - image_scaled.height()) / 2, image_scaled);
     p.end();
 
     image_scaled = image_padded;

--- a/src/utilities/imageutils.h
+++ b/src/utilities/imageutils.h
@@ -41,7 +41,7 @@ class ImageUtils {
   static QByteArray SaveImageToJpegData(const QImage &image = QImage());
   static QByteArray FileToJpegData(const QString &filename);
   static QPixmap TryLoadPixmap(const QUrl &automatic, const QUrl &manual, const QUrl &url = QUrl());
-  static QImage ScaleAndPad(const QImage &image, const bool scale, const bool pad, const int desired_height);
+  static QImage ScaleAndPad(const QImage &image, const bool scale, const bool pad, const int desired_height, const qreal device_pixel_ratio = 1.0f);
   static QImage CreateThumbnail(const QImage &image, const bool pad, const QSize size);
   static QImage GenerateNoCoverImage(const QSize size = QSize());
 

--- a/src/widgets/playingwidget.cpp
+++ b/src/widgets/playingwidget.cpp
@@ -333,7 +333,7 @@ void PlayingWidget::SetImage(const QImage &image) {
 
 void PlayingWidget::ScaleCover() {
 
-  QImage image = ImageUtils::ScaleAndPad(image_original_, cover_loader_options_.scale_output_image_, cover_loader_options_.pad_output_image_, cover_loader_options_.desired_height_);
+  QImage image = ImageUtils::ScaleAndPad(image_original_, cover_loader_options_.scale_output_image_, cover_loader_options_.pad_output_image_, cover_loader_options_.desired_height_, this->devicePixelRatioF());
   if (image.isNull()) pixmap_cover_ = QPixmap();
   else pixmap_cover_ = QPixmap::fromImage(image);
   update();

--- a/src/widgets/playingwidget.cpp
+++ b/src/widgets/playingwidget.cpp
@@ -333,7 +333,7 @@ void PlayingWidget::SetImage(const QImage &image) {
 
 void PlayingWidget::ScaleCover() {
 
-  QImage image = ImageUtils::ScaleAndPad(image_original_, cover_loader_options_.scale_output_image_, cover_loader_options_.pad_output_image_, cover_loader_options_.desired_height_, this->devicePixelRatioF());
+  QImage image = ImageUtils::ScaleAndPad(image_original_, cover_loader_options_.scale_output_image_, cover_loader_options_.pad_output_image_, cover_loader_options_.desired_height_, devicePixelRatioF());
   if (image.isNull()) pixmap_cover_ = QPixmap();
   else pixmap_cover_ = QPixmap::fromImage(image);
   update();


### PR DESCRIPTION
Rendering of album art does not take advantage of High DPI displays currently, leading to blurry album art on high density displays in every location.

This change creates album art QPixmaps with the appropriate pixel density and devicePixelRatio of the current widget fixing this issue.