### PR TITLE
Use accumulator variables for various scrolling

### DIFF
--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -1652,7 +1652,7 @@ void MainWindow::PlaylistDoubleClick(const QModelIndex &idx) {
 }
 
 void MainWindow::VolumeWheelEvent(const int delta) {
-  ui_->volume->setValue(ui_->volume->value() + delta / 30);
+  ui_->volume->HandleWheel(delta);
 }
 
 void MainWindow::ToggleShowHide() {

--- a/src/widgets/tracksliderslider.cpp
+++ b/src/widgets/tracksliderslider.cpp
@@ -42,7 +42,8 @@ TrackSliderSlider::TrackSliderSlider(QWidget *parent)
 #ifndef Q_OS_MACOS
       popup_(new TrackSliderPopup(window())),
 #endif
-      mouse_hover_seconds_(0) {
+      mouse_hover_seconds_(0),
+      wheel_accumulator_(0) {
 
   setMouseTracking(true);
 #ifndef Q_OS_MACOS
@@ -122,10 +123,14 @@ void TrackSliderSlider::mouseMoveEvent(QMouseEvent *e) {
 
 void TrackSliderSlider::wheelEvent(QWheelEvent *e) {
 
-  if (e->angleDelta().y() < 0) {
+  const int scroll_state = wheel_accumulator_ + e->angleDelta().y();
+  const int steps = scroll_state / WHEEL_ROTATION_TO_SEEK;
+  wheel_accumulator_ = scroll_state % WHEEL_ROTATION_TO_SEEK;
+
+  if (steps < 0) {
     emit SeekBackward();
   }
-  else {
+  else if (steps > 0) {
     emit SeekForward();
   }
   e->accept();

--- a/src/widgets/tracksliderslider.h
+++ b/src/widgets/tracksliderslider.h
@@ -66,11 +66,16 @@ class TrackSliderSlider : public QSlider {
   void UpdateDeltaTime();
 
  private:
+  // Units are eighths of a degree
+  static const int WHEEL_ROTATION_TO_SEEK = 120;
+
 #ifndef Q_OS_MACOS
   TrackSliderPopup *popup_;
 #endif
 
   int mouse_hover_seconds_;
+
+  int wheel_accumulator_;
 };
 
 #endif  // TRACKSLIDERSLIDER_H

--- a/src/widgets/volumeslider.h
+++ b/src/widgets/volumeslider.h
@@ -48,6 +48,7 @@ class VolumeSlider : public SliderSlider {
  public:
   explicit VolumeSlider(QWidget *parent, uint max = 0);
   void SetEnabled(const bool enabled);
+  void HandleWheel(const int delta);
 
  protected:
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
@@ -70,12 +71,17 @@ class VolumeSlider : public SliderSlider {
   static const int ANIM_INTERVAL = 18;
   static const int ANIM_MAX = 18;
 
+  // Units are eighths of a degree
+  static const int WHEEL_ROTATION_PER_STEP = 30;
+
   VolumeSlider(const VolumeSlider&);
   VolumeSlider &operator=(const VolumeSlider&);
 
   void generateGradient();
   QPixmap drawVolumePixmap() const;
   void drawVolumeSliderHandle();
+
+  int wheel_accumulator_;
 
   bool anim_enter_;
   int anim_count_;


### PR DESCRIPTION
I've noticed that scrolling to seek or change volume was not working well on my touchpad, so I went ahead and implemented accumulator variables for these cases.

### Previously

* Only moving fingers pretty quickly would register when scrolling on volume slider/analyzer, making it effectively unusable
* Even very slight scrolling on track slider would seek, again, making it unusable

### Now

* Scrolling on volume slider/analyzer works as expected - I can scroll as slowly as I want to and making either big or fine adjustments is intuitive
* Scrolling on track slider triggers seeking at predictable intervals, making it possible to utilize

### Considerations

* This will change behavior for users with mice possessing wheels with unusual resolutions:
* * Existence of accumulator for volume means that it's plausible that scrolling will sometimes change volume by +1 step due to carryover.
* * Existence of accumulator + minimum value for seeking by scrolling set according to most common wheel step means that high resolution mice users may have to scroll more than they used to in order to seek.
* This removes code that apparently attempted to reverse scroll direction for volume slider when using a touchpad. It was broken all around (not invoked when scrolling on analyzer and not reliable to begin with) and, honestly,  was a bad idea anyways.