### PR TITLE
[WIP] Output audio queue

### DIFF
--- a/src/engine/gstenginepipeline.cpp
+++ b/src/engine/gstenginepipeline.cpp
@@ -736,6 +736,7 @@ bool GstEnginePipeline::InitAudioBin(QString &error) {
     error = "Failed to link audio sink converter.";
     return false;
   }
+  element_link = audiosinkconverter;
 
   {
     GstCaps *caps = gst_caps_new_empty_simple("audio/x-raw");
@@ -753,6 +754,7 @@ bool GstEnginePipeline::InitAudioBin(QString &error) {
       error = "Failed to link audio sink converter to audio sink with filter for " + output_;
       return false;
     }
+    element_link = audiosink_;
   }
 
   {  // Add probes and handlers.

--- a/src/engine/gstenginepipeline.h
+++ b/src/engine/gstenginepipeline.h
@@ -302,6 +302,7 @@ class GstEnginePipeline : public QObject {
   GstElement *audiobin_;
   GstElement *audiosink_;
   GstElement *inputaudioqueue_;
+  GstElement *outputaudioqueue_;
   GstElement *audioqueueconverter_;
   GstElement *ebur128_volume_;
   GstElement *volume_;

--- a/src/engine/gstenginepipeline.h
+++ b/src/engine/gstenginepipeline.h
@@ -85,6 +85,7 @@ class GstEnginePipeline : public QObject {
   void RemoveAllBufferConsumers();
 
   // Control the music playback
+  QFuture<void> FlushPipeline();
   QFuture<GstStateChangeReturn> SetState(const GstState state);
   Q_INVOKABLE bool Seek(const qint64 nanosec);
   void SetEBUR128LoudnessNormalizingGain_dB(const double ebur128_loudness_normalizing_gain_db);

--- a/src/engine/gstenginepipeline.h
+++ b/src/engine/gstenginepipeline.h
@@ -301,7 +301,7 @@ class GstEnginePipeline : public QObject {
   GstElement *pipeline_;
   GstElement *audiobin_;
   GstElement *audiosink_;
-  GstElement *audioqueue_;
+  GstElement *inputaudioqueue_;
   GstElement *audioqueueconverter_;
   GstElement *ebur128_volume_;
   GstElement *volume_;


### PR DESCRIPTION
This is incomplete.

Currently, the queue is placed before all of our elements,
which is great to precache input and not stutter through
the times where there's IO latency spikes,
but if there's a CPU latency spike, we *may* still stutter
because we still need to process the input.

By also caching the final output, we should be safe from that.

This introduces subtleties: when changing parameters
of said modules, the changes will no longer be immediate,
but delayed by the cache length. So we must flush the pipeline's caches.

This sounds simple, but the obvious approach does not work,
and the one that works (seek to the current position)
causes temporary stutters. This isn't nice.

Also, probes need to be taken *after* the output queue.

Also, the way the fader is implemented just doesn't work with this approach.

But overall, this works better than i expected.