### PR TITLE
`Application::~Application()`: manually delete lyrics providers

### DIFF
--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -233,6 +233,13 @@ Application::Application(QObject *parent)
 
 Application::~Application() {
 
+  // It's important that the lyrics providers are deleted before the network manager.
+  // Deleting the network manager deletes all requests that have been created in its thread,
+  // that are still tracked by the lyrics providers.
+  for (LyricsProvider *provider : p_->lyrics_providers_->List()) {
+    delete provider;
+  }
+
   // It's important that the device manager is deleted before the database.
   // Deleting the database deletes all objects that have been created in its thread, including some device collection backends.
 #ifndef Q_OS_WIN


### PR DESCRIPTION
This must be done before the network manager is deleted.
Due to the lazy destruction during `Lazy<>.reset()`,
this appears to be one of the approaches that solves that.

Fixes https://github.com/strawberrymusicplayer/strawberry/issues/1239