### PR TITLE
Allow transcoding to ALAC for iPods

### DIFF
--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -1209,6 +1209,7 @@ QString Song::TextForFiletype(const FileType filetype) {
     case FileType::CDDA:        return u"CDDA"_s;
     case FileType::SPC:         return u"SNES SPC700"_s;
     case FileType::VGM:         return u"VGM"_s;
+    case FileType::ALAC:        return u"ALAC"_s;
     case FileType::Stream:      return u"Stream"_s;
     case FileType::Unknown:
     default:                    return QObject::tr("Unknown");
@@ -1241,6 +1242,7 @@ QString Song::ExtensionForFiletype(const FileType filetype) {
     case FileType::IT:          return u"it"_s;
     case FileType::SPC:         return u"spc"_s;
     case FileType::VGM:         return u"vgm"_s;
+    case FileType::ALAC:        return u"m4a"_s;
     case FileType::Unknown:
     default:                    return u"dat"_s;
   }
@@ -1273,6 +1275,7 @@ QIcon Song::IconForFiletype(const FileType filetype) {
     case FileType::IT:          return IconLoader::Load(u"it"_s);
     case FileType::CDDA:        return IconLoader::Load(u"cd"_s);
     case FileType::Stream:      return IconLoader::Load(u"applications-internet"_s);
+    case FileType::ALAC:        return IconLoader::Load(u"alac"_s);
     case FileType::Unknown:
     default:                    return IconLoader::Load(u"edit-delete"_s);
   }
@@ -1293,6 +1296,7 @@ bool Song::IsFileLossless() const {
     case FileType::TrueAudio:
     case FileType::PCM:
     case FileType::CDDA:
+    case FileType::ALAC:
       return true;
     default:
       return false;
@@ -1322,6 +1326,7 @@ Song::FileType Song::FiletypeByMimetype(const QString &mimetype) {
   if (mimetype.compare("audio/x-s3m"_L1, Qt::CaseInsensitive) == 0) return FileType::S3M;
   if (mimetype.compare("audio/x-spc"_L1, Qt::CaseInsensitive) == 0) return FileType::SPC;
   if (mimetype.compare("audio/x-vgm"_L1, Qt::CaseInsensitive) == 0) return FileType::VGM;
+  if (mimetype.compare("audio/x-alac"_L1, Qt::CaseInsensitive) == 0) return FileType::ALAC;
 
   return FileType::Unknown;
 
@@ -1349,6 +1354,7 @@ Song::FileType Song::FiletypeByDescription(const QString &text) {
   if (text.compare("Module Music Format (MOD)"_L1, Qt::CaseInsensitive) == 0) return FileType::S3M;
   if (text.compare("SNES SPC700"_L1, Qt::CaseInsensitive) == 0) return FileType::SPC;
   if (text.compare("VGM"_L1, Qt::CaseInsensitive) == 0) return FileType::VGM;
+  if (text.compare("Apple Lossless Audio Codec (ALAC)"_L1, Qt::CaseInsensitive) == 0) return FileType::ALAC;
 
   return FileType::Unknown;
 

--- a/src/core/song.h
+++ b/src/core/song.h
@@ -105,6 +105,7 @@ class Song {
     IT = 21,
     SPC = 22,
     VGM = 23,
+    ALAC = 24, // MP4, with ALAC codec
     CDDA = 90,
     Stream = 91
   };

--- a/src/device/gpoddevice.cpp
+++ b/src/device/gpoddevice.cpp
@@ -409,5 +409,6 @@ bool GPodDevice::FinishDelete(bool success, QString &error_text) {
 bool GPodDevice::GetSupportedFiletypes(QList<Song::FileType> *ret) {
   *ret << Song::FileType::MP4;
   *ret << Song::FileType::MPEG;
+  *ret << Song::FileType::ALAC;
   return true;
 }

--- a/src/transcoder/transcoder.cpp
+++ b/src/transcoder/transcoder.cpp
@@ -225,6 +225,7 @@ QList<TranscoderPreset> Transcoder::GetAllPresets() {
   ret << PresetForFileType(Song::FileType::MPEG);
   ret << PresetForFileType(Song::FileType::MP4);
   ret << PresetForFileType(Song::FileType::ASF);
+  ret << PresetForFileType(Song::FileType::ALAC);
 
   return ret;
 
@@ -253,6 +254,8 @@ TranscoderPreset Transcoder::PresetForFileType(const Song::FileType filetype) {
       return TranscoderPreset(filetype, u"M4A AAC"_s,                u"mp4"_s,  u"audio/mpeg, mpegversion=(int)4"_s, u"audio/mp4"_s);
     case Song::FileType::ASF:
       return TranscoderPreset(filetype, u"Windows Media audio"_s,    u"wma"_s,  u"audio/x-wma"_s, u"video/x-ms-asf"_s);
+    case Song::FileType::ALAC:
+      return TranscoderPreset(filetype, u"ALAC"_s,                   u"m4a"_s,  u"audio/x-alac"_s, u"audio/mp4"_s);
     default:
       qLog(Warning) << "Unsupported format in PresetForFileType:" << static_cast<int>(filetype);
       return TranscoderPreset();


### PR DESCRIPTION
ALAC is the only suitable lossless codec for iPods; WAV and AIFF simply take up way too much space, usually around twice that of ALAC. rhythmbox has supported syncing ALAC to iPods for [a while now](https://mail.gnome.org/archives/commits-list/2016-October/msg08018.html), but \<opinion\>it is an abysmal music player\</opinion\>.

a quick test with my own iPod 5.5 gen shows this patch seems to work fine. It uses whatever gstreamer provides for `audio/x-alac` (most likely ffmpeg, I don't know of any others supporting encoding alac)