### PR TITLE
ExtendedEditor: padding for `TextEdit` & RTL `LineEdit`

### DIFF
--- a/src/widgets/lineedit.cpp
+++ b/src/widgets/lineedit.cpp
@@ -119,8 +119,17 @@ void ExtendedEditor::UpdateButtonGeometry() {
   const int frame_width = widget_->style()->pixelMetric(QStyle::PM_DefaultFrameWidth);
   const int left = frame_width + 1 + (has_clear_button() ? clear_button_->sizeHint().width() : 0);
   const int right = frame_width + 1 + (has_reset_button() ? reset_button_->sizeHint().width() : 0);
+  const char *const class_name = widget_->metaObject()->className();
 
-  widget_->setStyleSheet(QStringLiteral("QLineEdit { padding-left: %1px; padding-right: %2px; }").arg(left).arg(right));
+  if (strcmp(class_name, "LineEdit") == 0) {
+    // Seems Qt inverts left/right padding for QLineEdit if layout direction RTL
+    const bool rtl = QGuiApplication::isRightToLeft();
+    widget_->setStyleSheet(QStringLiteral("QLineEdit { padding-left: %1px; padding-right: %2px; }").arg(rtl ? right : left).arg(rtl ? left : right));
+  }
+  else if (strcmp(class_name, "TextEdit") == 0) {
+    // But not for QPlainTextEdit
+    widget_->setStyleSheet(QStringLiteral("QPlainTextEdit { padding-left: %1px; padding-right: %2px; }").arg(left).arg(right));
+  }
 
   QSize msz = widget_->minimumSizeHint();
   widget_->setMinimumSize(msz.width() + (clear_button_->sizeHint().width() + frame_width + 1) * 2 + extra_right_padding_, qMax(msz.height(), clear_button_->sizeHint().height() + frame_width * 2 + 2));


### PR DESCRIPTION
`ExtendedEditor::UpdateButtonGeometry()`: specify "QPlainTextEdit" for `TextEdit`   padding (Comment and Lyrics) and invert left/right padding for   `LineEdit` if layout direction RTL