### PR TITLE
Add ability to filter the collection by numerical columns

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,7 @@ set(SOURCES
   utilities/filemanagerutils.cpp
   utilities/coverutils.cpp
   utilities/screenutils.cpp
+  utilities/searchparserutils.cpp
 
   engine/enginebase.cpp
   engine/enginedevice.cpp

--- a/src/collection/collectionfilterwidget.cpp
+++ b/src/collection/collectionfilterwidget.cpp
@@ -73,6 +73,7 @@ CollectionFilterWidget::CollectionFilterWidget(QWidget *parent)
   ui_->setupUi(this);
 
   QString available_fields = Song::kFtsColumns.join(", ").replace(QRegularExpression("\\bfts"), "");
+  available_fields += QString(", ") + Song::kNumericalColumns.join(", ");
 
   ui_->search_field->setToolTip(
     QString("<html><head/><body><p>") +
@@ -80,18 +81,26 @@ CollectionFilterWidget::CollectionFilterWidget(QWidget *parent)
     QString(" ") +
     QString("<span style=\"font-weight:600;\">") +
     tr("artist") +
-    QString(":") +
-    QString("</span><span style=\"font-style:italic;\">Strawbs</span>") +
-    QString(" ") +
-    tr("searches the collection for all artists that contain the word") +
-    QString(" Strawbs.") +
+    QString(":</span><span style=\"font-style:italic;\">Strawbs</span> ") +
+    tr("searches the collection for all artists that contain the word %1. ").arg("Strawbs") +
+    QString("</p><p>") +
+    tr("Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: ")
+      .arg(" =, !=, &lt;, &gt;, &lt;=", "&gt;=") +
+    QString("<span style=\"font-weight:600;\">") +
+    tr("rating") +
+    QString("</span>") +
+    QString(":>=") +
+    QString("<span style=\"font-weight:italic;\">4</span>") +
+
     QString("</p><p><span style=\"font-weight:600;\">") +
     tr("Available fields") +
     QString(": ") +
-    "</span><span style=\"font-style:italic;\">" +
+    QString("</span>") +
+    QString("<span style=\"font-style:italic;\">") +
     available_fields +
     QString("</span>.") +
-    QString("</p></body></html>"));
+    QString("</p></body></html>")
+  );
 
   QObject::connect(ui_->search_field, &QSearchField::returnPressed, this, &CollectionFilterWidget::ReturnPressed);
   QObject::connect(filter_delay_, &QTimer::timeout, this, &CollectionFilterWidget::FilterDelayTimeout);

--- a/src/collection/collectionquery.h
+++ b/src/collection/collectionquery.h
@@ -61,10 +61,15 @@ class CollectionQuery : public QSqlQuery {
   void SetOrderBy(const QString &order_by) { order_by_ = order_by; }
 
   void SetWhereClauses(const QStringList &where_clauses) { where_clauses_ = where_clauses; }
+
+  // Removes = < > <= >= <> from the beginning of the input string and returns the operator
+  // If the input String has no operator, returns "="
+  QString RemoveSqlOperator(QString &token);
   // Adds a fragment of WHERE clause. When executed, this Query will connect all the fragments with AND operator.
   // Please note that IN operator expects a QStringList as value.
   void AddWhere(const QString &column, const QVariant &value, const QString &op = "=");
   void AddWhereArtist(const QVariant &value);
+  void AddWhereRating(const QVariant &value, const QString &op = "=");
 
   void SetBoundValues(const QVariantList &bound_values) { bound_values_ = bound_values; }
   void SetDuplicatesOnly(const bool duplicates_only) { duplicates_only_ = duplicates_only; }

--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -142,6 +142,17 @@ const QString Song::kColumnSpec = Song::kColumns.join(", ");
 const QString Song::kBindSpec = Utilities::Prepend(":", Song::kColumns).join(", ");
 const QString Song::kUpdateSpec = Utilities::Updateify(Song::kColumns).join(", ");
 
+// used to indicate, what columns can be filtered numerically. Used by the CollectionQuery.
+const QStringList Song::kNumericalColumns = QStringList() << "year"
+                                                          << "length"
+                                                          << "samplerate"
+                                                          << "bitdepth"
+                                                          << "bitrate"
+                                                          << "rating"
+                                                          << "playcount"
+                                                          << "skipcount";
+
+
 const QStringList Song::kFtsColumns = QStringList() << "ftstitle"
                                                     << "ftsalbum"
                                                     << "ftsartist"

--- a/src/core/song.h
+++ b/src/core/song.h
@@ -116,6 +116,8 @@ class Song {
   static const QString kBindSpec;
   static const QString kUpdateSpec;
 
+  static const QStringList kNumericalColumns;
+
   static const QStringList kFtsColumns;
   static const QString kFtsColumnSpec;
   static const QString kFtsBindSpec;

--- a/src/playlist/playlistcontainer.cpp
+++ b/src/playlist/playlistcontainer.cpp
@@ -123,7 +123,7 @@ PlaylistContainer::PlaylistContainer(QWidget *parent)
   QObject::connect(ui_->playlist, &PlaylistView::FocusOnFilterSignal, this, &PlaylistContainer::FocusOnFilter);
   ui_->search_field->installEventFilter(this);
 
-  QString available_fields = PlaylistFilter().column_names_.keys().join(", ");
+  QString available_fields = PlaylistFilter().column_names().keys().join(", ");
   ui_->search_field->setToolTip(
     QString("<html><head/><body><p>") +
     tr("Prefix a search term with a field name to limit the search to that field, e.g.:") +
@@ -131,7 +131,7 @@ PlaylistContainer::PlaylistContainer(QWidget *parent)
     QString("<span style=\"font-weight:600;\">") +
     tr("artist") +
     QString(":</span><span style=\"font-style:italic;\">Strawbs</span> ") +
-    tr("searches the collection for all artists that contain the word %1. ").arg("Strawbs") +
+    tr("searches the playlist for all artists that contain the word %1. ").arg("Strawbs") +
     QString("</p><p>") +
 
     tr("Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: ")

--- a/src/playlist/playlistcontainer.cpp
+++ b/src/playlist/playlistcontainer.cpp
@@ -123,6 +123,38 @@ PlaylistContainer::PlaylistContainer(QWidget *parent)
   QObject::connect(ui_->playlist, &PlaylistView::FocusOnFilterSignal, this, &PlaylistContainer::FocusOnFilter);
   ui_->search_field->installEventFilter(this);
 
+  QString available_fields = PlaylistFilter().column_names_.keys().join(", ");
+  ui_->search_field->setToolTip(
+    QString("<html><head/><body><p>") +
+    tr("Prefix a search term with a field name to limit the search to that field, e.g.:") +
+    QString(" ") +
+    QString("<span style=\"font-weight:600;\">") +
+    tr("artist") +
+    QString(":</span><span style=\"font-style:italic;\">Strawbs</span> ") +
+    tr("searches the collection for all artists that contain the word %1. ").arg("Strawbs") +
+    QString("</p><p>") +
+
+    tr("Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: ")
+      .arg(" =, !=, &lt;, &gt;, &lt;=", "&gt;=") +
+    QString("<span style=\"font-weight:600;\">") +
+    tr("rating") +
+    QString("</span>") +
+    QString(":>=") +
+    QString("<span style=\"font-weight:italic;\">4</span>") +
+    QString("</p><p>") +
+
+    tr("Multiple search terms can also be combined with \"%1\" (default) and \"%2\", as well as grouped with parentheses. ")
+      .arg("AND", "OR") +
+
+    QString("</p><p><span style=\"font-weight:600;\">") +
+    tr("Available fields") +
+    QString(": ") + QString("</span><span style=\"font-style:italic;\">") +
+    available_fields +
+    QString("</span>.") +
+    QString("</p></body></html>")
+  );
+
+
   ReloadSettings();
 
 }

--- a/src/playlist/playlistfilter.cpp
+++ b/src/playlist/playlistfilter.cpp
@@ -57,6 +57,8 @@ PlaylistFilter::PlaylistFilter(QObject *parent)
   column_names_["grouping"] = Playlist::Column_Grouping;
   column_names_["comment"] = Playlist::Column_Comment;
   column_names_["rating"] = Playlist::Column_Rating;
+  column_names_["playcount"] = Playlist::Column_PlayCount;
+  column_names_["skipcount"] = Playlist::Column_SkipCount;
 
   numerical_columns_ << Playlist::Column_Year
                      << Playlist::Column_OriginalYear
@@ -65,7 +67,9 @@ PlaylistFilter::PlaylistFilter(QObject *parent)
                      << Playlist::Column_Length
                      << Playlist::Column_Samplerate
                      << Playlist::Column_Bitdepth
-                     << Playlist::Column_Bitrate;
+                     << Playlist::Column_Bitrate
+                     << Playlist::Column_PlayCount
+                     << Playlist::Column_SkipCount;
 
 }
 

--- a/src/playlist/playlistfilter.h
+++ b/src/playlist/playlistfilter.h
@@ -51,8 +51,7 @@ class PlaylistFilter : public QSortFilterProxyModel {
   void SetFilterText(const QString &filter_text);
 
   QString filter_text() const { return filter_text_; }
-
-  QMap<QString, int> column_names_;
+  QMap<QString, int> column_names() const { return column_names_; }
 
  private:
   // Mutable because they're modified from filterAcceptsRow() const
@@ -63,6 +62,7 @@ class PlaylistFilter : public QSortFilterProxyModel {
   mutable uint query_hash_;
 #endif
 
+  QMap<QString, int> column_names_;
   QSet<int> numerical_columns_;
   QString filter_text_;
 };

--- a/src/playlist/playlistfilter.h
+++ b/src/playlist/playlistfilter.h
@@ -52,6 +52,8 @@ class PlaylistFilter : public QSortFilterProxyModel {
 
   QString filter_text() const { return filter_text_; }
 
+  QMap<QString, int> column_names_;
+
  private:
   // Mutable because they're modified from filterAcceptsRow() const
   mutable QScopedPointer<FilterTree> filter_tree_;
@@ -61,7 +63,6 @@ class PlaylistFilter : public QSortFilterProxyModel {
   mutable uint query_hash_;
 #endif
 
-  QMap<QString, int> column_names_;
   QSet<int> numerical_columns_;
   QString filter_text_;
 };

--- a/src/playlist/playlistfilterparser.h
+++ b/src/playlist/playlistfilterparser.h
@@ -88,8 +88,6 @@ class FilterParser {
   FilterTree *parseSearchTerm();
 
   FilterTree *createSearchTermTreeNode(const QString &col, const QString &prefix, const QString &search) const;
-  static int parseTime(const QString &time_str);
-  static float parseRating(const QString &rating_str);
 
   QString::const_iterator iter_;
   QString::const_iterator end_;

--- a/src/utilities/searchparserutils.cpp
+++ b/src/utilities/searchparserutils.cpp
@@ -1,0 +1,112 @@
+/*
+ * Strawberry Music Player
+ * Copyright 2019-2023, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2023, Daniel Ostertag <daniel.ostertag@dakes.de>
+ *
+ * Strawberry is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Strawberry is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Strawberry.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <QString>
+
+#include "searchparserutils.h"
+
+namespace Utilities {
+
+/**
+ * @brief Try and parse the string as '[[h:]m:]s' (ignoring all spaces),
+ * and return the number of seconds if it parses correctly.
+ * If not, the original string is returned.
+ * The 'h', 'm' and 's' components can have any length (including 0).
+ * A few examples:
+ *  "::"       is parsed to "0"
+ *  "1::"      is parsed to "3600"
+ *  "3:45"     is parsed to "225"
+ *  "1:165"    is parsed to "225"
+ *  "225"      is parsed to "225" (srsly! ^.^)
+ *  "2:3:4:5"  is parsed to "2:3:4:5"
+ *  "25m"      is parsed to "25m"
+ * @param time_str
+ * @return
+ */
+int ParseSearchTime(const QString &time_str) {
+
+  int seconds = 0;
+  int accum = 0;
+  int colon_count = 0;
+  for (const QChar &c : time_str) {
+    if (c.isDigit()) {
+      accum = accum * 10 + c.digitValue();
+    }
+    else if (c == ':') {
+      seconds = seconds * 60 + accum;
+      accum = 0;
+      ++colon_count;
+      if (colon_count > 2) {
+        return 0;
+      }
+    }
+    else if (!c.isSpace()) {
+      return 0;
+    }
+  }
+  seconds = seconds * 60 + accum;
+
+  return seconds;
+
+}
+
+/**
+ * @brief Parses a rating search term to float.
+ *  If the rating is a number from 0-5, map it to 0-1
+ *  To use float values directly, the search term can be prefixed with "f" (rating:>f0.2)
+ *  If search str is 0, or by default, uses -1
+ * @param rating_str: Rating search 0-5, or "f0.2"
+ * @return float: rating from 0-1 or -1 if not rated.
+ */
+float ParseSearchRating(const QString &rating_str) {
+
+  if (rating_str.isEmpty()) {
+    return -1;
+  }
+  float rating = -1.0F;
+  bool ok = false;
+  float rating_input = rating_str.toFloat(&ok);
+  // is valid int from 0-5: convert to float
+  if (ok && rating_input >= 0 && rating_input <= 5) {
+    rating = rating_input / 5.0F;
+  }
+
+  // check if the search is a float
+  else if (rating_str.at(0) == 'f') {
+    QString rating_float = rating_str;
+    rating_float = rating_float.remove(0, 1);
+
+    ok = false;
+    rating_float.toFloat(&ok);
+    if (ok) {
+      rating = rating_float.toFloat(&ok);
+    }
+  }
+  // Songs with zero rating have -1 in the DB
+  if (rating == 0) {
+    rating = -1;
+  }
+
+  return rating;
+
+}
+
+
+}  // namespace Utilities

--- a/src/utilities/searchparserutils.h
+++ b/src/utilities/searchparserutils.h
@@ -1,0 +1,33 @@
+/*
+ * Strawberry Music Player
+ * Copyright 2019-2023, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2023, Daniel Ostertag <daniel.ostertag@dakes.de>
+ *
+ * Strawberry is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Strawberry is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Strawberry.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SEARCHPARSERUTILS_H
+#define SEARCHPARSERUTILS_H
+
+#include <QString>
+
+namespace Utilities {
+
+int ParseSearchTime(const QString &time_str);
+float ParseSearchRating(const QString &rating_str);
+
+}  // namespace Utilities
+
+#endif  // SEARCHPARSERUTILS_H


### PR DESCRIPTION
Since someone in the forum was asking how to filter playlists, I thought it would be useful to have a tooltip there, like the collection filter has. 
This person also named playcount as an example, which I thought would be pretty useful to have, so I added it together with the skipcount to the playlist filtering. 

Now for the big addition: I added filtering of numerical colums to the collection. So that you can filter it like: `rating:>3`
I tested it a while for the numerical cols: year, length, samplerate, bitdepth, bitrate, rating, playcount, skipcount and it seems to work great, also when combined with fts search terms. 
Though I am a bit wary about the comment, regarding performance and FilterModes. I don't really understand what is going on there, but I don't think it is relevant to what I added. 

I also created a new file `src/utilities/searchparserutils.cpp` to house common code for search parsing, used by the playlist and collection (and in the future maybe smart playlists? But I haven't looked at that code yet.)

I hope these changes are fine and not too intrusive. 

And one more question: since the changed/added tooltips, they require new translations, it is probably necessary to update the translation files. But I have not found documentation on how to do that. Could you point me in the right direction there?