### PR TITLE
Fix issues when using GME files

### DIFF
--- a/src/constants/filefilterconstants.h
+++ b/src/constants/filefilterconstants.h
@@ -30,7 +30,7 @@ constexpr char kFileFilter[] =
     "*.aif *.aiff *.mka *.tta *.dsf *.dsd "
     "*.cue *.m3u *.m3u8 *.pls *.xspf *.asxini "
     "*.ac3 *.dts "
-    "*.mod *.s3m *.xm *.it"
+    "*.mod *.s3m *.xm *.it "
     "*.spc *.vgm";
 
 constexpr char kLoadImageFileFilter[] = QT_TRANSLATE_NOOP("FileFilter", "Images (*.png *.jpg *.jpeg *.bmp *.gif *.xpm *.pbm *.pgm *.ppm *.xbm)");

--- a/src/engine/gstenginepipeline.cpp
+++ b/src/engine/gstenginepipeline.cpp
@@ -1369,6 +1369,12 @@ void GstEnginePipeline::AboutToFinishCallback(GstPlayBin *playbin, gpointer self
     qLog(Debug) << "Stream from URL" << instance->gst_url_ << "about to finish.";
   }
 
+  // When playing GME files it seems playbin3 emits about-to-finish early
+  // This stops us from skipping when the song has just started.
+  if(instance->position() == 0) {
+    return;
+  }
+
   instance->about_to_finish_ = true;
 
   if (instance->HasNextUrl() && !instance->next_uri_set_.value()) {

--- a/src/engine/gstenginepipeline.cpp
+++ b/src/engine/gstenginepipeline.cpp
@@ -1371,7 +1371,7 @@ void GstEnginePipeline::AboutToFinishCallback(GstPlayBin *playbin, gpointer self
 
   // When playing GME files it seems playbin3 emits about-to-finish early
   // This stops us from skipping when the song has just started.
-  if(instance->position() == 0) {
+  if (instance->position() == 0) {
     return;
   }
 

--- a/src/tagreader/tagreaderclient.cpp
+++ b/src/tagreader/tagreaderclient.cpp
@@ -251,9 +251,10 @@ TagReaderReplyPtr TagReaderClient::IsMediaFileAsync(const QString &filename) {
 
 TagReaderResult TagReaderClient::ReadFileBlocking(const QString &filename, Song *song) {
   TagReaderResult taglib_result = tagreader_.ReadFile(filename, song);
-  if(taglib_result.error_code == TagReaderResult::ErrorCode::FileOpenError || taglib_result.error_code == TagReaderResult::ErrorCode::Unsupported) {
+  if (taglib_result.error_code == TagReaderResult::ErrorCode::FileOpenError || taglib_result.error_code == TagReaderResult::ErrorCode::Unsupported) {
     return gmereader_.ReadFile(filename, song);
-  } else {
+  }
+  else {
     return taglib_result;
   }
 }

--- a/src/tagreader/tagreaderclient.cpp
+++ b/src/tagreader/tagreaderclient.cpp
@@ -229,7 +229,7 @@ bool TagReaderClient::IsMediaFileBlocking(const QString &filename) const {
 
   Q_ASSERT(QThread::currentThread() != thread());
 
-  return tagreader_.IsMediaFile(filename).success();
+  return tagreader_.IsMediaFile(filename).success() || gmereader_.IsMediaFile(filename).success();
 
 }
 
@@ -250,9 +250,12 @@ TagReaderReplyPtr TagReaderClient::IsMediaFileAsync(const QString &filename) {
 }
 
 TagReaderResult TagReaderClient::ReadFileBlocking(const QString &filename, Song *song) {
-
-  return tagreader_.ReadFile(filename, song);
-
+  TagReaderResult taglib_result = tagreader_.ReadFile(filename, song);
+  if(taglib_result.error_code == TagReaderResult::ErrorCode::FileOpenError || taglib_result.error_code == TagReaderResult::ErrorCode::Unsupported) {
+    return gmereader_.ReadFile(filename, song);
+  } else {
+    return taglib_result;
+  }
 }
 
 TagReaderReadFileReplyPtr TagReaderClient::ReadFileAsync(const QString &filename) {


### PR DESCRIPTION
Currently while strawberry contains code to support GME (`.spc` and `.vgm`) files, it seems to have gotten broken somewhere. This PR fixes 3 issues with the current integration. 

1) The `kFileFilter` array is missing a space between `.it` and `.spc` causing `.spc` (and maybe `.it`) files to not be selectable from the file picker.
2) `TagReaderClient` never actually calls `TagReaderGME` when checking if a file is valid or when reading files, meaning `.spc` and `.vgm` files always return `Unsupported`.
3) For some reason it seems playbin3 emits `about-to-finish` immediately when opening a GME file while also emitting the normal `about-to-finish` when playback ends. No clue why this happens but I added a check in the `about-to-finish` callback to ignore the event if the current track position is 0.

I'm PRing all these fixes together because they're all small and the implementation is broken without all 3. I can split them up if desired though.