### PR TITLE
Always perform EBU R 128 Loudness Normalization in floating-point

### DIFF
--- a/src/engine/gstenginepipeline.cpp
+++ b/src/engine/gstenginepipeline.cpp
@@ -667,10 +667,15 @@ bool GstEnginePipeline::InitAudioBin(QString &error) {
 
   // Link EBU R 128 loudness normalization volume element if enabled.
   if (ebur128_loudness_normalization_ && ebur128_volume_) {
-    if (!gst_element_link(element_link, ebur128_volume_)) {
+    GstStaticCaps static_raw_fp_audio_caps = GST_STATIC_CAPS(
+      "audio/x-raw,"
+      "format = (string) { F32LE, F64LE }");
+    GstCaps *raw_fp_audio_caps = gst_static_caps_get(&static_raw_fp_audio_caps);
+    if (!gst_element_link_filtered(element_link, ebur128_volume_, raw_fp_audio_caps)) {
       error = "Failed to link EBU R 128 volume element.";
       return false;
     }
+    gst_caps_unref(raw_fp_audio_caps);
     element_link = ebur128_volume_;
   }
 


### PR DESCRIPTION
While audio is most commonly stored in 16/24-bit integer format,
modern audio processing, and modern audio servers
are using floating point integrally, whereas PipeWire internally
essentially always uses 32-bit floating point, as far as i understand.

While it does not really matter that much to us
as long as we simply pass-through the audio (from the decoder to the playback),
the moment we start to mess with it, it does begin to affect us.

As a "contrived" "obscure" example, pick some audio that has large loudness range,
normalize it to `-0 LUFS`, and load a compressor in easyeffects.
The audio will be distorted, there will be clipping.
Looking at the pipeline dumps, it seems ReplayGain was already handling this correctly:
[pipeline-replaygain.pdf](https://github.com/strawberrymusicplayer/strawberry/files/12088865/pipeline-replaygain.pdf), even though [rgvolume.html](https://gstreamer.freedesktop.org/documentation/replaygain/rgvolume.html?gi-language=c) disagrees (`format: { F32LE, S16LE }`).

Therefore, we should always perform EBU R 128 loudness normalization in floating-point data format.

[pipeline-old.pdf](https://github.com/strawberrymusicplayer/strawberry/files/12088778/pipeline-old.pdf)
[pipeline-new.pdf](https://github.com/strawberrymusicplayer/strawberry/files/12089065/pipeline-new.pdf)
[pipeline-ebur128.pdf](https://github.com/strawberrymusicplayer/strawberry/files/12089066/pipeline-ebur128.pdf)
