### PR TITLE
CMake: Use result of find_program instead of calling xgettext directly

### DIFF
--- a/cmake/Translations.cmake
+++ b/cmake/Translations.cmake
@@ -44,7 +44,7 @@ macro(add_pot outfiles header pot)
   add_custom_command(
     OUTPUT ${pot}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMAND xgettext ${XGETTEXT_OPTIONS} -s -C --omit-header --output="${CMAKE_CURRENT_BINARY_DIR}/pot.temp" ${add_pot_sources}
+    COMMAND ${GETTEXT_XGETTEXT_EXECUTABLE} ${XGETTEXT_OPTIONS} -s -C --omit-header --output="${CMAKE_CURRENT_BINARY_DIR}/pot.temp" ${add_pot_sources}
     COMMAND cat ${header} ${CMAKE_CURRENT_BINARY_DIR}/pot.temp > ${pot}
     DEPENDS ${add_pot_sources} ${header}
   )


### PR DESCRIPTION
`find_program` may be able to find the executable in locations which require a path, so use the result variable in the command.