### PR TITLE
Settings: Add "Restart or previous" global shortcut

### DIFF
--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -830,6 +830,7 @@ MainWindow::MainWindow(Application *app, SharedPtr<SystemTrayIcon> tray_icon, OS
   QObject::connect(globalshortcuts_manager_, &GlobalShortcutsManager::StopAfter, ui_->action_stop_after_this_track, &QAction::trigger);
   QObject::connect(globalshortcuts_manager_, &GlobalShortcutsManager::Next, ui_->action_next_track, &QAction::trigger);
   QObject::connect(globalshortcuts_manager_, &GlobalShortcutsManager::Previous, ui_->action_previous_track, &QAction::trigger);
+  QObject::connect(globalshortcuts_manager_, &GlobalShortcutsManager::RestartOrPrevious, &*app_->player(), &Player::RestartOrPrevious);
   QObject::connect(globalshortcuts_manager_, &GlobalShortcutsManager::IncVolume, &*app_->player(), &Player::VolumeUp);
   QObject::connect(globalshortcuts_manager_, &GlobalShortcutsManager::DecVolume, &*app_->player(), &Player::VolumeDown);
   QObject::connect(globalshortcuts_manager_, &GlobalShortcutsManager::Mute, &*app_->player(), &Player::Mute);

--- a/src/globalshortcuts/globalshortcutsmanager.cpp
+++ b/src/globalshortcuts/globalshortcutsmanager.cpp
@@ -66,6 +66,7 @@ GlobalShortcutsManager::GlobalShortcutsManager(QWidget *parent) : QWidget(parent
   AddShortcut(QStringLiteral("stop_after"), tr("Stop playing after current track"), std::bind(&GlobalShortcutsManager::StopAfter, this));
   AddShortcut(QStringLiteral("next_track"), tr("Next track"), std::bind(&GlobalShortcutsManager::Next, this), QKeySequence(Qt::Key_MediaNext));
   AddShortcut(QStringLiteral("prev_track"), tr("Previous track"), std::bind(&GlobalShortcutsManager::Previous, this), QKeySequence(Qt::Key_MediaPrevious));
+  AddShortcut(QStringLiteral("restart_or_prev_track"), tr("Restart or previous track"), std::bind(&GlobalShortcutsManager::RestartOrPrevious, this));
   AddShortcut(QStringLiteral("inc_volume"), tr("Increase volume"), std::bind(&GlobalShortcutsManager::IncVolume, this));
   AddShortcut(QStringLiteral("dec_volume"), tr("Decrease volume"), std::bind(&GlobalShortcutsManager::DecVolume, this));
   AddShortcut(QStringLiteral("mute"), tr("Mute"), std::bind(&GlobalShortcutsManager::Mute, this));

--- a/src/globalshortcuts/globalshortcutsmanager.h
+++ b/src/globalshortcuts/globalshortcutsmanager.h
@@ -85,6 +85,7 @@ class GlobalShortcutsManager : public QWidget {
   void StopAfter();
   void Next();
   void Previous();
+  void RestartOrPrevious();
   void IncVolume();
   void DecVolume();
   void Mute();

--- a/src/translations/translations.pot
+++ b/src/translations/translations.pot
@@ -2000,6 +2000,9 @@ msgstr ""
 msgid "Previous track"
 msgstr ""
 
+msgid "Restart or previous track"
+msgstr ""
+
 msgid "Increase volume"
 msgstr ""
 


### PR DESCRIPTION
Small new feature as the title says: A new global shortcut "Restart or previous" is added that has the same functionality as the "--restart-or-previous" command line argument (and uses the same method `Player::RestartOrPrevious()`).