### PR TITLE
Mark Subsonic MD5 authentication as recommended

### DIFF
--- a/src/settings/subsonicsettingspage.ui
+++ b/src/settings/subsonicsettingspage.ui
@@ -124,7 +124,7 @@
       <item>
        <widget class="QRadioButton" name="auth_method_md5">
         <property name="text">
-         <string>MD5 token</string>
+         <string>MD5 token (Recommended)</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This simple MR just marks the MD5 authentication method for subsonic as recommended when editing the settings of subsonic.