### PR TITLE
AlsaDeviceFinder: Use card id instead of card index

### DIFF
--- a/src/engine/alsadevicefinder.cpp
+++ b/src/engine/alsadevicefinder.cpp
@@ -98,9 +98,9 @@ EngineDeviceList AlsaDeviceFinder::ListDevices() {
       device.card = card;
       device.device = dev;
 
-      device.value = QStringLiteral("hw:%1,%2").arg(card).arg(dev);
+      device.value = QStringLiteral("hw:%1,%2").arg(QString::fromUtf8(snd_ctl_card_info_get_id(cardinfo))).arg(dev);
       devices.append(device);
-      device.value = QStringLiteral("plughw:%1,%2").arg(card).arg(dev);
+      device.value = QStringLiteral("plughw:%1,%2").arg(QString::fromUtf8(snd_ctl_card_info_get_id(cardinfo))).arg(dev);
       devices.append(device);
 
     }


### PR DESCRIPTION
Like the card index, the card id is guaranteed to be unique. While the card index can easily change between reboots, the card id is based on the actual audio hardware and does not change between reboots; or even hardware changes. This makes using the card id preferable, because it will "just work" 99% of the time, and removes the need to force cards to have a specific index like in #351.

There is a corner case where card ids may change between reboots: If you have two (or more) of the same audio hardware in the system. But that should be rare enough, and requires explicit system configuration anyway, so using the "custom" option should work here.

If there is an previously-saved index-based ALSA device in the config, it will continue to work as-is and does not need to be migrated. There is only a small UI side-effect: Because the index-based device will no longer match any found id-based device, the settings window will show it as "custom". Simply selecting the ALSA device from the drop-down again will change it to the id-based device.

[This blog post](http://james.ahlstrom.name/alsa_names.html) has a nice summary of "index vs id", and while a bit aged it is still fairly accurate.