### PR TITLE
EditTagDialog: Add a button to fetch lyrics in tags edition dialog

### DIFF
--- a/src/context/contextview.cpp
+++ b/src/context/contextview.cpp
@@ -631,7 +631,11 @@ void ContextView::UpdateLyrics(const quint64 id, const QString &provider, const 
 
   if (static_cast<qint64>(id) != lyrics_id_) return;
 
-  lyrics_ = lyrics + "\n\n(Lyrics from " + provider + ")\n";
+  if (lyrics == nullptr) {
+    lyrics_ = "\n\nLyrics not found.\n";
+  } else {
+    lyrics_ = lyrics + "\n\n(Lyrics from " + provider + ")\n";
+  }
   lyrics_id_ = -1;
 
   if (action_show_lyrics_->isChecked() && !lyrics_.isEmpty()) {

--- a/src/context/contextview.cpp
+++ b/src/context/contextview.cpp
@@ -631,7 +631,7 @@ void ContextView::UpdateLyrics(const quint64 id, const QString &provider, const 
 
   if (static_cast<qint64>(id) != lyrics_id_) return;
 
-  if (lyrics == nullptr) {
+  if (lyrics.isEmpty()) {
     lyrics_ = "\n\nLyrics not found.\n";
   } else {
     lyrics_ = lyrics + "\n\n(Lyrics from " + provider + ")\n";

--- a/src/context/contextview.cpp
+++ b/src/context/contextview.cpp
@@ -633,7 +633,8 @@ void ContextView::UpdateLyrics(const quint64 id, const QString &provider, const 
 
   if (lyrics.isEmpty()) {
     lyrics_ = "\n\nLyrics not found.\n";
-  } else {
+  }
+  else {
     lyrics_ = lyrics + "\n\n(Lyrics from " + provider + ")\n";
   }
   lyrics_id_ = -1;

--- a/src/dialogs/edittagdialog.cpp
+++ b/src/dialogs/edittagdialog.cpp
@@ -1421,7 +1421,7 @@ void EditTagDialog::FetchTagSongChosen(const Song &original_song, const Song &ne
 void EditTagDialog::FetchLyrics() {
 
   if (ui_->song_list->selectionModel()->selectedIndexes().isEmpty()) return;
-  const Song song = data_[ui_->song_list->selectionModel()->selectedIndexes().first().row()].current_;
+  const Song &song = data_[ui_->song_list->selectionModel()->selectedIndexes().first().row()].current_;
   lyrics_fetcher_->Clear();
   ui_->lyrics->setPlainText(tr("loading..."));
   lyrics_id_ = static_cast<qint64>(lyrics_fetcher_->Search(song.effective_albumartist(), song.artist(), song.album(), song.title()));

--- a/src/dialogs/edittagdialog.cpp
+++ b/src/dialogs/edittagdialog.cpp
@@ -1436,7 +1436,8 @@ void EditTagDialog::UpdateLyrics(const quint64 id, const QString &provider, cons
   lyrics_id_ = -1;
   if (lyrics != nullptr) {
       ui_->lyrics->setPlainText(lyrics);
-  } else {
+  }
+  else {
       ui_->lyrics->setPlainText(tr("Not found."));
   }
 }

--- a/src/dialogs/edittagdialog.cpp
+++ b/src/dialogs/edittagdialog.cpp
@@ -1423,6 +1423,7 @@ void EditTagDialog::FetchLyrics() {
   if (ui_->song_list->selectionModel()->selectedIndexes().isEmpty()) return;
   const Song song = data_[ui_->song_list->selectionModel()->selectedIndexes().first().row()].current_;
   lyrics_fetcher_->Clear();
+  ui_->lyrics->setPlainText(tr("loading..."));
   lyrics_id_ = static_cast<qint64>(lyrics_fetcher_->Search(song.effective_albumartist(), song.artist(), song.album(), song.title()));
 
 }
@@ -1433,8 +1434,11 @@ void EditTagDialog::UpdateLyrics(const quint64 id, const QString &provider, cons
 
   if (static_cast<qint64>(id) != lyrics_id_) return;
   lyrics_id_ = -1;
-  ui_->lyrics->setPlainText(lyrics);
-
+  if (lyrics != nullptr) {
+      ui_->lyrics->setPlainText(lyrics);
+  } else {
+      ui_->lyrics->setPlainText(tr("Not found."));
+  }
 }
 
 void EditTagDialog::SongSaveTagsComplete(TagReaderReply *reply, const QString &filename, Song song, const UpdateCoverAction cover_action) {

--- a/src/dialogs/edittagdialog.cpp
+++ b/src/dialogs/edittagdialog.cpp
@@ -120,7 +120,8 @@ EditTagDialog::EditTagDialog(Application *app, QWidget *parent)
       summary_cover_art_id_(-1),
       tags_cover_art_id_(-1),
       cover_art_is_set_(false),
-      save_tag_pending_(0) {
+      save_tag_pending_(0),
+      lyrics_id_(-1) {
 
   QObject::connect(&*app_->album_cover_loader(), &AlbumCoverLoader::AlbumCoverLoaded, this, &EditTagDialog::AlbumCoverLoaded);
 
@@ -609,6 +610,8 @@ void EditTagDialog::SelectionChanged() {
 
   // Set the editable fields
   UpdateUI(indexes);
+
+  lyrics_id_ = -1;
 
   // If we're editing multiple songs then we have to disable certain tabs
   const bool multiple = indexes.count() > 1;
@@ -1417,17 +1420,19 @@ void EditTagDialog::FetchTagSongChosen(const Song &original_song, const Song &ne
 
 void EditTagDialog::FetchLyrics() {
 
-  Song song = data_[ui_->song_list->selectionModel()->selectedIndexes().first().row()].original_;
+  if (ui_->song_list->selectionModel()->selectedIndexes().isEmpty()) return;
+  const Song song = data_[ui_->song_list->selectionModel()->selectedIndexes().first().row()].current_;
   lyrics_fetcher_->Clear();
-  lyrics_fetcher_->Search(song.effective_albumartist(), song.artist(), song.album(), song.title());
+  lyrics_id_ = static_cast<qint64>(lyrics_fetcher_->Search(song.effective_albumartist(), song.artist(), song.album(), song.title()));
 
 }
 
 void EditTagDialog::UpdateLyrics(const quint64 id, const QString &provider, const QString &lyrics) {
 
-  Q_UNUSED(id);
   Q_UNUSED(provider);
 
+  if (static_cast<qint64>(id) != lyrics_id_) return;
+  lyrics_id_ = -1;
   ui_->lyrics->setPlainText(lyrics);
 
 }

--- a/src/dialogs/edittagdialog.cpp
+++ b/src/dialogs/edittagdialog.cpp
@@ -1434,7 +1434,7 @@ void EditTagDialog::UpdateLyrics(const quint64 id, const QString &provider, cons
 
   if (static_cast<qint64>(id) != lyrics_id_) return;
   lyrics_id_ = -1;
-  if (lyrics != nullptr) {
+  if (!lyrics.isEmpty()) {
       ui_->lyrics->setPlainText(lyrics);
   }
   else {

--- a/src/dialogs/edittagdialog.cpp
+++ b/src/dialogs/edittagdialog.cpp
@@ -1434,12 +1434,13 @@ void EditTagDialog::UpdateLyrics(const quint64 id, const QString &provider, cons
 
   if (static_cast<qint64>(id) != lyrics_id_) return;
   lyrics_id_ = -1;
-  if (!lyrics.isEmpty()) {
-      ui_->lyrics->setPlainText(lyrics);
+  if (lyrics.isEmpty()) {
+    ui_->lyrics->setPlainText(tr("Not found."));
   }
   else {
-      ui_->lyrics->setPlainText(tr("Not found."));
+    ui_->lyrics->setPlainText(lyrics);
   }
+
 }
 
 void EditTagDialog::SongSaveTagsComplete(TagReaderReply *reply, const QString &filename, Song song, const UpdateCoverAction cover_action) {

--- a/src/dialogs/edittagdialog.h
+++ b/src/dialogs/edittagdialog.h
@@ -214,6 +214,8 @@ class EditTagDialog : public QDialog {
   QMap<int, Song> collection_songs_;
 
   AlbumCoverLoaderOptions::Types cover_types_;
+
+  qint64 lyrics_id_;
 };
 
 #endif  // EDITTAGDIALOG_H

--- a/src/dialogs/edittagdialog.h
+++ b/src/dialogs/edittagdialog.h
@@ -57,6 +57,7 @@ class Ui_EditTagDialog;
 #ifdef HAVE_MUSICBRAINZ
 class TrackSelectionDialog;
 class TagFetcher;
+class LyricsFetcher;
 #endif
 
 class EditTagDialog : public QDialog {
@@ -120,6 +121,8 @@ class EditTagDialog : public QDialog {
   void SongRated(const float rating);
   void FetchTag();
   void FetchTagSongChosen(const Song &original_song, const Song &new_metadata);
+  void FetchLyrics();
+  void UpdateLyrics(const quint64 id, const QString &provider, const QString &lyrics);
 
   void AlbumCoverLoaded(const quint64 id, const AlbumCoverLoaderResult &cover_result);
 
@@ -185,6 +188,7 @@ class EditTagDialog : public QDialog {
   TagFetcher *tag_fetcher_;
   TrackSelectionDialog *results_dialog_;
 #endif
+  LyricsFetcher *lyrics_fetcher_;
 
   const QImage image_no_cover_thumbnail_;
 

--- a/src/dialogs/edittagdialog.ui
+++ b/src/dialogs/edittagdialog.ui
@@ -1131,6 +1131,13 @@
               </property>
              </widget>
             </item>
+            <item row="21" column="1">
+              <widget class="QPushButton" name="fetch_lyrics">
+                <property name="text">
+                  <string>Complete lyrics automatically</string>
+                </property>
+              </widget>
+            </item>
            </layout>
           </widget>
          </widget>
@@ -1213,6 +1220,7 @@
   <tabstop>fetch_tag</tabstop>
   <tabstop>comment</tabstop>
   <tabstop>lyrics</tabstop>
+  <tabstop>fetch_lyrics</tabstop>
  </tabstops>
  <resources>
   <include location="../../data/data.qrc"/>

--- a/src/lyrics/lyricsfetchersearch.cpp
+++ b/src/lyrics/lyricsfetchersearch.cpp
@@ -133,7 +133,8 @@ void LyricsFetcherSearch::AllProvidersFinished() {
   if (!results_.isEmpty()) {
     qLog(Debug) << "Using lyrics from" << results_.last().provider << "for" << request_.artist << request_.title << "with score" << results_.last().score;
     emit LyricsFetched(id_, results_.last().provider, results_.last().lyrics);
-  } else {
+  }
+  else {
     emit LyricsFetched(id_, QString(), QString());
   }
 

--- a/src/lyrics/lyricsfetchersearch.cpp
+++ b/src/lyrics/lyricsfetchersearch.cpp
@@ -133,6 +133,8 @@ void LyricsFetcherSearch::AllProvidersFinished() {
   if (!results_.isEmpty()) {
     qLog(Debug) << "Using lyrics from" << results_.last().provider << "for" << request_.artist << request_.title << "with score" << results_.last().score;
     emit LyricsFetched(id_, results_.last().provider, results_.last().lyrics);
+  } else {
+    emit LyricsFetched(id_, nullptr, nullptr);
   }
 
   emit SearchFinished(id_, results_);

--- a/src/lyrics/lyricsfetchersearch.cpp
+++ b/src/lyrics/lyricsfetchersearch.cpp
@@ -134,7 +134,7 @@ void LyricsFetcherSearch::AllProvidersFinished() {
     qLog(Debug) << "Using lyrics from" << results_.last().provider << "for" << request_.artist << request_.title << "with score" << results_.last().score;
     emit LyricsFetched(id_, results_.last().provider, results_.last().lyrics);
   } else {
-    emit LyricsFetched(id_, nullptr, nullptr);
+    emit LyricsFetched(id_, QString(), QString());
   }
 
   emit SearchFinished(id_, results_);


### PR DESCRIPTION
Strawberry is an awesome player having the ability to both fetch lyrics and edit tags. This PR aims at fetching lyrics directly into tags a bit faster (as required e.g. in #1287), by adding a "Complete lyrics automatically" in the lyrics tab of the tags edition dialog.
 
It probably needs a bit more polishing. I'd be happy to get help on a few points:
- I'm not sure `data_[ui_->song_list->selectionModel()->selectedIndexes().first().row()].original_;` was the most straightforward way to get the current song, but I didn't find another way
- I had to use `Q_UNUSED` twice because two of the parameters of the signal emitted by the LyricsFetcher are not useful here (not sure how to make a signal without these)
- might be better to display a loading icon and somehow display an error when nothing is found, but I don't know how to do both (adding "not found" in text area doesn't seem great)