### PR TITLE
Add icons only sidebar mode

### DIFF
--- a/src/translations/translations.pot
+++ b/src/translations/translations.pot
@@ -1757,6 +1757,9 @@ msgstr ""
 msgid "Large sidebar"
 msgstr ""
 
+msgid "Icons sidebar"
+msgstr ""
+
 msgid "Small sidebar"
 msgstr ""
 

--- a/src/widgets/fancytabbar.cpp
+++ b/src/widgets/fancytabbar.cpp
@@ -112,6 +112,9 @@ QSize FancyTabBar::tabSizeHint(const int index) const {
     QRect rect = fm.boundingRect(QRect(0, 0, w, height()), Qt::TextWordWrap, TabText(index));
     size = QSize(w, tabWidget->iconsize_largesidebar() + rect.height() + 10);
   }
+  else if (tabWidget->mode() == FancyTabWidget::Mode::IconsSidebar) {
+    size = QSize(tabWidget->iconsize_largesidebar() + 20, tabWidget->iconsize_largesidebar() + 20);
+  }
   else if (tabWidget->mode() == FancyTabWidget::Mode::SmallSidebar) {
 
     QFont bold_font(font());
@@ -156,7 +159,9 @@ void FancyTabBar::paintEvent(QPaintEvent *pe) {
 
   FancyTabWidget *tabWidget = qobject_cast<FancyTabWidget*>(parentWidget());
 
-  if (tabWidget->mode() != FancyTabWidget::Mode::LargeSidebar && tabWidget->mode() != FancyTabWidget::Mode::SmallSidebar) {
+  if (tabWidget->mode() != FancyTabWidget::Mode::LargeSidebar &&
+      tabWidget->mode() != FancyTabWidget::Mode::SmallSidebar &&
+      tabWidget->mode() != FancyTabWidget::Mode::IconsSidebar) {
     QTabBar::paintEvent(pe);
     return;
   }
@@ -273,7 +278,13 @@ void FancyTabBar::paintEvent(QPaintEvent *pe) {
         tabrectIcon.setSize(QSize(tabWidget->iconsize_largesidebar(), tabWidget->iconsize_largesidebar()));
         // Center the icon
         const int moveRight = (QTabBar::width() - tabWidget->iconsize_largesidebar() - 1) / 2;
-        tabrectIcon.translate(moveRight, 5);
+
+        if (tabWidget->mode() == FancyTabWidget::Mode::IconsSidebar) {
+          tabrectIcon.translate(moveRight, (tabSizeHint(0).height() - tabWidget->iconsize_largesidebar() - 5) / 2);
+        }
+        else {
+          tabrectIcon.translate(moveRight, 5);
+        }
       }
       tabIcon(index).paint(&p, tabrectIcon, iconFlags);
       p.restore();

--- a/src/widgets/fancytabwidget.cpp
+++ b/src/widgets/fancytabwidget.cpp
@@ -199,7 +199,7 @@ void FancyTabWidget::SetMode(const Mode mode) {
   }
 
 #ifndef Q_OS_MACOS
-  if (mode_ == Mode::LargeSidebar) {
+  if (mode_ == Mode::LargeSidebar || mode_ == Mode::IconsSidebar) {
     setIconSize(QSize(iconsize_largesidebar_, iconsize_largesidebar_));
   }
   else {
@@ -207,13 +207,15 @@ void FancyTabWidget::SetMode(const Mode mode) {
   }
 #endif
 
-  if (previous_mode == Mode::IconOnlyTabs && mode != Mode::IconOnlyTabs) {
+  if ((previous_mode == Mode::IconOnlyTabs || previous_mode == Mode::IconsSidebar) &&
+      (mode != Mode::IconOnlyTabs && mode != Mode::IconsSidebar)) {
     for (int i = 0; i < count(); ++i) {
       tabBar()->setTabText(i, tabBar()->tabData(i).value<FancyTabData*>()->label());
       tabBar()->setTabToolTip(i, ""_L1);
     }
   }
-  else if (previous_mode != Mode::IconOnlyTabs && mode == Mode::IconOnlyTabs) {
+  else if ((previous_mode != Mode::IconOnlyTabs && previous_mode != Mode::IconsSidebar) &&
+           (mode == Mode::IconOnlyTabs || mode == Mode::IconsSidebar)) {
     for (int i = 0; i < count(); ++i) {
       tabBar()->setTabText(i, ""_L1);
       tabBar()->setTabToolTip(i, tabBar()->tabData(i).value<FancyTabData*>()->label());
@@ -286,7 +288,7 @@ int FancyTabWidget::IndexOfTab(QWidget *widget) {
 
 void FancyTabWidget::paintEvent(QPaintEvent *pe) {
 
-  if (mode() != Mode::LargeSidebar && mode() != Mode::SmallSidebar) {
+  if (mode() != Mode::LargeSidebar && mode() != Mode::SmallSidebar && mode() != Mode::IconsSidebar) {
     QTabWidget::paintEvent(pe);
     return;
   }
@@ -383,6 +385,7 @@ void FancyTabWidget::contextMenuEvent(QContextMenuEvent *e) {
     menu_ = new QMenu(this);
     QActionGroup *group = new QActionGroup(this);
     addMenuItem(group, tr("Large sidebar"), Mode::LargeSidebar);
+    addMenuItem(group, tr("Icons sidebar"), Mode::IconsSidebar);
     addMenuItem(group, tr("Small sidebar"), Mode::SmallSidebar);
     addMenuItem(group, tr("Plain sidebar"), Mode::PlainSidebar);
     addMenuItem(group, tr("Tabs on top"), Mode::Tabs);

--- a/src/widgets/fancytabwidget.h
+++ b/src/widgets/fancytabwidget.h
@@ -48,7 +48,8 @@ class FancyTabWidget : public QTabWidget {
     SmallSidebar,
     Tabs,
     IconOnlyTabs,
-    PlainSidebar
+    PlainSidebar,
+    IconsSidebar,
   };
 
   Mode mode() const { return mode_; }


### PR DESCRIPTION
Hello to everyone,

I hope the work hasn't been done so far and I am not doing anything in parallel to someone else.

Nevertheless, I want the sidebar with the fancy background to have only icons and no text. So it gets a little bit smaller. I made the change here with the pull request. What is missing so far is the icon for smart playlists. There should be a different one to distinguish the smart and the custom playlists.

I hope that there is no big resistance for the change. I would really appreciate it. :-)

In case of any further questions, don't hesitate to contact me.

Thanks in advance.
Greetings Christian
 