### PR TITLE
TranscodeDialog: update dialog to optionally preserve directory structure during import

### DIFF
--- a/src/transcoder/transcodedialog.h
+++ b/src/transcoder/transcodedialog.h
@@ -49,6 +49,7 @@ class TranscodeDialog : public QDialog {
   ~TranscodeDialog() override;
 
   void SetFilenames(const QStringList &filenames);
+  void SetImportFilenames(const QStringList &filenames, const QString &path);
 
  protected:
   void showEvent(QShowEvent *e) override;
@@ -62,7 +63,8 @@ class TranscodeDialog : public QDialog {
   void UpdateStatusText();
   void UpdateProgress();
   static QString TrimPath(const QString &path);
-  QString GetOutputFileName(const QString &input, const TranscoderPreset &preset) const;
+  static void CreatePathIfNotExists(const QString &path);
+  QString GetOutputFileName(const QString &input, const QString &input_import_dir, const TranscoderPreset &preset) const;
 
  private Q_SLOTS:
   void Add();

--- a/src/transcoder/transcodedialog.ui
+++ b/src/transcoder/transcodedialog.ui
@@ -57,6 +57,11 @@
           <string>Directory</string>
          </property>
         </column>
+        <column>
+         <property name="text">
+          <string>Import Directory</string>
+         </property>
+        </column>
        </widget>
       </item>
       <item>
@@ -162,6 +167,13 @@
        <widget class="QPushButton" name="select">
         <property name="text">
          <string>Select...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="3">
+       <widget class="QCheckBox" name="preserve_dir_structure">
+        <property name="text">
+         <string>Preserve directory structure in output directory (import only)</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Introduces ability to preserve the directory structure when transcoding files when imported. 

Given the following directory structure: 

```
>Music
  > Blind Pilot
    > 3 Round and a Sound
      > track_1.flac
    > We Are The Tide
      > track_2.flac
  > Johann Johannson
    > Fordlandia
      > track_3.flac
```

During a normal import and transcode, all three tracks would be output to the same output directory, like so:

```
>Output
  > track_1.mp3
  > track_2.mp3
  > track_3.mp3
```

With the new functionality, the user can specify to keep the original structure from before transcoding. For example, if the user imported the directories `Blind Pilot` and `Johann Johannson` the output would look like this:

```
>Output
  > Blind Pilot
    > 3 Round and a Sound
      > track_1.mp3
    > We Are The Tide
      > track_2.mp3
  > Johann Johannson
    > Fordlandia
      > track_3.mp3
```