### PR TITLE
Subsonic: Add support to retrieve album covers using album id

### DIFF
--- a/src/constants/subsonicsettings.h
+++ b/src/constants/subsonicsettings.h
@@ -37,6 +37,7 @@ constexpr char kPassword[] = "password";
 constexpr char kHTTP2[] = "http2";
 constexpr char kVerifyCertificate[] = "verifycertificate";
 constexpr char kDownloadAlbumCovers[] = "downloadalbumcovers";
+constexpr char kUseAlbumIdForAlbumCovers[] = "usealbumidforalbumcovers";
 constexpr char kServerSideScrobbling[] = "serversidescrobbling";
 constexpr char kAuthMethod[] = "authmethod";
 

--- a/src/settings/subsonicsettingspage.cpp
+++ b/src/settings/subsonicsettingspage.cpp
@@ -51,6 +51,7 @@ SubsonicSettingsPage::SubsonicSettingsPage(SettingsDialog *dialog, const SharedP
 
   QObject::connect(ui_->button_test, &QPushButton::clicked, this, &SubsonicSettingsPage::TestClicked);
   QObject::connect(ui_->button_deletesongs, &QPushButton::clicked, &*service_, &SubsonicService::DeleteSongs);
+  QObject::connect(ui_->checkbox_download_album_covers, &QCheckBox::toggled, this, &SubsonicSettingsPage::CheckboxDownloadAlbumCoversToggled);
 
   QObject::connect(this, &SubsonicSettingsPage::Test, &*service_, &SubsonicService::SendPingWithCredentials);
 
@@ -78,6 +79,7 @@ void SubsonicSettingsPage::Load() {
   ui_->checkbox_http2->setChecked(s.value(kHTTP2, false).toBool());
   ui_->checkbox_verify_certificate->setChecked(s.value(kVerifyCertificate, false).toBool());
   ui_->checkbox_download_album_covers->setChecked(s.value(kDownloadAlbumCovers, true).toBool());
+  ui_->checkbox_use_album_id_for_album_covers->setChecked(s.value(kUseAlbumIdForAlbumCovers, false).toBool());
   ui_->checkbox_server_scrobbling->setChecked(s.value(kServerSideScrobbling, false).toBool());
 
   const AuthMethod auth_method = static_cast<AuthMethod>(s.value(kAuthMethod, static_cast<int>(AuthMethod::MD5)).toInt());
@@ -89,6 +91,8 @@ void SubsonicSettingsPage::Load() {
       ui_->auth_method_md5->setChecked(true);
       break;
   }
+
+  ui_->checkbox_use_album_id_for_album_covers->setEnabled(ui_->checkbox_download_album_covers->isChecked());
 
   s.endGroup();
 
@@ -109,6 +113,7 @@ void SubsonicSettingsPage::Save() {
   s.setValue(kHTTP2, ui_->checkbox_http2->isChecked());
   s.setValue(kVerifyCertificate, ui_->checkbox_verify_certificate->isChecked());
   s.setValue(kDownloadAlbumCovers, ui_->checkbox_download_album_covers->isChecked());
+  s.setValue(kUseAlbumIdForAlbumCovers, ui_->checkbox_use_album_id_for_album_covers->isChecked());
   s.setValue(kServerSideScrobbling, ui_->checkbox_server_scrobbling->isChecked());
   if (ui_->auth_method_hex->isChecked()) {
     s.setValue(kAuthMethod, static_cast<int>(AuthMethod::Hex));
@@ -116,7 +121,16 @@ void SubsonicSettingsPage::Save() {
   else {
     s.setValue(kAuthMethod, static_cast<int>(AuthMethod::MD5));
   }
+  
+  ui_->checkbox_use_album_id_for_album_covers->setEnabled(ui_->checkbox_download_album_covers->isChecked());
+
   s.endGroup();
+
+}
+
+void SubsonicSettingsPage::CheckboxDownloadAlbumCoversToggled(bool enabled) {
+
+  ui_->checkbox_use_album_id_for_album_covers->setEnabled(enabled);
 
 }
 

--- a/src/settings/subsonicsettingspage.h
+++ b/src/settings/subsonicsettingspage.h
@@ -51,6 +51,7 @@ class SubsonicSettingsPage : public SettingsPage {
   void Test(const QUrl &url, const QString &username, const QString &password, const SubsonicSettings::AuthMethod auth_method, const bool redirect = false);
 
  private Q_SLOTS:
+  void CheckboxDownloadAlbumCoversToggled(bool enabled);
   void TestClicked();
   void TestSuccess();
   void TestFailure(const QString &failure_reason);

--- a/src/settings/subsonicsettingspage.ui
+++ b/src/settings/subsonicsettingspage.ui
@@ -172,6 +172,13 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="checkbox_use_album_id_for_album_covers">
+        <property name="text">
+         <string>Use album ID for album covers</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="checkbox_server_scrobbling">
         <property name="text">
          <string>Server-side scrobbling</string>

--- a/src/subsonic/subsonicbaserequest.h
+++ b/src/subsonic/subsonicbaserequest.h
@@ -69,6 +69,7 @@ class SubsonicBaseRequest : public QObject {
   bool http2() const { return service_->http2(); }
   bool verify_certificate() const { return service_->verify_certificate(); }
   bool download_album_covers() const { return service_->download_album_covers(); }
+  bool use_album_id_for_album_covers() const { return service_->use_album_id_for_album_covers(); }
 
  private Q_SLOTS:
   void HandleSSLErrors(const QList<QSslError> &ssl_errors);

--- a/src/subsonic/subsonicrequest.cpp
+++ b/src/subsonic/subsonicrequest.cpp
@@ -606,12 +606,20 @@ QString SubsonicRequest::ParseSong(Song &song, const QJsonObject &json_obj, cons
   if (json_obj.contains("genre"_L1)) genre = json_obj["genre"_L1].toString();
 
   QString cover_id;
-  if (json_obj.contains("coverArt"_L1)) {
-    if (json_obj["coverArt"_L1].type() == QJsonValue::String) {
-      cover_id = json_obj["coverArt"_L1].toString();
+  if (use_album_id_for_album_covers()) {
+    cover_id = album_id;
+  }
+  else {
+    if (json_obj.contains("coverArt"_L1)) {
+      if (json_obj["coverArt"_L1].type() == QJsonValue::String) {
+        cover_id = json_obj["coverArt"_L1].toString();
+      }
+      else {
+        cover_id = QString::number(json_obj["coverArt"_L1].toInt());
+      }
     }
     else {
-      cover_id = QString::number(json_obj["coverArt"_L1].toInt());
+      cover_id = song_id;
     }
   }
 

--- a/src/subsonic/subsonicrequest.h
+++ b/src/subsonic/subsonicrequest.h
@@ -122,6 +122,7 @@ class SubsonicRequest : public SubsonicBaseRequest {
 
   QHash<QString, Request> album_songs_requests_pending_;
   QMultiMap<QString, QString> album_covers_requests_sent_;
+  QMultiMap<QString, QUrl> album_covers_retrieved_;
 
   int albums_requests_active_;
 

--- a/src/subsonic/subsonicservice.cpp
+++ b/src/subsonic/subsonicservice.cpp
@@ -82,6 +82,7 @@ SubsonicService::SubsonicService(const SharedPtr<TaskManager> task_manager,
       http2_(false),
       verify_certificate_(false),
       download_album_covers_(true),
+      use_album_id_for_album_covers_(false),
       auth_method_(SubsonicSettings::AuthMethod::MD5),
       ping_redirects_(0) {
 
@@ -128,6 +129,7 @@ void SubsonicService::ReloadSettings() {
   http2_ = s.value(SubsonicSettings::kHTTP2, false).toBool();
   verify_certificate_ = s.value(SubsonicSettings::kVerifyCertificate, false).toBool();
   download_album_covers_ = s.value(SubsonicSettings::kDownloadAlbumCovers, true).toBool();
+  use_album_id_for_album_covers_ = s.value(SubsonicSettings::kUseAlbumIdForAlbumCovers, false).toBool();
   auth_method_ = static_cast<SubsonicSettings::AuthMethod>(s.value(SubsonicSettings::kAuthMethod, static_cast<int>(SubsonicSettings::AuthMethod::MD5)).toInt());
 
   s.endGroup();

--- a/src/subsonic/subsonicservice.h
+++ b/src/subsonic/subsonicservice.h
@@ -80,6 +80,7 @@ class SubsonicService : public StreamingService {
   bool http2() const { return http2_; }
   bool verify_certificate() const { return verify_certificate_; }
   bool download_album_covers() const { return download_album_covers_; }
+  bool use_album_id_for_album_covers() const { return use_album_id_for_album_covers_; }
   SubsonicSettings::AuthMethod auth_method() const { return auth_method_; }
 
   SharedPtr<CollectionBackend> collection_backend() const { return collection_backend_; }
@@ -123,6 +124,7 @@ class SubsonicService : public StreamingService {
   bool http2_;
   bool verify_certificate_;
   bool download_album_covers_;
+  bool use_album_id_for_album_covers_;
   SubsonicSettings::AuthMethod auth_method_;
 
   QStringList errors_;

--- a/src/translations/strawberry_ca_ES.ts
+++ b/src/translations/strawberry_ca_ES.ts
@@ -6634,6 +6634,10 @@ Esteu segur que voleu continuar?</translation>
       <translation type="unfinished">Download album covers</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>Utilitza l'ID de l'àlbum per a les portades dels àlbums</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation type="unfinished">Server-side scrobbling</translation>
     </message>

--- a/src/translations/strawberry_cs_CZ.ts
+++ b/src/translations/strawberry_cs_CZ.ts
@@ -6644,6 +6644,10 @@ Opravdu chcete pokračovat?</translation>
       <translation>Stahovat obaly alb</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>Použijte ID alba pro obaly alb</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation type="unfinished">Server-side scrobbling</translation>
     </message>

--- a/src/translations/strawberry_de_DE.ts
+++ b/src/translations/strawberry_de_DE.ts
@@ -6634,6 +6634,10 @@ Möchten Sie wirklich fortfahren?</translation>
       <translation>Titelbilder herunterladen</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>Verwenden Sie die Album-ID für Albumcover</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation>Serverseitiges Scrobbling</translation>
     </message>

--- a/src/translations/strawberry_en_US.ts
+++ b/src/translations/strawberry_en_US.ts
@@ -6630,6 +6630,10 @@ Are you sure you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Use album ID for album covers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Server-side scrobbling</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/translations/strawberry_es_AR.ts
+++ b/src/translations/strawberry_es_AR.ts
@@ -6633,6 +6633,10 @@ Are you sure you want to continue?</source>
       <translation>Descargar las cubiertas de los álbumes</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>Usá el ID del álbum para las cubiertas de los álbumes</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation>Seguimiento de reproducción en el servidor</translation>
     </message>

--- a/src/translations/strawberry_es_ES.ts
+++ b/src/translations/strawberry_es_ES.ts
@@ -6633,6 +6633,10 @@ Are you sure you want to continue?</source>
       <translation>Descargar las portadas de los álbumes</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>Usá el ID del álbum para las portadas de los álbumes</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation>Seguimiento de reproducción en el servidor</translation>
     </message>

--- a/src/translations/strawberry_es_MX.ts
+++ b/src/translations/strawberry_es_MX.ts
@@ -6633,6 +6633,10 @@ Are you sure you want to continue?</source>
       <translation>Descargar las portadas de los álbumes</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>Usá el ID del álbum para las portadas de los álbumes</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation>Seguimiento de reproducción en el servidor</translation>
     </message>

--- a/src/translations/strawberry_et_EE.ts
+++ b/src/translations/strawberry_et_EE.ts
@@ -6634,6 +6634,10 @@ Kas soovid jätkata?</translation>
       <translation>Laadi alla albumi kaanepilte</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>Kasuta albumi ID-d albumi kaante jaoks</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation>Serveripoolne kraasimine</translation>
     </message>

--- a/src/translations/strawberry_fi_FI.ts
+++ b/src/translations/strawberry_fi_FI.ts
@@ -6634,6 +6634,10 @@ Haluatko varmasti jatkaa?</translation>
       <translation>Lataa albumien kansikuvat</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>Käytä albumin tunnusta albumin kansille</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation type="unfinished">Server-side scrobbling</translation>
     </message>

--- a/src/translations/strawberry_fr_FR.ts
+++ b/src/translations/strawberry_fr_FR.ts
@@ -6634,6 +6634,10 @@ Are you sure you want to continue?</source>
       <translation>Télécharger des pochettes d&apos;albums</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>Utilisez l'ID de l'album pour les couvertures d'album</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation>Scrobbling côté serveur</translation>
     </message>

--- a/src/translations/strawberry_hu_HU.ts
+++ b/src/translations/strawberry_hu_HU.ts
@@ -6635,6 +6635,10 @@ másodpercnél hosszabbak, illetve legalább a felükig vagy 4 percig vannak lej
       <translation>Albumborítók letöltése</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>Használja az album azonosítóját az album borítókhoz</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation>Kiszolgálóoldali scrobble funkció</translation>
     </message>

--- a/src/translations/strawberry_id_ID.ts
+++ b/src/translations/strawberry_id_ID.ts
@@ -6629,6 +6629,10 @@ Apakah Anda yakin ingin melanjutkan?</translation>
       <translation>Unduh sampul album</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>Gunakan ID album untuk sampul album</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation type="unfinished">Server-side scrobbling</translation>
     </message>

--- a/src/translations/strawberry_is_IS.ts
+++ b/src/translations/strawberry_is_IS.ts
@@ -6634,6 +6634,10 @@ Ertu viss um að þú viljir halda áfram?</translation>
       <translation>Sækja plötuumslög</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>Notaðu albumi ID fyrir album fyrirsagnir.</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation>Skráning á hlustunarvenjum (scrobbling) á netþjóni</translation>
     </message>

--- a/src/translations/strawberry_it_IT.ts
+++ b/src/translations/strawberry_it_IT.ts
@@ -6646,6 +6646,10 @@ Per ulteriori informazioni vedi &apos;%1&apos; .</translation>
       <translation>Scarica copertine album</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>Usa l'ID dell'album per le copertine degli album</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation>Scrobbling lato server</translation>
     </message>

--- a/src/translations/strawberry_ja_JP.ts
+++ b/src/translations/strawberry_ja_JP.ts
@@ -6629,6 +6629,10 @@ Are you sure you want to continue?</source>
       <translation>アルバムカバーをダウンロード</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>アルバムのIDをアルバムカバーに使用する</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation>サーバーサイドの scrobbling</translation>
     </message>

--- a/src/translations/strawberry_ko_KR.ts
+++ b/src/translations/strawberry_ko_KR.ts
@@ -6629,6 +6629,10 @@ Are you sure you want to continue?</source>
       <translation>앨범아트 다운로드 중</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>앨범 ID를 앨범 커버에 사용하세요</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation>서버 사이드 스크로블링</translation>
     </message>

--- a/src/translations/strawberry_nb_NO.ts
+++ b/src/translations/strawberry_nb_NO.ts
@@ -6634,6 +6634,10 @@ Er du sikker?</translation>
       <translation>Last ned plateomslag</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>Bruk album-ID for albumomslag</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation>Server-siding skrobbling</translation>
     </message>

--- a/src/translations/strawberry_nl_NL.ts
+++ b/src/translations/strawberry_nl_NL.ts
@@ -6634,6 +6634,10 @@ Weet je zeker dat je verder wilt gaan?</translation>
       <translation>Albumhoezen downloaden</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>Gebruik album-ID voor albumhoezen</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation type="unfinished">Server-side scrobbling</translation>
     </message>

--- a/src/translations/strawberry_pl_PL.ts
+++ b/src/translations/strawberry_pl_PL.ts
@@ -6646,6 +6646,10 @@ Na pewno chcesz usunąć?</translation>
       <translation>Pobieraj okładki albumów</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>Użyj identyfikatora albumu do okładek albumów</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation>Scrobblowanie po stronie serwera.</translation>
     </message>

--- a/src/translations/strawberry_pt_BR.ts
+++ b/src/translations/strawberry_pt_BR.ts
@@ -6634,6 +6634,10 @@ Deseja continuar?</translation>
       <translation type="unfinished">Download album covers</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>Usar o ID do álbum para as capas dos álbuns</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation type="unfinished">Server-side scrobbling</translation>
     </message>

--- a/src/translations/strawberry_ru_RU.ts
+++ b/src/translations/strawberry_ru_RU.ts
@@ -6644,6 +6644,10 @@ Are you sure you want to continue?</source>
       <translation>Скачивать обложки альбомов</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>Используйте ID альбома для обложек альбомов</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation>Скробблинг на стороне сервера</translation>
     </message>

--- a/src/translations/strawberry_sv_SE.ts
+++ b/src/translations/strawberry_sv_SE.ts
@@ -6634,6 +6634,10 @@ Are you sure you want to continue?</source>
       <translation>Hämta albumomslag</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>Använd album-ID för albumomslag</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation>Skrobbling på serversidan</translation>
     </message>

--- a/src/translations/strawberry_tr_CY.ts
+++ b/src/translations/strawberry_tr_CY.ts
@@ -6634,6 +6634,10 @@ Are you sure you want to continue?</translation>
       <translation type="unfinished">Download album covers</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>Albüm kapakları için albüm ID'sini kullanın</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation type="unfinished">Server-side scrobbling</translation>
     </message>

--- a/src/translations/strawberry_tr_TR.ts
+++ b/src/translations/strawberry_tr_TR.ts
@@ -6634,6 +6634,10 @@ Devam etmek istediğinizden emin misiniz?</translation>
       <translation type="unfinished">Download album covers</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>Albüm kapakları için albüm ID'sini kullanın</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation type="unfinished">Server-side scrobbling</translation>
     </message>

--- a/src/translations/strawberry_uk_UA.ts
+++ b/src/translations/strawberry_uk_UA.ts
@@ -6644,6 +6644,10 @@ Are you sure you want to continue?</source>
       <translation>Завантажити обкладинки альбомів</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>Використовуйте ID альбому для обкладинок альбомів</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation>Скроблінг на боці сервера</translation>
     </message>

--- a/src/translations/strawberry_zh_CN.ts
+++ b/src/translations/strawberry_zh_CN.ts
@@ -6629,6 +6629,10 @@ Are you sure you want to continue?</source>
       <translation>下载专辑封面</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>使用专辑ID来获取专辑封面</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation type="unfinished">Server-side scrobbling</translation>
     </message>

--- a/src/translations/strawberry_zh_TW.ts
+++ b/src/translations/strawberry_zh_TW.ts
@@ -6629,6 +6629,10 @@ Are you sure you want to continue?</translation>
       <translation type="unfinished">Download album covers</translation>
     </message>
     <message>
+      <source>Use album ID for album covers</source>
+      <translation>使用專輯ID來獲取專輯封面</translation>
+    </message>
+    <message>
       <source>Server-side scrobbling</source>
       <translation type="unfinished">Server-side scrobbling</translation>
     </message>


### PR DESCRIPTION
I started using strawberry client exclusively for the subsonic support.

Im always updating my library, and this became a problem because it always retrieves all the covers based on the "coverArt" value, which is always different due to each of my songs having embedded covers, so if I have 2000 songs it fetches the 2000 covers. I think a lot of people struggle with that. 

Since the subsonic API supports retrieving the cover art by the album id, I've just added support for that.

![image](https://github.com/user-attachments/assets/351a90e6-5b47-4929-ac50-d3e31abbfc81)

This is optional and it can be enabled or disabled in subsonic settings page.

![image](https://github.com/user-attachments/assets/6ebe8e98-5007-445e-b000-cc9632955106)

With "Use album id for album covers" option enabled:

![image](https://github.com/user-attachments/assets/69bf185e-1b0b-4b29-8b5c-0a6d8a6ba223)

With "Use album id for album covers" option disabled:

![image](https://github.com/user-attachments/assets/b29e9187-79e8-47bc-8ede-70f3927a94e4)
