### PR TITLE
Allow forcing GStreamer pipeline to the floating-point data format

### DIFF
--- a/src/engine/enginebase.cpp
+++ b/src/engine/enginebase.cpp
@@ -39,6 +39,7 @@
 
 EngineBase::EngineBase(QObject *parent)
     : QObject(parent),
+      force_floating_point_(false),
       volume_control_(true),
       volume_(100),
       beginning_nanosec_(0),
@@ -166,6 +167,8 @@ void EngineBase::ReloadSettings() {
 
   output_ = s.value("output").toString();
   device_ = s.value("device");
+
+  force_floating_point_ = s.value("force_floating_point", false).toBool();
 
   volume_control_ = s.value("volume_control", true).toBool();
 

--- a/src/engine/enginebase.h
+++ b/src/engine/enginebase.h
@@ -142,6 +142,7 @@ class EngineBase : public QObject {
 
  public:
   // Simple accessors
+  bool force_floating_point() const { return force_floating_point_; }
   bool volume_control() const { return volume_control_; }
   inline uint volume() const { return volume_; }
 
@@ -188,6 +189,7 @@ class EngineBase : public QObject {
   void VolumeChanged(const uint volume);
 
  protected:
+  bool force_floating_point_;
   bool volume_control_;
   uint volume_;
   quint64 beginning_nanosec_;

--- a/src/engine/gstengine.cpp
+++ b/src/engine/gstengine.cpp
@@ -785,6 +785,7 @@ std::shared_ptr<GstEnginePipeline> GstEngine::CreatePipeline() {
 
   std::shared_ptr<GstEnginePipeline> ret = std::make_shared<GstEnginePipeline>();
   ret->set_output_device(output_, device_);
+  ret->set_force_floating_point(force_floating_point_);
   ret->set_volume_enabled(volume_control_);
   ret->set_stereo_balancer_enabled(stereo_balancer_enabled_);
   ret->set_equalizer_enabled(equalizer_enabled_);

--- a/src/engine/gstenginepipeline.h
+++ b/src/engine/gstenginepipeline.h
@@ -62,6 +62,7 @@ class GstEnginePipeline : public QObject {
 
   // Call these setters before Init
   void set_output_device(const QString &output, const QVariant &device);
+  void set_force_floating_point(const bool enabled);
   void set_volume_enabled(const bool enabled);
   void set_stereo_balancer_enabled(const bool enabled);
   void set_equalizer_enabled(const bool enabled);
@@ -198,6 +199,7 @@ class GstEnginePipeline : public QObject {
   bool valid_;
   QString output_;
   QVariant device_;
+  bool force_floating_point_;
   bool volume_enabled_;
   bool stereo_balancer_enabled_;
   bool eq_enabled_;

--- a/src/settings/backendsettingspage.cpp
+++ b/src/settings/backendsettingspage.cpp
@@ -151,6 +151,8 @@ void BackendSettingsPage::Load() {
 
   if (EngineInitialized()) Load_Engine(enginetype);
 
+  ui_->checkbox_force_floating_point->setChecked(s.value("force_floating_point", false).toBool());
+
   ui_->checkbox_volume_control->setChecked(s.value("volume_control", true).toBool());
 
   ui_->checkbox_channels->setChecked(s.value("channels_enabled", false).toBool());
@@ -268,6 +270,8 @@ void BackendSettingsPage::Load_Engine(const EngineBase::Type enginetype) {
   ui_->lineedit_device->setEnabled(false);
   ui_->lineedit_device->clear();
 
+  ui_->checkbox_force_floating_point->setEnabled(false);
+
   ui_->groupbox_replaygain->setEnabled(false);
   ui_->groupbox_ebur128->setEnabled(false);
 
@@ -321,11 +325,13 @@ void BackendSettingsPage::Load_Output(QString output, QVariant device) {
   }
 
   if (engine()->type() == EngineBase::Type::GStreamer) {
+    ui_->checkbox_force_floating_point->setEnabled(true);
     ui_->groupbox_buffer->setEnabled(true);
     ui_->groupbox_replaygain->setEnabled(true);
     ui_->groupbox_ebur128->setEnabled(true);
   }
   else {
+    ui_->checkbox_force_floating_point->setEnabled(false);
     ui_->groupbox_buffer->setEnabled(false);
     ui_->groupbox_replaygain->setEnabled(false);
     ui_->groupbox_ebur128->setEnabled(false);
@@ -480,6 +486,8 @@ void BackendSettingsPage::Save() {
   else if (ui_->radiobutton_alsa_pcm->isChecked()) s.setValue("alsaplugin", static_cast<int>(ALSAPluginType::PCM));
   else s.remove("alsaplugin");
 #endif
+
+  s.setValue("force_floating_point", ui_->checkbox_force_floating_point->isChecked());
 
   s.setValue("volume_control", ui_->checkbox_volume_control->isChecked());
 

--- a/src/settings/backendsettingspage.ui
+++ b/src/settings/backendsettingspage.ui
@@ -163,6 +163,13 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
+       <widget class="QCheckBox" name="checkbox_force_floating_point">
+        <property name="text">
+         <string>Convert audio to floating-point data format immediately after decoding</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="checkbox_volume_control">
         <property name="text">
          <string>Enable volume control</string>


### PR DESCRIPTION
While audio is most commonly stored in 16/24-bit integer format,
modern audio processing, and modern audio servers
are using floating point integrally, whereas PipeWire internally
essentially always uses 32-bit floating point, as far as i understand.

While it does not really matter that much to us
as long as we simply pass-through the audio (from the decoder to the playback),
the moment we start to mess with it, it does begin to affect us.

As a "contrived" "obscure" example, pick some audio that has large loudness range,
normalize it to `-0 LUFS`, and load a compressor in easyeffects.
The audio will be distorted, there will be clipping.
Looking at the pipeline dumps, ReplayGain was already handling this correctly:
[pipeline-replaygain.pdf](https://github.com/strawberrymusicplayer/strawberry/files/12088865/pipeline-replaygain.pdf)

Here i propose two things:
* Fix: Always perform EBU R 128 loudness normalization in floating-point
* Feature: subj. Support forcing GStreamer pipeline to always be in floating-point. 

[pipeline-old.pdf](https://github.com/strawberrymusicplayer/strawberry/files/12088778/pipeline-old.pdf)
[pipeline-new-ebur128.pdf](https://github.com/strawberrymusicplayer/strawberry/files/12088922/pipeline-ebur128.pdf)
[pipeline-new-force.pdf](https://github.com/strawberrymusicplayer/strawberry/files/12088923/pipeline-force.pdf)

Thoughts?