### PR TITLE
QobuzRequest: Handle multiple discs in integration

### DIFF
--- a/src/qobuz/qobuzrequest.cpp
+++ b/src/qobuz/qobuzrequest.cpp
@@ -1079,11 +1079,16 @@ void QobuzRequest::ParseSong(Song &song, const QJsonObject &json_obj, const Arti
 
   QString title = json_obj["title"].toString();
   int track = json_obj["track_number"].toInt();
+  int disc = 1;
   QString copyright = json_obj["copyright"].toString();
   qint64 duration = json_obj["duration"].toInt() * kNsecPerSec;
   //bool streamable = json_obj["streamable"].toBool();
   QString composer;
   QString performer;
+
+  if (json_obj.contains("media_number")) {
+      disc = json_obj["media_number"].toInt();
+  }
 
   Artist song_artist = album_artist;
   Album song_album = album;
@@ -1193,6 +1198,7 @@ void QobuzRequest::ParseSong(Song &song, const QJsonObject &json_obj, const Arti
   song.set_artist_id(song_artist.artist_id);
   song.set_album(song_album.album);
   song.set_artist(song_artist.artist);
+  song.set_disc(disc);
   if (!album_artist.artist.isEmpty() && album_artist.artist != song_artist.artist) {
     song.set_albumartist(album_artist.artist);
   }

--- a/src/qobuz/qobuzrequest.cpp
+++ b/src/qobuz/qobuzrequest.cpp
@@ -1079,7 +1079,7 @@ void QobuzRequest::ParseSong(Song &song, const QJsonObject &json_obj, const Arti
 
   QString title = json_obj["title"].toString();
   int track = json_obj["track_number"].toInt();
-  int disc = 1;
+  int disc = 0;
   QString copyright = json_obj["copyright"].toString();
   qint64 duration = json_obj["duration"].toInt() * kNsecPerSec;
   //bool streamable = json_obj["streamable"].toBool();
@@ -1087,7 +1087,7 @@ void QobuzRequest::ParseSong(Song &song, const QJsonObject &json_obj, const Arti
   QString performer;
 
   if (json_obj.contains("media_number")) {
-      disc = json_obj["media_number"].toInt();
+    disc = json_obj["media_number"].toInt();
   }
 
   Artist song_artist = album_artist;


### PR DESCRIPTION
Albums with multiple discs are not being handled which results in tracks being listed out of order. If the disc (media_number) is present in JSON, we use it to set the disc in the Song object.

### Before
![Before](https://user-images.githubusercontent.com/815873/228345179-07731afb-96cc-49c4-bd90-3e8ea1b7d2ec.png)

### After
![After](https://user-images.githubusercontent.com/815873/228345221-bb1eb305-3304-472d-a487-2ebb9ec0792b.png)

