### PR TITLE
Mpris2: Add new property to read/write the rating

### DIFF
--- a/src/core/mpris2.cpp
+++ b/src/core/mpris2.cpp
@@ -212,6 +212,7 @@ void Mpris2::EmitNotification(const QString &name) {
   else if (name == "LoopStatus") value = LoopStatus();
   else if (name == "Shuffle") value = Shuffle();
   else if (name == "Metadata") value = Metadata();
+  else if (name == "Rating") value = Rating();
   else if (name == "Volume") value = Volume();
   else if (name == "Position") value = Position();
   else if (name == "CanPlay") value = CanPlay();
@@ -368,6 +369,22 @@ void Mpris2::SetShuffle(bool enable) {
 }
 
 QVariantMap Mpris2::Metadata() const { return last_metadata_; }
+
+double Mpris2::Rating() const {
+  float rating = app_->playlist_manager()->active()->current_item_metadata().rating();
+  return (rating <= 0) ? 0 : rating;
+}
+
+void Mpris2::SetRating(double rating) {
+  if (rating > 1.0) {
+    rating = 1.0;
+  }
+  else if (rating <= 0.0) {
+    rating = -1.0;
+  }
+
+  app_->playlist_manager()->RateCurrentSong(rating);
+}
 
 QString Mpris2::current_track_id() const {
   return QString("/org/strawberrymusicplayer/strawberry/Track/%1").arg(QString::number(app_->playlist_manager()->active()->current_row()));

--- a/src/core/mpris2.h
+++ b/src/core/mpris2.h
@@ -117,6 +117,9 @@ class Mpris2 : public QObject {
   Q_PROPERTY(QStringList Orderings READ Orderings)
   Q_PROPERTY(MaybePlaylist ActivePlaylist READ ActivePlaylist)
 
+  // strawberry specific additional property to extend MPRIS Player interface
+  Q_PROPERTY(double Rating READ Rating WRITE SetRating)
+
   // Root Properties
   bool CanQuit() const;
   bool CanRaise() const;
@@ -144,6 +147,8 @@ class Mpris2 : public QObject {
   bool Shuffle() const;
   void SetShuffle(bool enable);
   QVariantMap Metadata() const;
+  double Rating() const;
+  void SetRating(double rating);
   double Volume() const;
   void SetVolume(const double volume);
   qint64 Position() const;

--- a/src/dbus/org.mpris.MediaPlayer2.Player.xml
+++ b/src/dbus/org.mpris.MediaPlayer2.Player.xml
@@ -29,6 +29,7 @@
 		<property name='Metadata' type='a{sv}' access='read'>
 			<annotation name="org.qtproject.QtDBus.QtTypeName" value="QVariantMap"/>
 		</property>
+		<property name='Rating' type='d' access='readwrite'/>
 		<property name='Volume' type='d' access='readwrite'/>
 		<property name='Position' type='x' access='read'/>
 		<property name='MinimumRate' type='d' access='read'/>


### PR DESCRIPTION
This is to create shortcuts to set the rating and/or to set it from scripts.
This feature was wished for in these threads: 
https://forum.strawberrymusicplayer.org/topic/99/shortcuts-for-ratings
https://forum.strawberrymusicplayer.org/topic/326/set-ratings-per-dbus-shortcut
https://forum.strawberrymusicplayer.org/topic/879/expose-rating-of-songs-to-automation-shortcuts

This is technically out of spec for the [mpris specification](https://specifications.freedesktop.org/mpris-spec/2.2/Player_Interface.html). But since it does not modify any of the original methods it should be fine. If you prefer I could move this to a different bus name like `org.strawberry.Player.Rating` or something. 

Currently it can for example be accessed like this: `qdbus org.mpris.MediaPlayer2.strawberry /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.Rating` to get the rating of the currently playing song (As float from 0-1)
Or `qdbus org.mpris.MediaPlayer2.strawberry /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.Rating 0.6` to set the rating to a float, here 0.6. (from 0-1)
