### PR TITLE
Fix integer overflow in free space bar

### DIFF
--- a/src/widgets/freespacebar.cpp
+++ b/src/widgets/freespacebar.cpp
@@ -66,6 +66,7 @@ FreeSpaceBar::FreeSpaceBar(QWidget *parent)
       total_(100),
       free_text_(tr("Available")),
       additional_text_(tr("New songs")),
+      exceeded_text_(tr("Exceeded by")),
       used_text_(tr("Used")) {
 
   setMinimumHeight(FreeSpaceBar::sizeHint().height());
@@ -194,7 +195,12 @@ void FreeSpaceBar::DrawText(QPainter *p, const QRect r) {
   if (additional_ > 0) {
     labels << Label(TextForSize(additional_text_, additional_), kColorAdd1);
   }
-  labels << Label(TextForSize(free_text_, free_ - additional_), kColorBg2);
+  if (free_ > additional_ || additional_ == 0) {
+    labels << Label(TextForSize(free_text_, free_ - additional_), kColorBg2);
+  }
+  else {
+    labels << Label(TextForSize(exceeded_text_, additional_ - free_), kColorBar2);
+  }
 
   int text_width = 0;
   for (const Label &label : std::as_const(labels)) {

--- a/src/widgets/freespacebar.h
+++ b/src/widgets/freespacebar.h
@@ -87,6 +87,7 @@ class FreeSpaceBar : public QWidget {
 
   QString free_text_;
   QString additional_text_;
+  QString exceeded_text_;
   QString used_text_;
 };
 


### PR DESCRIPTION
This fixes a bug in the free space bar. If more songs were added to a device than the device had storage capacity for, there would be an integer underflow and it would show that the device had an incorrect amount of storage available as in the picture.
![image](https://github.com/strawberrymusicplayer/strawberry/assets/59752545/f731a3ba-a3f6-49af-b894-a97cc73b2763)
This fix checks for that condition and replaces it as shown in this picture
![image](https://github.com/strawberrymusicplayer/strawberry/assets/59752545/7b01a4f5-9b4d-4b0b-a09c-e63c4f9fe935)
