### PR TITLE
Playlist: skip invalid songs to prevent playback interruptions

### DIFF
--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -2164,10 +2164,14 @@ void Playlist::InvalidateDeletedSongs() {
         // gray out the song if it's not there
         item->SetForegroundColor(kInvalidSongPriority, kInvalidSongColor);
         invalidated_rows.append(row);  // clazy:exclude=reserve-candidates
+        // skip invalid song
+        item->SetShouldSkip(true);
       }
       else if (exists && item->HasForegroundColor(kInvalidSongPriority)) {
         item->RemoveForegroundColor(kInvalidSongPriority);
         invalidated_rows.append(row);  // clazy:exclude=reserve-candidates
+        // song is valid again; do not skip it
+        item->SetShouldSkip(false);
       }
     }
   }
@@ -2285,9 +2289,13 @@ bool Playlist::ApplyValidityOnCurrentSong(const QUrl &url, const bool valid) {
     // Gray out the song if it's now broken; otherwise undo the gray color
     if (valid) {
       current->RemoveForegroundColor(kInvalidSongPriority);
+      // Song is valid again; do not skip it
+      current->SetShouldSkip(false);
     }
     else {
       current->SetForegroundColor(kInvalidSongPriority, kInvalidSongColor);
+      // Skip invalid song
+      current->SetShouldSkip(true);
     }
   }
 


### PR DESCRIPTION
Also skips invalid songs if the option to gray out unavailable songs is enabled.

When the option to gray out unavailable songs on playback is enabled, this will now also skip the song after they become invalid.
Once invalid they will be skipped until they are valid again, which requires manually selecting the song.
Before songs become invalid there still is an error message and playback gets interrupted.

When the option to gray out unavailable song on startup is enabled, all invalid grayed out songs are skipped during playback.
This means that playback can be expected to be uninterrupted, even when there is a great amount of missing songs in the playlist for whatever reason.

This simply uses the skip function to skip/unskip invalid songs.
Side effect is that the visual appearance of grayed out songs changes so these will also have a strikethrough formatting.
Also if a manually skipped song becomes invalid, then gets fixed and becomes valid again it will no longer be skipped.
However since user action is required for this it could be considered expected behaviour.

This change is intentionally kept minimal initially, since it is not completely clear to me whether this is the right approach.
There are no changes to surrounding code or comments.
Nor are the descriptions changed of the 2 options for graying out song.
Renaming or rephrasing the options, or introducing an additional option might be more confusing than just changing the behaviour.
If necessary possibly best would be to only rephrase the 2 options to 'gray out and skip unavailable song' to convey the behaviour.

To me, also skipping unavailable songs is more expected than only graying them out when the option is enabled, and then still attempting to play them which is likely to fail.
Especially on large playlists that gets shared between different systems (but where not all of the files are synced too) this can lead to repeated unnecessary playback interruptions.
The function to remove unavailable song from the playlist is a nice workaround, but it is a bit hidden and requires user action.
Plus having the unavailable songs still visible in the playlist can be handy when wanting to resolve the issue with the files at a later time without having to mess with different versions of the playlist.

Vaguely related to #1347