### PR TITLE
Add Id3v2 Parsing to RIFF WAV files

### DIFF
--- a/ext/libstrawberry-tagreader/tagreadertaglib.cpp
+++ b/ext/libstrawberry-tagreader/tagreadertaglib.cpp
@@ -988,6 +988,25 @@ bool TagReaderTagLib::SaveFile(const spb::tagreader::SaveFileRequest &request) c
     }
   }
 
+  else if (TagLib::RIFF::WAV::File *file_wav = dynamic_cast<TagLib::RIFF::WAV::File*>(fileref->file())) {
+    if (file_wav->hasID3v2Tag()) {
+      TagLib::ID3v2::Tag *tag = file_wav->ID3v2Tag();
+      if (!tag) return false;
+      if (save_tags) {
+        SaveID3v2Tag(tag, song);
+      }
+      if (save_playcount) {
+        SetPlaycount(tag, song);
+      }
+      if (save_rating) {
+        SetRating(tag, song);
+      }
+      if (save_cover) {
+        SetEmbeddedArt(file_mpeg, tag, cover.data, cover.mime_type);
+      }
+    }
+  }
+
   // Handle all the files which have VorbisComments (Ogg, OPUS, ...) in the same way;
   // apart, so we keep specific behavior for some formats by adding another "else if" block above.
   if (!is_flac) {

--- a/ext/libstrawberry-tagreader/tagreadertaglib.cpp
+++ b/ext/libstrawberry-tagreader/tagreadertaglib.cpp
@@ -579,7 +579,16 @@ bool TagReaderTagLib::ReadFile(const QString &filename, spb::tagreader::SongMeta
 
 }
 
+void TagReaderTagLib::TStringToStdString(const TagLib::String &tag, std::string *output) {
+
+  const QString tmp = TStringToQString(tag).trimmed();
+  const QByteArray data = tmp.toUtf8();
+  output->assign(data.constData(), data.size());
+
+}
+
 void TagReaderTagLib::ParseID3v2Tag(TagLib::ID3v2::Tag *tag, QString *disc, QString *compilation, spb::tagreader::SongMetadata *song) const {
+
   TagLib::ID3v2::FrameListMap map = tag->frameListMap();
 
   if (map.contains("TPOS")) *disc = TStringToQString(map["TPOS"].front()->toString()).trimmed();
@@ -708,14 +717,6 @@ void TagReaderTagLib::ParseID3v2Tag(TagLib::ID3v2::Tag *tag, QString *disc, QStr
       }
     }
   }
-
-}
-
-void TagReaderTagLib::TStringToStdString(const TagLib::String &tag, std::string *output) {
-
-  const QString tmp = TStringToQString(tag).trimmed();
-  const QByteArray data = tmp.toUtf8();
-  output->assign(data.constData(), data.size());
 
 }
 

--- a/ext/libstrawberry-tagreader/tagreadertaglib.cpp
+++ b/ext/libstrawberry-tagreader/tagreadertaglib.cpp
@@ -953,14 +953,7 @@ bool TagReaderTagLib::SaveFile(const spb::tagreader::SaveFileRequest &request) c
     TagLib::ID3v2::Tag *tag = file_mpeg->ID3v2Tag(true);
     if (!tag) return false;
     if (save_tags) {
-      SetTextFrame("TPOS", song.disc() <= 0 ? QString() : QString::number(song.disc()), tag);
-      SetTextFrame("TCOM", song.composer().empty() ? std::string() : song.composer(), tag);
-      SetTextFrame("TIT1", song.grouping().empty() ? std::string() : song.grouping(), tag);
-      SetTextFrame("TOPE", song.performer().empty() ? std::string() : song.performer(), tag);
-      // Skip TPE1 (which is the artist) here because we already set it
-      SetTextFrame("TPE2", song.albumartist().empty() ? std::string() : song.albumartist(), tag);
-      SetTextFrame("TCMP", song.compilation() ? QString::number(1) : QString(), tag);
-      SetUnsyncLyricsFrame(song.lyrics().empty() ? std::string() : song.lyrics(), tag);
+      SaveID3v2Tag(tag, song);
     }
     if (save_playcount) {
       SetPlaycount(tag, song);
@@ -1023,6 +1016,19 @@ bool TagReaderTagLib::SaveFile(const spb::tagreader::SaveFileRequest &request) c
 #endif  // Q_OS_LINUX
 
   return success;
+
+}
+
+void TagReaderTagLib::SaveID3v2Tag(TagLib::ID3v2::Tag *tag, const spb::tagreader::SongMetadata &song) const {
+
+  SetTextFrame("TPOS", song.disc() <= 0 ? QString() : QString::number(song.disc()), tag);
+  SetTextFrame("TCOM", song.composer().empty() ? std::string() : song.composer(), tag);
+  SetTextFrame("TIT1", song.grouping().empty() ? std::string() : song.grouping(), tag);
+  SetTextFrame("TOPE", song.performer().empty() ? std::string() : song.performer(), tag);
+  // Skip TPE1 (which is the artist) here because we already set it
+  SetTextFrame("TPE2", song.albumartist().empty() ? std::string() : song.albumartist(), tag);
+  SetTextFrame("TCMP", song.compilation() ? QString::number(1) : QString(), tag);
+  SetUnsyncLyricsFrame(song.lyrics().empty() ? std::string() : song.lyrics(), tag);
 
 }
 

--- a/ext/libstrawberry-tagreader/tagreadertaglib.cpp
+++ b/ext/libstrawberry-tagreader/tagreadertaglib.cpp
@@ -529,6 +529,12 @@ bool TagReaderTagLib::ReadFile(const QString &filename, spb::tagreader::SongMeta
     if (tag) TStringToStdString(tag->comment(), song->mutable_comment());
   }
 
+  else if (TagLib::RIFF::WAV::File *file_wav = dynamic_cast<TagLib::RIFF::WAV::File*>(fileref->file())) {
+    if (file_wav->hasID3v2Tag()) {
+      ParseID3v2Tag(file_wav->ID3v2Tag(), &disc, &compilation, song);
+    }
+  }
+
   else if (tag) {
     TStringToStdString(tag->comment(), song->mutable_comment());
   }

--- a/ext/libstrawberry-tagreader/tagreadertaglib.cpp
+++ b/ext/libstrawberry-tagreader/tagreadertaglib.cpp
@@ -962,7 +962,7 @@ bool TagReaderTagLib::SaveFile(const spb::tagreader::SaveFileRequest &request) c
       SetRating(tag, song);
     }
     if (save_cover) {
-      SetEmbeddedArt(file_mpeg, tag, cover.data, cover.mime_type);
+      SetEmbeddedArt(tag, cover.data, cover.mime_type);
     }
   }
 
@@ -1002,7 +1002,7 @@ bool TagReaderTagLib::SaveFile(const spb::tagreader::SaveFileRequest &request) c
         SetRating(tag, song);
       }
       if (save_cover) {
-        SetEmbeddedArt(file_mpeg, tag, cover.data, cover.mime_type);
+        SetEmbeddedArt(tag, cover.data, cover.mime_type);
       }
     }
   }
@@ -1313,9 +1313,7 @@ void TagReaderTagLib::SetEmbeddedArt(TagLib::Ogg::XiphComment *xiph_comment, con
 
 }
 
-void TagReaderTagLib::SetEmbeddedArt(TagLib::MPEG::File *file_mp3, TagLib::ID3v2::Tag *tag, const QByteArray &data, const QString &mime_type) const {
-
-  (void)file_mp3;
+void TagReaderTagLib::SetEmbeddedArt(TagLib::ID3v2::Tag *tag, const QByteArray &data, const QString &mime_type) const {
 
   // Remove existing covers
   TagLib::ID3v2::FrameList apiclist = tag->frameListMap()["APIC"];
@@ -1395,7 +1393,7 @@ bool TagReaderTagLib::SaveEmbeddedArt(const spb::tagreader::SaveEmbeddedArtReque
   else if (TagLib::MPEG::File *file_mp3 = dynamic_cast<TagLib::MPEG::File*>(fileref.file())) {
     TagLib::ID3v2::Tag *tag = file_mp3->ID3v2Tag();
     if (!tag) return false;
-    SetEmbeddedArt(file_mp3, tag, cover.data, cover.mime_type);
+    SetEmbeddedArt(tag, cover.data, cover.mime_type);
   }
 
   // MP4/AAC

--- a/ext/libstrawberry-tagreader/tagreadertaglib.cpp
+++ b/ext/libstrawberry-tagreader/tagreadertaglib.cpp
@@ -989,21 +989,18 @@ bool TagReaderTagLib::SaveFile(const spb::tagreader::SaveFileRequest &request) c
   }
 
   else if (TagLib::RIFF::WAV::File *file_wav = dynamic_cast<TagLib::RIFF::WAV::File*>(fileref->file())) {
-    if (file_wav->hasID3v2Tag()) {
-      TagLib::ID3v2::Tag *tag = file_wav->ID3v2Tag();
-      if (!tag) return false;
-      if (save_tags) {
-        SaveID3v2Tag(tag, song);
-      }
-      if (save_playcount) {
-        SetPlaycount(tag, song);
-      }
-      if (save_rating) {
-        SetRating(tag, song);
-      }
-      if (save_cover) {
-        SetEmbeddedArt(tag, cover.data, cover.mime_type);
-      }
+    TagLib::ID3v2::Tag *tag = file_wav->ID3v2Tag();
+    if (save_tags) {
+      SaveID3v2Tag(tag, song);
+    }
+    if (save_playcount) {
+      SetPlaycount(tag, song);
+    }
+    if (save_rating) {
+      SetRating(tag, song);
+    }
+    if (save_cover) {
+      SetEmbeddedArt(tag, cover.data, cover.mime_type);
     }
   }
 

--- a/ext/libstrawberry-tagreader/tagreadertaglib.h
+++ b/ext/libstrawberry-tagreader/tagreadertaglib.h
@@ -100,7 +100,7 @@ class TagReaderTagLib : public TagReaderBase {
 
   void SetEmbeddedArt(TagLib::FLAC::File *flac_file, TagLib::Ogg::XiphComment *xiph_comment, const QByteArray &data, const QString &mime_type) const;
   void SetEmbeddedArt(TagLib::Ogg::XiphComment *xiph_comment, const QByteArray &data, const QString &mime_type) const;
-  void SetEmbeddedArt(TagLib::MPEG::File *file_mp3, TagLib::ID3v2::Tag *tag, const QByteArray &data, const QString &mime_type) const;
+  void SetEmbeddedArt(TagLib::ID3v2::Tag *tag, const QByteArray &data, const QString &mime_type) const;
   void SetEmbeddedArt(TagLib::MP4::File *aac_file, TagLib::MP4::Tag *tag, const QByteArray &data, const QString &mime_type) const;
 
  private:

--- a/ext/libstrawberry-tagreader/tagreadertaglib.h
+++ b/ext/libstrawberry-tagreader/tagreadertaglib.h
@@ -68,6 +68,7 @@ class TagReaderTagLib : public TagReaderBase {
  private:
   spb::tagreader::SongMetadata_FileType GuessFileType(TagLib::FileRef *fileref) const;
 
+  void ParseID3v2Tag(TagLib::ID3v2::Tag *tag, QString *disc, QString *compilation, spb::tagreader::SongMetadata *song) const;
   void ParseOggTag(const TagLib::Ogg::FieldListMap &map, QString *disc, QString *compilation, spb::tagreader::SongMetadata *song) const;
   void ParseAPETag(const TagLib::APE::ItemListMap &map, QString *disc, QString *compilation, spb::tagreader::SongMetadata *song) const;
 

--- a/ext/libstrawberry-tagreader/tagreadertaglib.h
+++ b/ext/libstrawberry-tagreader/tagreadertaglib.h
@@ -73,6 +73,7 @@ class TagReaderTagLib : public TagReaderBase {
   void ParseAPETag(const TagLib::APE::ItemListMap &map, QString *disc, QString *compilation, spb::tagreader::SongMetadata *song) const;
 
   void SetVorbisComments(TagLib::Ogg::XiphComment *vorbis_comment, const spb::tagreader::SongMetadata &song) const;
+  void SaveID3v2Tag(TagLib::ID3v2::Tag *tag, const spb::tagreader::SongMetadata &song) const;
   void SaveAPETag(TagLib::APE::Tag *tag, const spb::tagreader::SongMetadata &song) const;
 
   void SetTextFrame(const char *id, const QString &value, TagLib::ID3v2::Tag *tag) const;

--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -570,7 +570,8 @@ bool Song::write_tags_supported() const {
          d->filetype_ == FileType::TrueAudio ||
          d->filetype_ == FileType::APE ||
          d->filetype_ == FileType::DSF ||
-         d->filetype_ == FileType::DSDIFF;
+         d->filetype_ == FileType::DSDIFF ||
+         d->filetype_ == FileType::WAV;
 
 }
 
@@ -585,7 +586,8 @@ bool Song::additional_tags_supported() const {
     d->filetype_ == FileType::MPEG ||
     d->filetype_ == FileType::MP4 ||
     d->filetype_ == FileType::MPC ||
-    d->filetype_ == FileType::APE;
+    d->filetype_ == FileType::APE ||
+    d->filetype_ == FileType::WAV;
 
 }
 
@@ -607,7 +609,8 @@ bool Song::performer_supported() const {
     d->filetype_ == FileType::OggSpeex ||
     d->filetype_ == FileType::MPEG ||
     d->filetype_ == FileType::MPC ||
-    d->filetype_ == FileType::APE;
+    d->filetype_ == FileType::APE ||
+    d->filetype_ == FileType::WAV;
 
 }
 


### PR DESCRIPTION
Small change per the title. Abstracts the Id3v2 parsing logic from the MPEG filetype branch to it's own function then reuses it for RIFF WAV files.

EDIT: updated commit messages per CONTRIBUTING.md