### PR TITLE
mpris2: Fix `mpris:trackid` type with Plasma 6

### DIFF
--- a/src/core/mpris2.cpp
+++ b/src/core/mpris2.cpp
@@ -379,8 +379,8 @@ void Mpris2::SetRating(double rating) {
 
 }
 
-QString Mpris2::current_track_id() const {
-  return QString("/org/strawberrymusicplayer/strawberry/Track/%1").arg(QString::number(app_->playlist_manager()->active()->current_row()));
+QDBusObjectPath Mpris2::current_track_id() const {
+  return QDBusObjectPath(QString("/org/strawberrymusicplayer/strawberry/Track/%1").arg(QString::number(app_->playlist_manager()->active()->current_row())));
 }
 
 // We send Metadata change notification as soon as the process of changing song starts...
@@ -512,7 +512,7 @@ void Mpris2::Seek(qint64 offset) {
 
 void Mpris2::SetPosition(const QDBusObjectPath &trackId, qint64 offset) {
 
-  if (CanSeek() && trackId.path() == current_track_id() && offset >= 0) {
+  if (CanSeek() && trackId == current_track_id() && offset >= 0) {
     offset *= kNsecPerUsec;
 
     if (offset < app_->player()->GetCurrentItem()->Metadata().length_nanosec()) {

--- a/src/core/mpris2.h
+++ b/src/core/mpris2.h
@@ -225,7 +225,7 @@ class Mpris2 : public QObject {
 
   QString PlaybackStatus(EngineBase::State state) const;
 
-  QString current_track_id() const;
+  QDBusObjectPath current_track_id() const;
 
   bool CanSeek(EngineBase::State state) const;
 

--- a/src/core/mpris_common.h
+++ b/src/core/mpris_common.h
@@ -28,6 +28,7 @@
 #include <QDateTime>
 #include <QString>
 #include <QStringList>
+#include <QDBusObjectPath>
 
 namespace mpris {
 
@@ -53,6 +54,10 @@ inline void AddMetadata(const QString &key, double metadata, QVariantMap *map) {
 
 inline void AddMetadata(const QString &key, const QDateTime &metadata, QVariantMap *map) {
   if (metadata.isValid()) (*map)[key] = metadata;
+}
+
+inline void AddMetadata(const QString &key, const QDBusObjectPath &metadata, QVariantMap *map) {
+  if (metadata.path().length() > 0) (*map)[key] = metadata;
 }
 
 inline QString AsMPRISDateTimeType(const qint64 time) {

--- a/src/core/mpris_common.h
+++ b/src/core/mpris_common.h
@@ -57,7 +57,7 @@ inline void AddMetadata(const QString &key, const QDateTime &metadata, QVariantM
 }
 
 inline void AddMetadata(const QString &key, const QDBusObjectPath &metadata, QVariantMap *map) {
-  if (metadata.path().length() > 0) (*map)[key] = metadata;
+  if (metadata.path().length() > 0) (*map)[key] = QVariant::fromValue<QDBusObjectPath>(metadata);
 }
 
 inline QString AsMPRISDateTimeType(const qint64 time) {


### PR DESCRIPTION
Plasma 6 now type-checks `mpris:trackid` in the MPRIS2 protocol, which only works if it is of type `object path` (corresponding to the `QDBusObjectPath` type in Qt). Otherwise, `SetPosition` and `Seek` will not work in Plasma 6.

Original journal logs:

```
Mar 13 16:28:42 Reverier-Arch plasmashell[1407]: QDBusObjectPath: invalid path ""
Mar 13 16:28:42 Reverier-Arch plasmashell[1407]: qt.dbus.integration: QDBusConnection: error: could not send message to service "org.mpris.MediaPlayer2.strawberry" path "/org/mpris/MediaPlayer2" interface "org.mpris.MediaPlayer2.Player" member "SetPosition": Marshalling failed: Invalid object path passed in arguments
```

DBus messages:

```diff
signal time=1710328893.489827 sender=:1.329 -> destination=(null destination) serial=71 path=/org/mpris/MediaPlayer2; interface=org.freedesktop.DBus.Properties; member=PropertiesChanged
   string "org.mpris.MediaPlayer2.Player"
   array [
      dict entry(
         string "Metadata"
         variant             array [
               dict entry(
                  string "bitrate"
                  variant                      int32 1075
               )
               dict entry(
                  string "mpris:artUrl"
                  variant                      string "file:///tmp/strawberry-cover-TLEWft.jpg"
               )
               dict entry(
                  string "mpris:length"
                  variant                      int64 220067000
               )
               dict entry(
                  string "mpris:trackid"
-                 variant                      string "/org/strawberrymusicplayer/strawberry/Track/0"
+                 variant                      object path "/org/strawberrymusicplayer/strawberry/Track/0"
               )
               dict entry(
                  string "xesam:album"
                  variant                      string "HATSUNE MIKU EXPO 2016 E.P."
               )
               dict entry(
                  string "xesam:artist"
                  variant                      array [
                        string "初音ミク/Anamanaguchi"
                     ]
               )
               dict entry(
                  string "xesam:contentCreated"
                  variant                      string "2024-03-06T03:52:36"
               )
               dict entry(
                  string "xesam:title"
                  variant                      string "Miku"
               )
               dict entry(
                  string "xesam:trackNumber"
                  variant                      int32 11
               )
               dict entry(
                  string "xesam:url"
                  variant                      string "file:///home/reverier/Music/初音ミク,Anamanaguchi - Miku.flac"
               )
            ]
      )
   ]
   array [
   ]
```

this pr fixes the type of `mpris:trackid` .