### PR TITLE
Support arbitrarily large EBU R 128 loudness normalization

### DIFF
--- a/src/engine/ebur128analysis.cpp
+++ b/src/engine/ebur128analysis.cpp
@@ -32,6 +32,7 @@
 #include <gst/gst.h>
 #include <gst/audio/audio-channels.h>
 #include <gst/app/gstappsink.h>
+#include <gst/pbutils/pbutils.h>
 #include <ebur128.h>
 
 #include <QCoreApplication>
@@ -88,6 +89,13 @@ channel gst_channel_to_ebur_channel(GstAudioChannelPosition pos) {
       return EBUR128_LEFT_SURROUND;
     case GST_AUDIO_CHANNEL_POSITION_SURROUND_RIGHT:
       return EBUR128_RIGHT_SURROUND;
+
+#if (GST_PLUGINS_BASE_VERSION_MAJOR > 1 || (GST_PLUGINS_BASE_VERSION_MAJOR == 1 && GST_PLUGINS_BASE_VERSION_MINOR >= 26))
+    case GST_AUDIO_CHANNEL_POSITION_TOP_SURROUND_LEFT:
+      return EBUR128_LEFT_SURROUND;
+    case GST_AUDIO_CHANNEL_POSITION_TOP_SURROUND_RIGHT:
+      return EBUR128_RIGHT_SURROUND;
+#endif
 
     case GST_AUDIO_CHANNEL_POSITION_BOTTOM_FRONT_CENTER:
       return EBUR128_Bp000;

--- a/src/engine/gstenginepipeline.h
+++ b/src/engine/gstenginepipeline.h
@@ -261,6 +261,7 @@ class GstEnginePipeline : public QObject {
 
   // EBU R 128 Loudness Normalization
   bool ebur128_loudness_normalization_;
+  bool gstreamer_supports_volume_full_range_;
 
   // Spotify
 #ifdef HAVE_SPOTIFY


### PR DESCRIPTION
While i have fixed gstreamer's `volume` in
https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/5063 i did not see anything that followed after it was merged, namely, in https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/6222, the feature was moved, `"volume"` was reverted to only handle `x10` gain, and one needs to use `"volume-full-range"` instead to do arbitrary gain. So let's do that.

This, of course, requires run-time detection of the version of gstreamer base plugins that we are running with, specifically, we need version `1.24`.