### PR TITLE
Wait for set state to finish before deleting pipeline

### DIFF
--- a/src/core/player.h
+++ b/src/core/player.h
@@ -70,7 +70,7 @@ class PlayerInterface : public QObject {
   virtual void SaveVolume() = 0;
 
   // Manual track change to the specified track
-  virtual void PlayAt(const int index, const quint64 offset_nanosec, EngineBase::TrackChangeFlags change, const Playlist::AutoScroll autoscroll, const bool reshuffle, const bool force_inform = false) = 0;
+  virtual void PlayAt(const int index, const bool pause, const quint64 offset_nanosec, EngineBase::TrackChangeFlags change, const Playlist::AutoScroll autoscroll, const bool reshuffle, const bool force_inform = false) = 0;
 
   // If there's currently a song playing, pause it, otherwise play the track that was playing last, or the first one on the playlist
   virtual void PlayPause(const quint64 offset_nanosec = 0, const Playlist::AutoScroll autoscroll = Playlist::AutoScroll::Always) = 0;
@@ -98,6 +98,7 @@ class PlayerInterface : public QObject {
   virtual void Pause() = 0;
   virtual void Stop(const bool stop_after = false) = 0;
   virtual void Play(const quint64 offset_nanosec = 0) = 0;
+  virtual void PlayWithPause(const quint64 offset_nanosec) = 0;
   virtual void PlayHelper() = 0;
   virtual void ShowOSD() = 0;
 
@@ -159,7 +160,7 @@ class Player : public PlayerInterface {
   void LoadVolume() override;
   void SaveVolume() override;
 
-  void PlayAt(const int index, const quint64 offset_nanosec, EngineBase::TrackChangeFlags change, const Playlist::AutoScroll autoscroll, const bool reshuffle, const bool force_inform = false) override;
+  void PlayAt(const int index, const bool pause, const quint64 offset_nanosec, EngineBase::TrackChangeFlags change, const Playlist::AutoScroll autoscroll, const bool reshuffle, const bool force_inform = false) override;
   void PlayPause(const quint64 offset_nanosec = 0, const Playlist::AutoScroll autoscroll = Playlist::AutoScroll::Always) override;
   void PlayPauseHelper() override { PlayPause(play_offset_nanosec_); }
   void RestartOrPrevious() override;
@@ -182,6 +183,7 @@ class Player : public PlayerInterface {
   void Stop(const bool stop_after = false) override;
   void StopAfterCurrent();
   void Play(const quint64 offset_nanosec = 0) override;
+  void PlayWithPause(const quint64 offset_nanosec) override;
   void PlayHelper() override { Play(); }
   void ShowOSD() override;
   void TogglePrettyOSD();
@@ -228,6 +230,7 @@ class Player : public PlayerInterface {
 
   PlaylistItemPtr current_item_;
 
+  bool pause_;
   EngineBase::TrackChangeFlags stream_change_type_;
   Playlist::AutoScroll autoscroll_;
   EngineBase::State last_state_;

--- a/src/engine/enginebase.cpp
+++ b/src/engine/enginebase.cpp
@@ -139,13 +139,13 @@ bool EngineBase::Load(const QUrl &media_url, const QUrl &stream_url, const Track
 
 }
 
-bool EngineBase::Play(const QUrl &media_url, const QUrl &stream_url, const TrackChangeFlags flags, const bool force_stop_at_end, const quint64 beginning_nanosec, const qint64 end_nanosec, const quint64 offset_nanosec, const std::optional<double> ebur128_integrated_loudness_lufs) {
+bool EngineBase::Play(const QUrl &media_url, const QUrl &stream_url, const bool pause, const TrackChangeFlags flags, const bool force_stop_at_end, const quint64 beginning_nanosec, const qint64 end_nanosec, const quint64 offset_nanosec, const std::optional<double> ebur128_integrated_loudness_lufs) {
 
   if (!Load(media_url, stream_url, flags, force_stop_at_end, beginning_nanosec, end_nanosec, ebur128_integrated_loudness_lufs)) {
     return false;
   }
 
-  return Play(offset_nanosec);
+  return Play(pause, offset_nanosec);
 
 }
 

--- a/src/engine/enginebase.h
+++ b/src/engine/enginebase.h
@@ -105,7 +105,7 @@ class EngineBase : public QObject {
   virtual State state() const = 0;
   virtual void StartPreloading(const QUrl&, const QUrl&, const bool, const qint64, const qint64) {}
   virtual bool Load(const QUrl &media_url, const QUrl &stream_url, const TrackChangeFlags change, const bool force_stop_at_end, const quint64 beginning_nanosec, const qint64 end_nanosec, const std::optional<double> ebur128_integrated_loudness_lufs);
-  virtual bool Play(const quint64 offset_nanosec) = 0;
+  virtual bool Play(const bool pause, const quint64 offset_nanosec) = 0;
   virtual void Stop(const bool stop_after = false) = 0;
   virtual void Pause() = 0;
   virtual void Unpause() = 0;
@@ -133,7 +133,7 @@ class EngineBase : public QObject {
 
   // Plays a media stream represented with the URL 'u' from the given 'beginning' to the given 'end' (usually from 0 to a song's length).
   // Both markers should be passed in nanoseconds. 'end' can be negative, indicating that the real length of 'u' stream is unknown.
-  bool Play(const QUrl &media_url, const QUrl &stream_url, const TrackChangeFlags flags, const bool force_stop_at_end, const quint64 beginning_nanosec, const qint64 end_nanosec, const quint64 offset_nanosec, const std::optional<double> ebur128_integrated_loudness_lufs);
+  bool Play(const QUrl &media_url, const QUrl &stream_url, const bool pause, const TrackChangeFlags flags, const bool force_stop_at_end, const quint64 beginning_nanosec, const qint64 end_nanosec, const quint64 offset_nanosec, const std::optional<double> ebur128_integrated_loudness_lufs);
   void SetVolume(const uint volume);
 
  public slots:

--- a/src/engine/gstengine.h
+++ b/src/engine/gstengine.h
@@ -35,18 +35,19 @@
 #include <QFuture>
 #include <QByteArray>
 #include <QList>
+#include <QMap>
 #include <QString>
 #include <QUrl>
 
 #include "core/shared_ptr.h"
 #include "enginebase.h"
 #include "gststartup.h"
+#include "gstenginepipeline.h"
 #include "gstbufferconsumer.h"
 
 class QTimer;
 class QTimerEvent;
 class TaskManager;
-class GstEnginePipeline;
 
 class GstEngine : public EngineBase, public GstBufferConsumer {
   Q_OBJECT
@@ -63,7 +64,7 @@ class GstEngine : public EngineBase, public GstBufferConsumer {
   State state() const override;
   void StartPreloading(const QUrl &media_url, const QUrl &stream_url, const bool force_stop_at_end, const qint64 beginning_nanosec, const qint64 end_nanosec) override;
   bool Load(const QUrl &media_url, const QUrl &stream_url, const EngineBase::TrackChangeFlags change, const bool force_stop_at_end, const quint64 beginning_nanosec, const qint64 end_nanosec, const std::optional<double> ebur128_integrated_loudness_lufs) override;
-  bool Play(const quint64 offset_nanosec) override;
+  bool Play(const bool pause, const quint64 offset_nanosec) override;
   void Stop(const bool stop_after = false) override;
   void Pause() override;
   void Unpause() override;
@@ -115,32 +116,39 @@ class GstEngine : public EngineBase, public GstBufferConsumer {
   void HandlePipelineError(const int pipeline_id, const int domain, const int error_code, const QString &message, const QString &debugstr);
   void NewMetaData(const int pipeline_id, const EngineMetadata &engine_metadata);
   void AddBufferToScope(GstBuffer *buf, const int pipeline_id, const QString &format);
-  void FadeoutFinished();
+  void FadeoutFinished(const int pipeline_id);
   void FadeoutPauseFinished();
   void SeekNow();
-  void PlayDone(const GstStateChangeReturn ret, const quint64, const int);
+  void PlayDone(const GstStateChangeReturn ret, const bool pause, const quint64 offset_nanosec, const int pipeline_id);
 
   void BufferingStarted();
   void BufferingProgress(int percent);
   void BufferingFinished();
+
+  void PipelineFinished(const int pipeline_id);
 
  private:
   QByteArray FixupUrl(const QUrl &url);
 
   void StartFadeout();
   void StartFadeoutPause();
+  void StopFadeoutPause();
 
   void StartTimers();
   void StopTimers();
 
-  SharedPtr<GstEnginePipeline> CreatePipeline();
-  SharedPtr<GstEnginePipeline> CreatePipeline(const QUrl &media_url, const QUrl &stream_url, const QByteArray &gst_url, const qint64 end_nanosec, const double ebur128_loudness_normalizing_gain_db);
+  GstEnginePipelinePtr CreatePipeline();
+  GstEnginePipelinePtr CreatePipeline(const QUrl &media_url, const QUrl &stream_url, const QByteArray &gst_url, const qint64 end_nanosec, const double ebur128_loudness_normalizing_gain_db);
+
+  void FinishPipeline(GstEnginePipelinePtr pipeline);
 
   void UpdateScope(int chunk_length);
 
   static void StreamDiscovered(GstDiscoverer*, GstDiscovererInfo *info, GError*, gpointer self);
   static void StreamDiscoveryFinished(GstDiscoverer*, gpointer);
   static QString GSTdiscovererErrorMessage(GstDiscovererResult result);
+
+  bool ExclusivePipelineActive() const;
 
  private:
   SharedPtr<TaskManager> task_manager_;
@@ -149,9 +157,10 @@ class GstEngine : public EngineBase, public GstBufferConsumer {
 
   int buffering_task_id_;
 
-  SharedPtr<GstEnginePipeline> current_pipeline_;
-  SharedPtr<GstEnginePipeline> fadeout_pipeline_;
-  SharedPtr<GstEnginePipeline> fadeout_pause_pipeline_;
+  GstEnginePipelinePtr current_pipeline_;
+  QMap<int, GstEnginePipelinePtr> fadeout_pipelines_;
+  GstEnginePipelinePtr fadeout_pause_pipeline_;
+  QMap<int, GstEnginePipelinePtr> old_pipelines_;
 
   QList<GstBufferConsumer*> buffer_consumers_;
 
@@ -171,8 +180,7 @@ class GstEngine : public EngineBase, public GstBufferConsumer {
 
   int timer_id_;
 
-  bool is_fading_out_to_pause_;
-  bool has_faded_out_;
+  bool has_faded_out_to_pause_;
 
   int scope_chunk_;
   bool have_new_buffer_;
@@ -181,6 +189,10 @@ class GstEngine : public EngineBase, public GstBufferConsumer {
 
   int discovery_finished_cb_id_;
   int discovery_discovered_cb_id_;
+
+  State delayed_state_;
+  bool delayed_state_pause_;
+  quint64 delayed_state_offset_nanosec_;
 };
 
 #endif  // GSTENGINE_H

--- a/src/engine/vlcengine.cpp
+++ b/src/engine/vlcengine.cpp
@@ -124,7 +124,9 @@ bool VLCEngine::Load(const QUrl &media_url, const QUrl &stream_url, const Engine
 
 }
 
-bool VLCEngine::Play(const quint64 offset_nanosec) {
+bool VLCEngine::Play(const bool pause, const quint64 offset_nanosec) {
+
+  Q_UNUSED(pause);
 
   if (!Initialized()) return false;
 

--- a/src/engine/vlcengine.h
+++ b/src/engine/vlcengine.h
@@ -52,7 +52,7 @@ class VLCEngine : public EngineBase {
   bool Init() override;
   EngineBase::State state() const override { return state_; }
   bool Load(const QUrl &media_url, const QUrl &stream_url, const EngineBase::TrackChangeFlags change, const bool force_stop_at_end, const quint64 beginning_nanosec, const qint64 end_nanosec, const std::optional<double> ebur128_integrated_loudness_lufs) override;
-  bool Play(const quint64 offset_nanosec) override;
+  bool Play(const bool pause, const quint64 offset_nanosec) override;
   void Stop(const bool stop_after = false) override;
   void Pause() override;
   void Unpause() override;


### PR DESCRIPTION
Setting state to GST_STATE_NULL sometimes blocks, to fix this use the threadpool to set the state to NULL and wait with deleting the pipeline until the state is changed. This fixes blocking the main thread when switching Spotify songs.