### PR TITLE
Add ability to filter playlists by rating

### DIFF
--- a/src/playlist/playlistfilter.cpp
+++ b/src/playlist/playlistfilter.cpp
@@ -56,6 +56,7 @@ PlaylistFilter::PlaylistFilter(QObject *parent)
   column_names_["filename"] = Playlist::Column_Filename;
   column_names_["grouping"] = Playlist::Column_Grouping;
   column_names_["comment"] = Playlist::Column_Comment;
+  column_names_["rating"] = Playlist::Column_Rating;
 
   numerical_columns_ << Playlist::Column_Year
                      << Playlist::Column_OriginalYear

--- a/src/playlist/playlistfilterparser.h
+++ b/src/playlist/playlistfilterparser.h
@@ -89,6 +89,7 @@ class FilterParser {
 
   FilterTree *createSearchTermTreeNode(const QString &col, const QString &prefix, const QString &search) const;
   static int parseTime(const QString &time_str);
+  static float parseRating(const QString &rating_str);
 
   QString::const_iterator iter_;
   QString::const_iterator end_;


### PR DESCRIPTION
This adds the ability to filter your playlists by rating in two different ways. 
For example you can filter by 0-5 Stars like this:
`rating:5` `rating:>=3` `rating:!=0`
Or use float values from 0-1 with a prefixed "f":
`rating:f1` `rating:>f0.5`

The implementation got a little messy, unfortunately. But it works. 