### PR TITLE
Allow drag and drop of songs to favorite playlists

### DIFF
--- a/src/playlist/playlistlistcontainer.h
+++ b/src/playlist/playlistlistcontainer.h
@@ -63,6 +63,7 @@ class PlaylistListContainer : public QWidget {
   // From the UI
   void NewFolderClicked();
   void ItemDoubleClicked(const QModelIndex &proxy_idx);
+  void ItemMimeDataDropped(const QModelIndex &proxy_idx, const QMimeData *q_mimedata);
 
   // From the model
   void PlaylistPathChanged(const int id, const QString &new_path);

--- a/src/playlist/playlistlistview.h
+++ b/src/playlist/playlistlistview.h
@@ -24,6 +24,7 @@
 
 #include "config.h"
 
+#include <QBasicTimer>
 #include <QObject>
 #include <QWidget>
 #include <QString>
@@ -31,6 +32,11 @@
 #include "widgets/autoexpandingtreeview.h"
 
 class QPaintEvent;
+class QDragEnterEvent;
+class QDragLeaveEvent;
+class QDragMoveEvent;
+class QDropEvent;
+class QTimerEvent;
 
 class PlaylistListView : public AutoExpandingTreeView {
   Q_OBJECT
@@ -42,11 +48,23 @@ class PlaylistListView : public AutoExpandingTreeView {
 
  signals:
   void ItemsSelectedChanged(const bool);
+  void ItemMimeDataDroppedSignal(const QModelIndex &proxy_idx, const QMimeData *q_mimedata);
 
  protected:
   // QWidget
   void paintEvent(QPaintEvent *event) override;
   void selectionChanged(const QItemSelection&, const QItemSelection&) override;
+
+  void dragEnterEvent(QDragEnterEvent *e) override;
+  void dragMoveEvent(QDragMoveEvent *e) override;
+  void dragLeaveEvent(QDragLeaveEvent *e) override;
+  void dropEvent(QDropEvent *e) override;
+  void timerEvent(QTimerEvent *e) override;
+
+ private:
+  static const int kDragHoverTimeout = 500;
+
+  QBasicTimer drag_hover_timer_;
 };
 
 #endif  // PLAYLISTVIEW_H


### PR DESCRIPTION

![outstrawberry](https://github.com/strawberrymusicplayer/strawberry/assets/18371538/8a7007c6-356c-4e16-b5e2-731e37c841c1)

- allows adding songs from active playlist to any favourite by drag&drop
- after 500msec hovering with the songs over desired playlist it becomes current
- drag & drop multiple songs is supported