### PR TITLE
Internet: Use DescriptionForSource instead of TextForSource in menus

### DIFF
--- a/src/internet/internetsearchview.cpp
+++ b/src/internet/internetsearchview.cpp
@@ -176,7 +176,7 @@ void InternetSearchView::Init(Application *app, InternetServicePtr service) {
   QMenu *settings_menu = new QMenu(this);
   settings_menu->addActions(group_by_actions_->actions());
   settings_menu->addSeparator();
-  settings_menu->addAction(IconLoader::Load("configure"), tr("Configure %1...").arg(Song::TextForSource(service_->source())), this, &InternetSearchView::OpenSettingsDialog);
+  settings_menu->addAction(IconLoader::Load("configure"), tr("Configure %1...").arg(Song::DescriptionForSource(service_->source())), this, &InternetSearchView::OpenSettingsDialog);
   ui_->settings->setMenu(settings_menu);
 
   swap_models_timer_->setSingleShot(true);

--- a/src/internet/internetsongsview.cpp
+++ b/src/internet/internetsongsview.cpp
@@ -56,7 +56,7 @@ InternetSongsView::InternetSongsView(Application *app, InternetServicePtr servic
   ui_->filter_widget->SetSettingsGroup(settings_group);
   ui_->filter_widget->Init(service_->songs_collection_model());
 
-  QAction *action_configure = new QAction(IconLoader::Load("configure"), tr("Configure %1...").arg(Song::TextForSource(service_->source())), this);
+  QAction *action_configure = new QAction(IconLoader::Load("configure"), tr("Configure %1...").arg(Song::DescriptionForSource(service_->source())), this);
   QObject::connect(action_configure, &QAction::triggered, this, &InternetSongsView::OpenSettingsDialog);
   ui_->filter_widget->AddMenuAction(action_configure);
 


### PR DESCRIPTION
The filter menus for InternetSongsView and InternetSearchView get the name of the source for the Configure entry from the TextForSource array.  This array uses lowercase names for the sources.  This PR changes this to use the DescriptionForSource array which uses proper uppercase names for sources.

Before:
![Screenshot_20240217_213855](https://github.com/strawberrymusicplayer/strawberry/assets/43704682/ddd06c74-2df9-41ae-9c92-8b262e11771d)

After:
![Screenshot_20240218_095521](https://github.com/strawberrymusicplayer/strawberry/assets/43704682/9ea80eef-48e2-4a6c-b6fd-2cdee76e8e33)
![Screenshot_20240218_104419](https://github.com/strawberrymusicplayer/strawberry/assets/43704682/88b55aff-016b-44d2-9fb3-eef3008a1ab5)
