### PR TITLE
CMake: Fix KDSingleApplication package name for Qt5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,7 +301,7 @@ endif()
 
 # SingleApplication
 if(QT_VERSION_MAJOR EQUAL 5)
-  set(KDSINGLEAPPLICATION_NAME "KDSingleApplication-qt")
+  set(KDSINGLEAPPLICATION_NAME "KDSingleApplication")
 else()
   set(KDSINGLEAPPLICATION_NAME "KDSingleApplication-qt${QT_VERSION_MAJOR}")
 endif()


### PR DESCRIPTION
The name of the Qt5 KDSingleApplication CMake package is just "KDSingleApplication", not "KDSingleApplication-qt".