### PR TITLE
simplify CreateElementForMimeType + good practices

### DIFF
--- a/src/transcoder/transcoder.h
+++ b/src/transcoder/transcoder.h
@@ -133,7 +133,7 @@ class Transcoder : public QObject {
   bool StartJob(const Job &job);
 
   GstElement *CreateElement(const QString &factory_name, GstElement *bin = nullptr, const QString &name = QString());
-  GstElement *CreateElementForMimeType(const QString &element_type, const QString &mime_type, GstElement *bin = nullptr);
+  GstElement *CreateElementForMimeType(GstElementFactoryListType element_type, const QString &mime_type, GstElement *bin = nullptr);
   void SetElementProperties(const QString &name, GObject *object);
 
   static void NewPadCallback(GstElement*, GstPad *pad, gpointer data);


### PR DESCRIPTION
suggestions from gstreamer dev slomo on gst's matrix:
- whole static_pad_templates loop can be avoided with gst_element_factory_can_src_any_caps
- ffmpeg elements have been av* prefixed for a while now
- should be looking for Muxer instead of Codec/Muxer, Encoder/Audio instead of Codec/Encoder/Audio, and there are  constants for that