### PR TITLE
Use the coverArt field from song JSON if available

### DIFF
--- a/src/subsonic/subsonicrequest.h
+++ b/src/subsonic/subsonicrequest.h
@@ -98,7 +98,7 @@ class SubsonicRequest : public SubsonicBaseRequest {
   void AddAlbumSongsRequest(const QString &artist_id, const QString &album_id, const QString &album_artist, const int offset = 0);
   void FlushAlbumSongsRequests();
 
-  QString ParseSong(Song &song, const QJsonObject &json_object, const QString &artist_id_requested = QString(), const QString &album_id_requested = QString(), const QString &album_artist = QString(), const qint64 album_created = 0);
+  QString ParseSong(Song &song, const QJsonObject &json_object, const QString &artist_id_requested = QString(), const QString &album_id_requested = QString(), const QString &album_artist = QString(), const QString &album_cover_id = QString(), const qint64 album_created = 0);
 
   void GetAlbumCovers();
   void AddAlbumCoverRequest(const Song &song);


### PR DESCRIPTION
This PR make sure that the coverArt JSON field in the subsonic song API takes precedence over the album or song ID.
As I understand it, if a song has a coverArt field then that one is the one to be used. As a fallback solution strawberry uses the song id. However if the setting "Use Album ID for album covers" is set, then the coverArt is ignored.

I have tried with the lms (https://github.com/epoupon/lms/tree/master) server and causes many errors since the album id is not mapped to the cover id (i.e., the only option for the getCoverArt method is to give the cover id).

My interpretation is that the "Use Album ID for album covers" uses album id as a fallback solution when the coverArt is not found in the song. If false, then the song id will be used as a fallback solution. That's the logic that this PR implements.

Thanks!