### PR TITLE
Player controls position switch

### DIFF
--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -954,12 +954,6 @@ MainWindow::MainWindow(Application *app, SharedPtr<SystemTrayIcon> tray_icon, OS
   // Reload playlist settings, for BG and glowing
   ui_->playlist->view()->ReloadSettings();
 
-  // Initialize the player controls position.
-  PlayerControlsPosition default_position = PlayerControlsPosition::Bottom;
-  PlayerControlsPosition player_controls_position = static_cast<PlayerControlsPosition>(settings_.value("player_controls_position", static_cast<int>(default_position)).toInt());
-  if (player_controls_position == PlayerControlsPosition::None) player_controls_position = default_position;
-  SetPlayerControlsPosition(player_controls_position);
-
 #ifdef Q_OS_MACOS  // Always show the mainwindow on startup for macOS
   show();
 #else
@@ -1141,6 +1135,12 @@ void MainWindow::ReloadSettings() {
 
   s.beginGroup(AppearanceSettingsPage::kSettingsGroup);
   int iconsize = s.value(AppearanceSettingsPage::kIconSizePlayControlButtons, 32).toInt();
+
+  // Initialize the player controls position.
+  PlayerControlsPosition default_position = PlayerControlsPosition::Bottom;
+  PlayerControlsPosition player_controls_position = static_cast<PlayerControlsPosition>(s.value(AppearanceSettingsPage::kPlayerControlsPosition, static_cast<int>(default_position)).toInt());
+  if (player_controls_position == PlayerControlsPosition::None) player_controls_position = default_position;
+  SetPlayerControlsPosition(player_controls_position);
   s.endGroup();
 
   tray_icon_->SetTrayiconProgress(trayicon_progress);
@@ -1291,7 +1291,6 @@ void MainWindow::SaveSettings() {
 
   settings_.setValue("show_sidebar", ui_->action_toggle_show_sidebar->isChecked());
   settings_.setValue("search_for_cover_auto", album_cover_choice_controller_->search_cover_auto_action()->isChecked());
-  settings_.setValue("player_controls_position", static_cast<int>(player_controls_position_));
 
 }
 

--- a/src/core/mainwindow.h
+++ b/src/core/mainwindow.h
@@ -112,6 +112,12 @@ class MainWindow : public QMainWindow, public PlatformInterface {
   static const char *kSettingsGroup;
   static const char *kAllFilesFilterSpec;
 
+  enum class PlayerControlsPosition {
+    None = 0,
+    Top,
+    Bottom,
+  };
+
   void SetHiddenInTray(const bool hidden);
   void CommandlineOptionsReceived(const CommandlineOptions &options);
 
@@ -270,6 +276,7 @@ class MainWindow : public QMainWindow, public PlatformInterface {
  public Q_SLOTS:
   void CommandlineOptionsReceived(const QByteArray &string_options);
   void Raise();
+  void SetPlayerControlsPosition(const PlayerControlsPosition position);
 
  private:
 
@@ -405,6 +412,8 @@ class MainWindow : public QMainWindow, public PlatformInterface {
   int exit_count_;
   bool delete_files_;
   bool ignore_close_;
+
+  PlayerControlsPosition player_controls_position_;
 
 };
 

--- a/src/core/mainwindow.ui
+++ b/src/core/mainwindow.ui
@@ -456,7 +456,7 @@
      <x>0</x>
      <y>0</y>
      <width>1131</width>
-     <height>30</height>
+     <height>23</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_music">
@@ -501,7 +501,7 @@
    </widget>
    <widget class="QMenu" name="menu_help">
     <property name="title">
-     <string>Hel&amp;p</string>
+     <string>Help</string>
     </property>
     <addaction name="action_about_strawberry"/>
     <addaction name="action_about_qt"/>
@@ -532,7 +532,7 @@
   </widget>
   <action name="action_previous_track">
    <property name="text">
-    <string>P&amp;revious track</string>
+    <string>Previous track</string>
    </property>
    <property name="shortcut">
     <string>F5</string>
@@ -589,7 +589,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>&amp;Love</string>
+    <string>Love</string>
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+L</string>
@@ -755,7 +755,7 @@
   </action>
   <action name="action_save_all_playlists">
    <property name="text">
-    <string>Sa&amp;ve all playlists...</string>
+    <string>&amp;Save all playlists...</string>
    </property>
   </action>
   <action name="action_next_playlist">
@@ -799,7 +799,7 @@
   </action>
   <action name="action_stop_collection_scan">
    <property name="text">
-    <string>Sto&amp;p collection scan</string>
+    <string>Stop collection scan</string>
    </property>
    <property name="toolTip">
     <string>Stop collection scan</string>
@@ -844,7 +844,7 @@
   </action>
   <action name="action_add_stream">
    <property name="text">
-    <string>Add str&amp;eam...</string>
+    <string>Add stream...</string>
    </property>
   </action>
   <action name="action_toggle_show_sidebar">
@@ -852,12 +852,12 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Sho&amp;w sidebar</string>
+    <string>Show sidebar</string>
    </property>
   </action>
   <action name="action_import_data_from_last_fm">
    <property name="text">
-    <string>&amp;Import data from last.fm...</string>
+    <string>Import data from last.fm...</string>
    </property>
   </action>
  </widget>

--- a/src/core/mainwindow.ui
+++ b/src/core/mainwindow.ui
@@ -70,379 +70,379 @@
          </widget>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="layout_bottom">
-          <property name="spacing">
-           <number>0</number>
+         <widget class="Line" name="line_playlist_sep">
+          <property name="orientation">
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
-          <item>
-           <widget class="QWidget" name="player_controls_container" native="true">
-            <layout class="QVBoxLayout" name="layout_player_controls_container">
-             <property name="spacing">
-              <number>0</number>
+         </widget>
+        </item>
+        <item>
+         <widget class="QWidget" name="player_controls_container" native="true">
+          <layout class="QVBoxLayout" name="layout_player_controls_container">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QFrame" name="player_controls">
+             <property name="frameShape">
+              <enum>QFrame::Shape::NoFrame</enum>
              </property>
-             <property name="leftMargin">
-              <number>0</number>
+             <layout class="QHBoxLayout" name="layout_player_controls">
+              <property name="spacing">
+               <number>1</number>
+              </property>
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <widget class="QToolButton" name="back_button">
+                <property name="accessibleName">
+                 <string>MenuPopupToolButton</string>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>32</width>
+                  <height>32</height>
+                 </size>
+                </property>
+                <property name="autoRaise">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QToolButton" name="pause_play_button">
+                <property name="accessibleName">
+                 <string>MenuPopupToolButton</string>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>32</width>
+                  <height>32</height>
+                 </size>
+                </property>
+                <property name="autoRaise">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QToolButton" name="stop_button">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="accessibleName">
+                 <string>MenuPopupToolButton</string>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>32</width>
+                  <height>32</height>
+                 </size>
+                </property>
+                <property name="popupMode">
+                 <enum>QToolButton::ToolButtonPopupMode::MenuButtonPopup</enum>
+                </property>
+                <property name="autoRaise">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QToolButton" name="forward_button">
+                <property name="accessibleName">
+                 <string>MenuPopupToolButton</string>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>32</width>
+                  <height>32</height>
+                 </size>
+                </property>
+                <property name="autoRaise">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QWidget" name="widget_love" native="true">
+                <layout class="QHBoxLayout" name="layout_widget_love">
+                 <property name="spacing">
+                  <number>1</number>
+                 </property>
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <widget class="Line" name="line_love">
+                   <property name="orientation">
+                    <enum>Qt::Orientation::Vertical</enum>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QToolButton" name="button_love">
+                   <property name="accessibleName">
+                    <string>MenuPopupToolButton</string>
+                   </property>
+                   <property name="iconSize">
+                    <size>
+                     <width>32</width>
+                     <height>32</height>
+                    </size>
+                   </property>
+                   <property name="autoRaise">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="Line" name="line_buttons">
+                <property name="orientation">
+                 <enum>Qt::Orientation::Vertical</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="AnalyzerContainer" name="analyzer" native="true">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>100</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>36</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer">
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Policy::Expanding</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>0</width>
+                  <height>0</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="Line" name="line_volume">
+                <property name="orientation">
+                 <enum>Qt::Orientation::Vertical</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="VolumeSlider" name="volume">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="maximum">
+                 <number>100</number>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QWidget" name="status_bar" native="true">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
              </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QFrame" name="player_controls">
-               <property name="frameShape">
-                <enum>QFrame::Shape::NoFrame</enum>
-               </property>
-               <layout class="QHBoxLayout" name="layout_player_controls">
-                <property name="spacing">
-                 <number>1</number>
+             <layout class="QVBoxLayout" name="layout_status_bar">
+              <property name="spacing">
+               <number>0</number>
+              </property>
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <widget class="Line" name="status_bar_line">
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
                 </property>
-                <property name="leftMargin">
-                 <number>0</number>
+               </widget>
+              </item>
+              <item>
+               <widget class="QWidget" name="status_bar_internal" native="true">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
                 </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <property name="rightMargin">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QToolButton" name="back_button">
-                  <property name="accessibleName">
-                   <string>MenuPopupToolButton</string>
-                  </property>
-                  <property name="iconSize">
-                   <size>
-                    <width>32</width>
-                    <height>32</height>
-                   </size>
-                  </property>
-                  <property name="autoRaise">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QToolButton" name="pause_play_button">
-                  <property name="accessibleName">
-                   <string>MenuPopupToolButton</string>
-                  </property>
-                  <property name="iconSize">
-                   <size>
-                    <width>32</width>
-                    <height>32</height>
-                   </size>
-                  </property>
-                  <property name="autoRaise">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QToolButton" name="stop_button">
-                  <property name="enabled">
-                   <bool>false</bool>
-                  </property>
-                  <property name="accessibleName">
-                   <string>MenuPopupToolButton</string>
-                  </property>
-                  <property name="iconSize">
-                   <size>
-                    <width>32</width>
-                    <height>32</height>
-                   </size>
-                  </property>
-                  <property name="popupMode">
-                   <enum>QToolButton::ToolButtonPopupMode::MenuButtonPopup</enum>
-                  </property>
-                  <property name="autoRaise">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QToolButton" name="forward_button">
-                  <property name="accessibleName">
-                   <string>MenuPopupToolButton</string>
-                  </property>
-                  <property name="iconSize">
-                   <size>
-                    <width>32</width>
-                    <height>32</height>
-                   </size>
-                  </property>
-                  <property name="autoRaise">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QWidget" name="widget_love" native="true">
-                  <layout class="QHBoxLayout" name="layout_widget_love">
-                   <property name="spacing">
+                <layout class="QHBoxLayout" name="layout_status_bar_internal">
+                 <property name="spacing">
+                  <number>3</number>
+                 </property>
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <widget class="QStackedWidget" name="status_bar_stack">
+                   <property name="currentIndex">
                     <number>1</number>
                    </property>
-                   <property name="leftMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>0</number>
-                   </property>
-                   <item>
-                    <widget class="Line" name="line_love">
-                     <property name="orientation">
-                      <enum>Qt::Orientation::Vertical</enum>
+                   <widget class="MultiLoadingIndicator" name="multi_loading_indicator"/>
+                   <widget class="QWidget" name="playlist_summary_page">
+                    <layout class="QVBoxLayout" name="layout_playlist_summary">
+                     <property name="spacing">
+                      <number>0</number>
                      </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QToolButton" name="button_love">
-                     <property name="accessibleName">
-                      <string>MenuPopupToolButton</string>
+                     <property name="leftMargin">
+                      <number>0</number>
                      </property>
-                     <property name="iconSize">
-                      <size>
-                       <width>32</width>
-                       <height>32</height>
-                      </size>
+                     <property name="topMargin">
+                      <number>0</number>
                      </property>
-                     <property name="autoRaise">
-                      <bool>true</bool>
+                     <property name="rightMargin">
+                      <number>0</number>
                      </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="Line" name="line_buttons">
-                  <property name="orientation">
-                   <enum>Qt::Orientation::Vertical</enum>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="AnalyzerContainer" name="analyzer" native="true">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                    <horstretch>100</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>0</width>
-                    <height>36</height>
-                   </size>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="horizontalSpacer">
-                  <property name="orientation">
-                   <enum>Qt::Orientation::Horizontal</enum>
-                  </property>
-                  <property name="sizeType">
-                   <enum>QSizePolicy::Policy::Expanding</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>0</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-                <item>
-                 <widget class="Line" name="line_volume">
-                  <property name="orientation">
-                   <enum>Qt::Orientation::Vertical</enum>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="VolumeSlider" name="volume">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="maximum">
-                   <number>100</number>
-                  </property>
-                  <property name="orientation">
-                   <enum>Qt::Orientation::Horizontal</enum>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QWidget" name="status_bar" native="true">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <layout class="QVBoxLayout" name="layout_status_bar">
-                <property name="spacing">
-                 <number>0</number>
-                </property>
-                <property name="leftMargin">
-                 <number>0</number>
-                </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <property name="rightMargin">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="Line" name="status_bar_line">
-                  <property name="orientation">
-                   <enum>Qt::Orientation::Horizontal</enum>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QWidget" name="status_bar_internal" native="true">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <layout class="QHBoxLayout" name="layout_status_bar_internal">
-                   <property name="spacing">
-                    <number>3</number>
-                   </property>
-                   <property name="leftMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>0</number>
-                   </property>
-                   <item>
-                    <widget class="QStackedWidget" name="status_bar_stack">
-                     <property name="currentIndex">
-                      <number>1</number>
+                     <property name="bottomMargin">
+                      <number>0</number>
                      </property>
-                     <widget class="MultiLoadingIndicator" name="multi_loading_indicator"/>
-                     <widget class="QWidget" name="playlist_summary_page">
-                      <layout class="QVBoxLayout" name="layout_playlist_summary">
-                       <property name="spacing">
-                        <number>0</number>
+                     <item>
+                      <widget class="QLabel" name="playlist_summary">
+                       <property name="alignment">
+                        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                        </property>
-                       <property name="leftMargin">
-                        <number>0</number>
-                       </property>
-                       <property name="topMargin">
-                        <number>0</number>
-                       </property>
-                       <property name="rightMargin">
-                        <number>0</number>
-                       </property>
-                       <property name="bottomMargin">
-                        <number>0</number>
-                       </property>
-                       <item>
-                        <widget class="QLabel" name="playlist_summary">
-                         <property name="alignment">
-                          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                         </property>
-                        </widget>
-                       </item>
-                      </layout>
-                     </widget>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="Line" name="line_5">
-                     <property name="orientation">
-                      <enum>Qt::Orientation::Vertical</enum>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="PlaylistSequence" name="playlist_sequence" native="true"/>
-                   </item>
-                   <item>
-                    <widget class="Line" name="line_2">
-                     <property name="orientation">
-                      <enum>Qt::Orientation::Vertical</enum>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QToolButton" name="button_scrobble">
-                     <property name="enabled">
-                      <bool>true</bool>
-                     </property>
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <property name="text">
-                      <string/>
-                     </property>
-                     <property name="iconSize">
-                      <size>
-                       <width>16</width>
-                       <height>16</height>
-                      </size>
-                     </property>
-                     <property name="autoRaise">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="TrackSlider" name="track_slider" native="true">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                       <horstretch>10</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="Line" name="line_5">
+                   <property name="orientation">
+                    <enum>Qt::Orientation::Vertical</enum>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="PlaylistSequence" name="playlist_sequence" native="true"/>
+                 </item>
+                 <item>
+                  <widget class="Line" name="line_2">
+                   <property name="orientation">
+                    <enum>Qt::Orientation::Vertical</enum>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QToolButton" name="button_scrobble">
+                   <property name="enabled">
+                    <bool>true</bool>
+                   </property>
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string/>
+                   </property>
+                   <property name="iconSize">
+                    <size>
+                     <width>16</width>
+                     <height>16</height>
+                    </size>
+                   </property>
+                   <property name="autoRaise">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="TrackSlider" name="track_slider" native="true">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                     <horstretch>10</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
+         </widget>
         </item>
        </layout>
       </widget>

--- a/src/core/mainwindow.ui
+++ b/src/core/mainwindow.ui
@@ -75,13 +75,6 @@
            <number>0</number>
           </property>
           <item>
-           <widget class="Line" name="line_6">
-            <property name="orientation">
-             <enum>Qt::Orientation::Vertical</enum>
-            </property>
-           </widget>
-          </item>
-          <item>
            <widget class="QWidget" name="player_controls_container" native="true">
             <layout class="QVBoxLayout" name="layout_player_controls_container">
              <property name="spacing">
@@ -463,7 +456,7 @@
      <x>0</x>
      <y>0</y>
      <width>1131</width>
-     <height>23</height>
+     <height>30</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_music">
@@ -508,7 +501,7 @@
    </widget>
    <widget class="QMenu" name="menu_help">
     <property name="title">
-     <string>Help</string>
+     <string>Hel&amp;p</string>
     </property>
     <addaction name="action_about_strawberry"/>
     <addaction name="action_about_qt"/>
@@ -539,7 +532,7 @@
   </widget>
   <action name="action_previous_track">
    <property name="text">
-    <string>Previous track</string>
+    <string>P&amp;revious track</string>
    </property>
    <property name="shortcut">
     <string>F5</string>
@@ -596,7 +589,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Love</string>
+    <string>&amp;Love</string>
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+L</string>
@@ -762,7 +755,7 @@
   </action>
   <action name="action_save_all_playlists">
    <property name="text">
-    <string>&amp;Save all playlists...</string>
+    <string>Sa&amp;ve all playlists...</string>
    </property>
   </action>
   <action name="action_next_playlist">
@@ -806,7 +799,7 @@
   </action>
   <action name="action_stop_collection_scan">
    <property name="text">
-    <string>Stop collection scan</string>
+    <string>Sto&amp;p collection scan</string>
    </property>
    <property name="toolTip">
     <string>Stop collection scan</string>
@@ -851,7 +844,7 @@
   </action>
   <action name="action_add_stream">
    <property name="text">
-    <string>Add stream...</string>
+    <string>Add str&amp;eam...</string>
    </property>
   </action>
   <action name="action_toggle_show_sidebar">
@@ -859,12 +852,12 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Show sidebar</string>
+    <string>Sho&amp;w sidebar</string>
    </property>
   </action>
   <action name="action_import_data_from_last_fm">
    <property name="text">
-    <string>Import data from last.fm...</string>
+    <string>&amp;Import data from last.fm...</string>
    </property>
   </action>
  </widget>

--- a/src/settings/appearancesettingspage.cpp
+++ b/src/settings/appearancesettingspage.cpp
@@ -52,6 +52,8 @@
 #include "settingsdialog.h"
 #include "ui_appearancesettingspage.h"
 
+#include <core/mainwindow.h>
+
 const char *AppearanceSettingsPage::kSettingsGroup = "Appearance";
 
 const char *AppearanceSettingsPage::kStyle = "style";
@@ -84,6 +86,8 @@ const char *AppearanceSettingsPage::kIconSizeConfigureButtons = "icon_size_confi
 
 const char *AppearanceSettingsPage::kPlaylistPlayingSongColor = "playlist_playing_song_color";
 
+const char *AppearanceSettingsPage::kPlayerControlsPosition = "player_controls_position";
+
 AppearanceSettingsPage::AppearanceSettingsPage(SettingsDialog *dialog, QWidget *parent)
     : SettingsPage(dialog, parent),
       ui_(new Ui_AppearanceSettingsPage),
@@ -103,6 +107,9 @@ AppearanceSettingsPage::AppearanceSettingsPage(SettingsDialog *dialog, QWidget *
   ui_->combobox_backgroundimageposition->setItemData(2, static_cast<int>(BackgroundImagePosition::Middle));
   ui_->combobox_backgroundimageposition->setItemData(3, static_cast<int>(BackgroundImagePosition::BottomLeft));
   ui_->combobox_backgroundimageposition->setItemData(4, static_cast<int>(BackgroundImagePosition::BottomRight));
+
+  ui_->comboBox_player_controls_position->setItemData(0, static_cast<int>(MainWindow::PlayerControlsPosition::Bottom));
+  ui_->comboBox_player_controls_position->setItemData(1, static_cast<int>(MainWindow::PlayerControlsPosition::Top));
 
   QObject::connect(ui_->blur_slider, &QSlider::valueChanged, this, &AppearanceSettingsPage::BlurLevelChanged);
   QObject::connect(ui_->opacity_slider, &QSlider::valueChanged, this, &AppearanceSettingsPage::OpacityLevelChanged);
@@ -215,6 +222,8 @@ void AppearanceSettingsPage::Load() {
   UpdateColorSelectorColor(ui_->select_playlist_playing_song_color, current_playlist_playing_song_color_);
   PlaylistPlayingSongColorSystem(ui_->playlist_playing_song_color_system->isChecked());
 
+  ui_->comboBox_player_controls_position->setCurrentIndex(ui_->comboBox_player_controls_position->findData(s.value(kPlayerControlsPosition, static_cast<int>(MainWindow::PlayerControlsPosition::Bottom)).toInt()));
+
   s.endGroup();
 
   Init(ui_->layout_appearancesettingspage->parentWidget());
@@ -287,6 +296,8 @@ void AppearanceSettingsPage::Save() {
   else {
     s.setValue(kPlaylistPlayingSongColor, current_playlist_playing_song_color_);
   }
+
+  s.setValue(kPlayerControlsPosition, ui_->comboBox_player_controls_position->currentData().toInt());
 
   s.endGroup();
 

--- a/src/settings/appearancesettingspage.h
+++ b/src/settings/appearancesettingspage.h
@@ -75,6 +75,8 @@ class AppearanceSettingsPage : public SettingsPage {
 
   static const char *kPlaylistPlayingSongColor;
 
+  static const char *kPlayerControlsPosition;
+
   enum class BackgroundImageType {
     Default,
     None,

--- a/src/settings/appearancesettingspage.ui
+++ b/src/settings/appearancesettingspage.ui
@@ -144,14 +144,14 @@
          <string>The album cover of the currently playing song</string>
         </property>
         <property name="text">
-         <string>Albu&amp;m cover</string>
+         <string>A&amp;lbum cover</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QRadioButton" name="use_strawbs_background">
         <property name="text">
-         <string notr="true">A Taste of Strawbs</string>
+         <string notr="true">A &amp;Taste of Strawbs</string>
         </property>
        </widget>
       </item>
@@ -160,7 +160,7 @@
         <item>
          <widget class="QRadioButton" name="use_custom_background_image">
           <property name="text">
-           <string>Custom image:</string>
+           <string>&amp;Custom image:</string>
           </property>
          </widget>
         </item>
@@ -553,7 +553,7 @@
       <item>
        <widget class="QRadioButton" name="playlist_playing_song_color_system">
         <property name="text">
-         <string>System highlight color</string>
+         <string>System hi&amp;ghlight color</string>
         </property>
        </widget>
       </item>
@@ -579,6 +579,53 @@
            <string/>
           </property>
          </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_player_controls">
+     <property name="title">
+      <string>Player controls</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Position</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="comboBox_player_controls_position">
+          <item>
+           <property name="text">
+            <string>Bottom</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Top</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Orientation::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
         </item>
        </layout>
       </item>

--- a/src/settings/appearancesettingspage.ui
+++ b/src/settings/appearancesettingspage.ui
@@ -144,14 +144,14 @@
          <string>The album cover of the currently playing song</string>
         </property>
         <property name="text">
-         <string>A&amp;lbum cover</string>
+         <string>Albu&amp;m cover</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QRadioButton" name="use_strawbs_background">
         <property name="text">
-         <string notr="true">A &amp;Taste of Strawbs</string>
+         <string notr="true">A Taste of Strawbs</string>
         </property>
        </widget>
       </item>
@@ -160,7 +160,7 @@
         <item>
          <widget class="QRadioButton" name="use_custom_background_image">
           <property name="text">
-           <string>&amp;Custom image:</string>
+           <string>Custom image:</string>
           </property>
          </widget>
         </item>
@@ -553,7 +553,7 @@
       <item>
        <widget class="QRadioButton" name="playlist_playing_song_color_system">
         <property name="text">
-         <string>System hi&amp;ghlight color</string>
+         <string>System highlight color</string>
         </property>
        </widget>
       </item>

--- a/src/translations/translations.pot
+++ b/src/translations/translations.pot
@@ -3696,6 +3696,15 @@ msgstr ""
 msgid "Select playlist playing song color:"
 msgstr ""
 
+msgid "Player controls"
+msgstr ""
+
+msgid "Bottom"
+msgstr ""
+
+msgid "Top"
+msgstr ""
+
 msgid "Notifications"
 msgstr ""
 


### PR DESCRIPTION
Hello again,

I would like to have a position switch for the player controls (including the status information with the slider). I am sure this might lead to some discussion because of bigger ui changes.

I placed the setting for it inside the appearance settings dialog and also removed the vertical (for me not needed) line at the left side of the player controls.

You can toggle the position of the player controls widget between top and bottom.

INFO: I will squash the commits before final approvement. Till then I wanted to keep my commit structure alive for any further changes.

Thanks for your time. :-)

Greetings