### PR TITLE
Linux: enable startup notify

### DIFF
--- a/dist/unix/org.strawberrymusicplayer.strawberry.desktop
+++ b/dist/unix/org.strawberrymusicplayer.strawberry.desktop
@@ -14,7 +14,6 @@ Icon=strawberry
 Terminal=false
 Categories=AudioVideo;Player;Qt;Audio;
 Keywords=Audio;Player;Clementine;
-StartupNotify=false
 MimeType=x-content/audio-player;application/ogg;application/x-ogg;application/x-ogm-audio;audio/flac;audio/ogg;audio/vorbis;audio/aac;audio/mp4;audio/mpeg;audio/mpegurl;audio/vnd.rn-realaudio;audio/x-flac;audio/x-oggflac;audio/x-vorbis;audio/x-vorbis+ogg;audio/x-speex;audio/x-wav;audio/x-wavpack;audio/x-ape;audio/x-mp3;audio/x-mpeg;audio/x-mpegurl;audio/x-ms-wma;audio/x-musepack;audio/x-pn-realaudio;audio/x-scpls;video/x-ms-asf;x-scheme-handler/tidal;
 StartupWMClass=strawberry
 Actions=Play-Pause;Stop;StopAfterCurrent;Previous;Next;


### PR DESCRIPTION
It was very odd for me why Strawberry doesn't have any feedback when launching from application menu. Turns out its desktop file had "StartupNotify=false" for some reason?