### PR TITLE
Support for Sort Tags

### DIFF
--- a/src/collection/collectionlibrary.cpp
+++ b/src/collection/collectionlibrary.cpp
@@ -78,6 +78,8 @@ CollectionLibrary::CollectionLibrary(const SharedPtr<Database> database,
 
   model_ = new CollectionModel(backend_, albumcover_loader, this);
 
+  full_rescan_revisions_[21] = tr("Support for sort tags artist, album, album artist, title, composer, and performer");
+
   ReloadSettings();
 
 }

--- a/src/collection/collectionmodel.h
+++ b/src/collection/collectionmodel.h
@@ -52,6 +52,7 @@
 #include "collectionmodelupdate.h"
 #include "collectionfilteroptions.h"
 #include "collectionitem.h"
+#include "constants/collectionsettings.h"
 
 class QTimer;
 class Settings;
@@ -129,14 +130,14 @@ class CollectionModel : public SimpleTreeModel<CollectionItem> {
                 show_dividers(true),
                 show_pretty_covers(true),
                 show_various_artists(true),
-                sort_skips_articles(true),
+                sort_behaviour(CollectionSettings::SortBehaviour::SkipArticles),
                 separate_albums_by_grouping(false) {}
 
     Grouping group_by;
     bool show_dividers;
     bool show_pretty_covers;
     bool show_various_artists;
-    bool sort_skips_articles;
+    CollectionSettings::SortBehaviour sort_behaviour;
     bool separate_albums_by_grouping;
     CollectionFilterOptions filter_options;
   };
@@ -176,17 +177,19 @@ class CollectionModel : public SimpleTreeModel<CollectionItem> {
   QMimeData *mimeData(const QModelIndexList &indexes) const override;
 
   // Utility functions for manipulating text
-  static QString DisplayText(const GroupBy group_by, const Song &song);
+  static QString DisplayText(const GroupBy group_by, const Song &song, const CollectionSettings::SortBehaviour &sort_behaviour);
+  static QString NameOrSortname(const QString &name, const QString &sort_name, const CollectionSettings::SortBehaviour &sort_behaviour);
   static QString TextOrUnknown(const QString &text);
   static QString PrettyYearAlbum(const int year, const QString &album);
   static QString PrettyAlbumDisc(const QString &album, const int disc);
   static QString PrettyYearAlbumDisc(const int year, const QString &album, const int disc);
   static QString PrettyDisc(const int disc);
   static QString PrettyFormat(const Song &song);
-  QString SortText(const GroupBy group_by, const Song &song, const bool sort_skips_articles);
+  QString SortText(const GroupBy group_by, const Song &song, const CollectionSettings::SortBehaviour &sort_behaviour);
   static QString SortText(QString text);
+  static QString SortTextForName(const QString &name, const QString &sort_name, const CollectionSettings::SortBehaviour &sort_behaviour);
   static QString SortTextForNumber(const int number);
-  static QString SortTextForArtist(QString artist, const bool skip_articles);
+  static QString SortTextSkipArticles(QString name);
   static QString SortTextForSong(const Song &song);
   static QString SortTextForYear(const int year);
   static QString SortTextForBitrate(const int bitrate);

--- a/src/constants/collectionsettings.h
+++ b/src/constants/collectionsettings.h
@@ -28,7 +28,7 @@ constexpr char kAutoOpen[] = "auto_open";
 constexpr char kShowDividers[] = "show_dividers";
 constexpr char kPrettyCovers[] = "pretty_covers";
 constexpr char kVariousArtists[] = "various_artists";
-constexpr char kSortSkipsArticles[] = "sort_skips_articles";
+constexpr char kSortBehaviour[] = "sort_behaviour";
 constexpr char kStartupScan[] = "startup_scan";
 constexpr char kMonitor[] = "monitor";
 constexpr char kSongTracking[] = "song_tracking";
@@ -49,6 +49,13 @@ constexpr char kOverwritePlaycount[] = "overwrite_playcount";
 constexpr char kOverwriteRating[] = "overwrite_rating";
 constexpr char kDeleteFiles[] = "delete_files";
 constexpr char kLastPath[] = "last_path";
+
+enum class SortBehaviour {
+  AsIs = 1,
+  SkipArticles = 2,
+  UseSortTagForSort = 3,
+  UseSortTagForDisplayAndSort = 4
+};
 
 enum class CacheSizeUnit {
   KB,

--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -68,9 +68,13 @@
 using namespace Qt::Literals::StringLiterals;
 
 const QStringList Song::kColumns = QStringList() << u"title"_s
+                                                 << u"titlesort"_s
                                                  << u"album"_s
+                                                 << u"albumsort"_s
                                                  << u"artist"_s
+                                                 << u"artistsort"_s
                                                  << u"albumartist"_s
+                                                 << u"albumartistsort"_s
                                                  << u"track"_s
                                                  << u"disc"_s
                                                  << u"year"_s
@@ -78,7 +82,9 @@ const QStringList Song::kColumns = QStringList() << u"title"_s
                                                  << u"genre"_s
                                                  << u"compilation"_s
                                                  << u"composer"_s
+                                                 << u"composersort"_s
                                                  << u"performer"_s
+                                                 << u"performersort"_s
                                                  << u"grouping"_s
                                                  << u"comment"_s
                                                  << u"lyrics"_s
@@ -261,9 +267,13 @@ struct Song::Private : public QSharedData {
   bool valid_;
 
   QString title_;
+  QString titlesort_;
   QString album_;
+  QString albumsort_;
   QString artist_;
+  QString artistsort_;
   QString albumartist_;
+  QString albumartistsort_;
   int track_;
   int disc_;
   int year_;
@@ -271,7 +281,9 @@ struct Song::Private : public QSharedData {
   QString genre_;
   bool compilation_;  // From the file tag
   QString composer_;
+  QString composersort_;
   QString performer_;
+  QString performersort_;
   QString grouping_;
   QString comment_;
   QString lyrics_;
@@ -411,9 +423,13 @@ int Song::id() const { return d->id_; }
 bool Song::is_valid() const { return d->valid_; }
 
 const QString &Song::title() const { return d->title_; }
+const QString &Song::titlesort() const { return d->titlesort_; }
 const QString &Song::album() const { return d->album_; }
+const QString &Song::albumsort() const { return d->albumsort_; }
 const QString &Song::artist() const { return d->artist_; }
+const QString &Song::artistsort() const { return d->artistsort_; }
 const QString &Song::albumartist() const { return d->albumartist_; }
+const QString &Song::albumartistsort() const { return d->albumartistsort_; }
 int Song::track() const { return d->track_; }
 int Song::disc() const { return d->disc_; }
 int Song::year() const { return d->year_; }
@@ -421,7 +437,9 @@ int Song::originalyear() const { return d->originalyear_; }
 const QString &Song::genre() const { return d->genre_; }
 bool Song::compilation() const { return d->compilation_; }
 const QString &Song::composer() const { return d->composer_; }
+const QString &Song::composersort() const { return d->composersort_; }
 const QString &Song::performer() const { return d->performer_; }
+const QString &Song::performersort() const { return d->performersort_; }
 const QString &Song::grouping() const { return d->grouping_; }
 const QString &Song::comment() const { return d->comment_; }
 const QString &Song::lyrics() const { return d->lyrics_; }
@@ -522,9 +540,13 @@ void Song::set_id(const int id) { d->id_ = id; }
 void Song::set_valid(const bool v) { d->valid_ = v; }
 
 void Song::set_title(const QString &v) { d->title_sortable_ = sortable(v); d->title_ = v; }
+void Song::set_titlesort(const QString &v) { d->titlesort_ = v; }
 void Song::set_album(const QString &v) { d->album_sortable_ = sortable(v); d->album_ = v; }
+void Song::set_albumsort(const QString &v) { d->albumsort_ = v; }
 void Song::set_artist(const QString &v) { d->artist_sortable_ = sortable(v); d->artist_ = v; }
+void Song::set_artistsort(const QString &v) { d->artistsort_ = v; }
 void Song::set_albumartist(const QString &v) { d->albumartist_sortable_ = sortable(v); d->albumartist_ = v; }
+void Song::set_albumartistsort(const QString &v) { d->albumartistsort_ = v; }
 void Song::set_track(const int v) { d->track_ = v; }
 void Song::set_disc(const int v) { d->disc_ = v; }
 void Song::set_year(const int v) { d->year_ = v; }
@@ -532,7 +554,9 @@ void Song::set_originalyear(const int v) { d->originalyear_ = v; }
 void Song::set_genre(const QString &v) { d->genre_ = v; }
 void Song::set_compilation(const bool v) { d->compilation_ = v; }
 void Song::set_composer(const QString &v) { d->composer_ = v; }
+void Song::set_composersort(const QString &v) { d->composersort_ = v; }
 void Song::set_performer(const QString &v) { d->performer_ = v; }
+void Song::set_performersort(const QString &v) { d->performersort_ = v; }
 void Song::set_grouping(const QString &v) { d->grouping_ = v; }
 void Song::set_comment(const QString &v) { d->comment_ = v; }
 void Song::set_lyrics(const QString &v) { d->lyrics_ = v; }
@@ -608,6 +632,8 @@ void Song::set_title(const TagLib::String &v) {
 
 }
 
+void Song::set_titlesort(const TagLib::String &v) { d->titlesort_ = TagLibStringToQString(v); }
+
 void Song::set_album(const TagLib::String &v) {
 
   const QString album = TagLibStringToQString(v);
@@ -615,6 +641,9 @@ void Song::set_album(const TagLib::String &v) {
   d->album_ = album;
 
 }
+
+void Song::set_albumsort(const TagLib::String &v) { d->albumsort_ = TagLibStringToQString(v); }
+
 void Song::set_artist(const TagLib::String &v) {
 
   const QString artist = TagLibStringToQString(v);
@@ -622,6 +651,8 @@ void Song::set_artist(const TagLib::String &v) {
   d->artist_ = artist;
 
 }
+
+void Song::set_artistsort(const TagLib::String &v) { d->artistsort_ = TagLibStringToQString(v); }
 
 void Song::set_albumartist(const TagLib::String &v) {
 
@@ -631,9 +662,12 @@ void Song::set_albumartist(const TagLib::String &v) {
 
 }
 
+void Song::set_albumartistsort(const TagLib::String &v) { d->albumartistsort_ = TagLibStringToQString(v); }
 void Song::set_genre(const TagLib::String &v) { d->genre_ = TagLibStringToQString(v); }
 void Song::set_composer(const TagLib::String &v) { d->composer_ = TagLibStringToQString(v); }
+void Song::set_composersort(const TagLib::String &v) { d->composersort_ = TagLibStringToQString(v); }
 void Song::set_performer(const TagLib::String &v) { d->performer_ = TagLibStringToQString(v); }
+void Song::set_performersort(const TagLib::String &v) { d->performersort_ = TagLibStringToQString(v); }
 void Song::set_grouping(const TagLib::String &v) { d->grouping_ = TagLibStringToQString(v); }
 void Song::set_comment(const TagLib::String &v) { d->comment_ = TagLibStringToQString(v); }
 void Song::set_lyrics(const TagLib::String &v) { d->lyrics_ = TagLibStringToQString(v); }
@@ -1498,9 +1532,13 @@ void Song::InitFromQuery(const QSqlRecord &r, const bool reliable_metadata, cons
   d->id_ = SqlHelper::ValueToInt(r, ColumnIndex(u"ROWID"_s) + col);
 
   set_title(SqlHelper::ValueToString(r, ColumnIndex(u"title"_s) + col));
+  set_titlesort(SqlHelper::ValueToString(r, ColumnIndex(u"titlesort"_s) + col));
   set_album(SqlHelper::ValueToString(r, ColumnIndex(u"album"_s) + col));
+  set_albumsort(SqlHelper::ValueToString(r, ColumnIndex(u"albumsort"_s) + col));
   set_artist(SqlHelper::ValueToString(r, ColumnIndex(u"artist"_s) + col));
+  set_artistsort(SqlHelper::ValueToString(r, ColumnIndex(u"artistsort"_s) + col));
   set_albumartist(SqlHelper::ValueToString(r, ColumnIndex(u"albumartist"_s) + col));
+  set_albumartistsort(SqlHelper::ValueToString(r, ColumnIndex(u"albumartistsort"_s) + col));
   d->track_ = SqlHelper::ValueToInt(r, ColumnIndex(u"track"_s) + col);
   d->disc_ = SqlHelper::ValueToInt(r, ColumnIndex(u"disc"_s) + col);
   d->year_ = SqlHelper::ValueToInt(r, ColumnIndex(u"year"_s) + col);
@@ -1508,7 +1546,9 @@ void Song::InitFromQuery(const QSqlRecord &r, const bool reliable_metadata, cons
   d->genre_ = SqlHelper::ValueToString(r, ColumnIndex(u"genre"_s) + col);
   d->compilation_ = r.value(ColumnIndex(u"compilation"_s) + col).toBool();
   d->composer_ = SqlHelper::ValueToString(r, ColumnIndex(u"composer"_s) + col);
+  d->composersort_ = SqlHelper::ValueToString(r, ColumnIndex(u"composersort"_s) + col);
   d->performer_ = SqlHelper::ValueToString(r, ColumnIndex(u"performer"_s) + col);
+  d->performersort_ = SqlHelper::ValueToString(r, ColumnIndex(u"performersort"_s) + col);
   d->grouping_ = SqlHelper::ValueToString(r, ColumnIndex(u"grouping"_s) + col);
   d->comment_ = SqlHelper::ValueToString(r, ColumnIndex(u"comment"_s) + col);
   d->lyrics_ = SqlHelper::ValueToString(r, ColumnIndex(u"lyrics"_s) + col);
@@ -1816,9 +1856,13 @@ void Song::BindToQuery(SqlQuery *query) const {
   // Remember to bind these in the same order as kBindSpec
 
   query->BindStringValue(u":title"_s, d->title_);
+  query->BindStringValue(u":titlesort"_s, d->titlesort_);
   query->BindStringValue(u":album"_s, d->album_);
+  query->BindStringValue(u":albumsort"_s, d->albumsort_);
   query->BindStringValue(u":artist"_s, d->artist_);
+  query->BindStringValue(u":artistsort"_s, d->artistsort_);
   query->BindStringValue(u":albumartist"_s, d->albumartist_);
+  query->BindStringValue(u":albumartistsort"_s, d->albumartistsort_);
   query->BindIntValue(u":track"_s, d->track_);
   query->BindIntValue(u":disc"_s, d->disc_);
   query->BindIntValue(u":year"_s, d->year_);
@@ -1826,7 +1870,9 @@ void Song::BindToQuery(SqlQuery *query) const {
   query->BindStringValue(u":genre"_s, d->genre_);
   query->BindBoolValue(u":compilation"_s, d->compilation_);
   query->BindStringValue(u":composer"_s, d->composer_);
+  query->BindStringValue(u":composersort"_s, d->composersort_);
   query->BindStringValue(u":performer"_s, d->performer_);
+  query->BindStringValue(u":performersort"_s, d->performersort_);
   query->BindStringValue(u":grouping"_s, d->grouping_);
   query->BindStringValue(u":comment"_s, d->comment_);
   query->BindStringValue(u":lyrics"_s, d->lyrics_);

--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -816,6 +816,31 @@ bool Song::lyrics_supported() const {
   return additional_tags_supported() || d->filetype_ == FileType::ASF;
 }
 
+bool Song::albumartistsort_supported() const {
+  return d->filetype_ == FileType::FLAC || d->filetype_ == FileType::OggFlac || d->filetype_ == FileType::OggVorbis || d->filetype_ == FileType::MPEG;
+}
+
+bool Song::albumsort_supported() const {
+  return d->filetype_ == FileType::FLAC || d->filetype_ == FileType::OggFlac || d->filetype_ == FileType::OggVorbis || d->filetype_ == FileType::MPEG;
+}
+
+bool Song::artistsort_supported() const {
+  return d->filetype_ == FileType::FLAC || d->filetype_ == FileType::OggFlac || d->filetype_ == FileType::OggVorbis || d->filetype_ == FileType::MPEG;
+}
+
+bool Song::composersort_supported() const {
+  return d->filetype_ == FileType::FLAC || d->filetype_ == FileType::OggFlac || d->filetype_ == FileType::OggVorbis || d->filetype_ == FileType::MPEG;
+}
+
+bool Song::performersort_supported() const {
+  // Performer sort is a rare custom field even in vorbis comments, no write support in MPEG formats
+  return d->filetype_ == FileType::FLAC || d->filetype_ == FileType::OggFlac || d->filetype_ == FileType::OggVorbis;
+}
+
+bool Song::titlesort_supported() const {
+  return d->filetype_ == FileType::FLAC || d->filetype_ == FileType::OggFlac || d->filetype_ == FileType::OggVorbis || d->filetype_ == FileType::MPEG;
+}
+
 bool Song::save_embedded_cover_supported(const FileType filetype) {
 
   return filetype == FileType::FLAC ||

--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -1000,9 +1000,13 @@ bool Song::IsFileInfoEqual(const Song &other) const {
 bool Song::IsMetadataEqual(const Song &other) const {
 
   return d->title_ == other.d->title_ &&
+         d->titlesort_ == other.d->titlesort_ &&
          d->album_ == other.d->album_ &&
+         d->albumsort_ == other.d->albumsort_ &&
          d->artist_ == other.d->artist_ &&
+         d->artistsort_ == other.d->artistsort_ &&
          d->albumartist_ == other.d->albumartist_ &&
+         d->albumartistsort_ == other.d->albumartistsort_ &&
          d->track_ == other.d->track_ &&
          d->disc_ == other.d->disc_ &&
          d->year_ == other.d->year_ &&
@@ -1010,7 +1014,9 @@ bool Song::IsMetadataEqual(const Song &other) const {
          d->genre_ == other.d->genre_ &&
          d->compilation_ == other.d->compilation_ &&
          d->composer_ == other.d->composer_ &&
+         d->composersort_ == other.d->composersort_ &&
          d->performer_ == other.d->performer_ &&
+         d->performersort_ == other.d->performersort_ &&
          d->grouping_ == other.d->grouping_ &&
          d->comment_ == other.d->comment_ &&
          d->lyrics_ == other.d->lyrics_ &&

--- a/src/core/song.h
+++ b/src/core/song.h
@@ -421,6 +421,13 @@ class Song {
   bool comment_supported() const;
   bool lyrics_supported() const;
 
+  bool albumartistsort_supported() const;
+  bool albumsort_supported() const;
+  bool artistsort_supported() const;
+  bool composersort_supported() const;
+  bool performersort_supported() const;
+  bool titlesort_supported() const;
+
   static bool save_embedded_cover_supported(const FileType filetype);
   bool save_embedded_cover_supported() const { return url().isLocalFile() && save_embedded_cover_supported(filetype()) && !has_cue(); };
 

--- a/src/core/song.h
+++ b/src/core/song.h
@@ -150,9 +150,13 @@ class Song {
   bool is_valid() const;
 
   const QString &title() const;
+  const QString &titlesort() const;
   const QString &album() const;
+  const QString &albumsort() const;
   const QString &artist() const;
+  const QString &artistsort() const;
   const QString &albumartist() const;
+  const QString &albumartistsort() const;
   int track() const;
   int disc() const;
   int year() const;
@@ -160,7 +164,9 @@ class Song {
   const QString &genre() const;
   bool compilation() const;
   const QString &composer() const;
+  const QString &composersort() const;
   const QString &performer() const;
+  const QString &performersort() const;
   const QString &grouping() const;
   const QString &comment() const;
   const QString &lyrics() const;
@@ -262,9 +268,13 @@ class Song {
   void set_valid(const bool v);
 
   void set_title(const QString &v);
+  void set_titlesort(const QString &v);
   void set_album(const QString &v);
+  void set_albumsort(const QString &v);
   void set_artist(const QString &v);
+  void set_artistsort(const QString &v);
   void set_albumartist(const QString &v);
+  void set_albumartistsort(const QString &v);
   void set_track(const int v);
   void set_disc(const int v);
   void set_year(const int v);
@@ -272,7 +282,9 @@ class Song {
   void set_genre(const QString &v);
   void set_compilation(bool v);
   void set_composer(const QString &v);
+  void set_composersort(const QString &v);
   void set_performer(const QString &v);
+  void set_performersort(const QString &v);
   void set_grouping(const QString &v);
   void set_comment(const QString &v);
   void set_lyrics(const QString &v);
@@ -341,12 +353,18 @@ class Song {
   void set_stream_url(const QUrl &v);
 
   void set_title(const TagLib::String &v);
+  void set_titlesort(const TagLib::String &v);
   void set_album(const TagLib::String &v);
+  void set_albumsort(const TagLib::String &v);
   void set_artist(const TagLib::String &v);
+  void set_artistsort(const TagLib::String &v);
   void set_albumartist(const TagLib::String &v);
+  void set_albumartistsort(const TagLib::String &v);
   void set_genre(const TagLib::String &v);
   void set_composer(const TagLib::String &v);
+  void set_composersort(const TagLib::String &v);
   void set_performer(const TagLib::String &v);
+  void set_performersort(const TagLib::String &v);
   void set_grouping(const TagLib::String &v);
   void set_comment(const TagLib::String &v);
   void set_lyrics(const TagLib::String &v);

--- a/src/device/cddasongloader.cpp
+++ b/src/device/cddasongloader.cpp
@@ -248,11 +248,21 @@ void CDDASongLoader::LoadSongsFromCDDA() {
         g_free(tag);
         tag = nullptr;
       }
+      if (gst_tag_list_get_string(tags, GST_TAG_ALBUM_ARTIST_SORTNAME, &tag)) {
+        song.set_albumartistsort(QString::fromUtf8(tag));
+        g_free(tag);
+        tag = nullptr;
+      }
       if (gst_tag_list_get_string(tags, GST_TAG_ARTIST, &tag)) {
         song.set_artist(QString::fromUtf8(tag));
         g_free(tag);
         tag = nullptr;
         ++track_artist_tags;
+      }
+      if (gst_tag_list_get_string(tags, GST_TAG_ARTIST_SORTNAME, &tag)) {
+        song.set_artistsort(QString::fromUtf8(tag));
+        g_free(tag);
+        tag = nullptr;
       }
       if (gst_tag_list_get_string(tags, GST_TAG_ALBUM, &tag)) {
         song.set_album(QString::fromUtf8(tag));
@@ -260,11 +270,21 @@ void CDDASongLoader::LoadSongsFromCDDA() {
         tag = nullptr;
         ++track_album_tags;
       }
+      if (gst_tag_list_get_string(tags, GST_TAG_ALBUM_SORTNAME, &tag)) {
+        song.set_albumsort(QString::fromUtf8(tag));
+        g_free(tag);
+        tag = nullptr;
+      }
       if (gst_tag_list_get_string(tags, GST_TAG_TITLE, &tag)) {
         song.set_title(QString::fromUtf8(tag));
         g_free(tag);
         tag = nullptr;
         ++track_title_tags;
+      }
+      if (gst_tag_list_get_string(tags, GST_TAG_TITLE_SORTNAME, &tag)) {
+        song.set_titlesort(QString::fromUtf8(tag));
+        g_free(tag);
+        tag = nullptr;
       }
       if (gst_tag_list_get_string(tags, GST_TAG_GENRE, &tag)) {
         song.set_genre(QString::fromUtf8(tag));
@@ -273,6 +293,11 @@ void CDDASongLoader::LoadSongsFromCDDA() {
       }
       if (gst_tag_list_get_string(tags, GST_TAG_COMPOSER, &tag)) {
         song.set_composer(QString::fromUtf8(tag));
+        g_free(tag);
+        tag = nullptr;
+      }
+      if (gst_tag_list_get_string(tags, GST_TAG_COMPOSER_SORTNAME, &tag)) {
+        song.set_composersort(QString::fromUtf8(tag));
         g_free(tag);
         tag = nullptr;
       }

--- a/src/dialogs/edittagdialog.cpp
+++ b/src/dialogs/edittagdialog.cpp
@@ -274,12 +274,18 @@ EditTagDialog::EditTagDialog(const SharedPtr<NetworkAccessManager> network,
       QKeySequence(QKeySequence::MoveToNextPage).toString(QKeySequence::NativeText)));
 
   new TagCompleter(collection_backend, Playlist::Column::Artist, ui_->artist);
+  new TagCompleter(collection_backend, Playlist::Column::ArtistSort, ui_->artistsort);
   new TagCompleter(collection_backend, Playlist::Column::Album, ui_->album);
+  new TagCompleter(collection_backend, Playlist::Column::AlbumSort, ui_->albumsort);
   new TagCompleter(collection_backend, Playlist::Column::AlbumArtist, ui_->albumartist);
+  new TagCompleter(collection_backend, Playlist::Column::AlbumArtistSort, ui_->albumartistsort);
   new TagCompleter(collection_backend, Playlist::Column::Genre, ui_->genre);
   new TagCompleter(collection_backend, Playlist::Column::Composer, ui_->composer);
+  new TagCompleter(collection_backend, Playlist::Column::ComposerSort, ui_->composersort);
   new TagCompleter(collection_backend, Playlist::Column::Performer, ui_->performer);
+  new TagCompleter(collection_backend, Playlist::Column::PerformerSort, ui_->performersort);
   new TagCompleter(collection_backend, Playlist::Column::Grouping, ui_->grouping);
+  new TagCompleter(collection_backend, Playlist::Column::TitleSort, ui_->titlesort);
 
 }
 
@@ -493,11 +499,17 @@ void EditTagDialog::SetSongListVisibility(bool visible) {
 QVariant EditTagDialog::Data::value(const Song &song, const QString &id) {
 
   if (id == "title"_L1) return song.title();
+  if (id == "titlesort"_L1) return song.titlesort();
   if (id == "artist"_L1) return song.artist();
+  if (id == "artistsort"_L1) return song.artistsort();
   if (id == "album"_L1) return song.album();
+  if (id == "albumsort"_L1) return song.albumsort();
   if (id == "albumartist"_L1) return song.albumartist();
+  if (id == "albumartistsort"_L1) return song.albumartistsort();
   if (id == "composer"_L1) return song.composer();
+  if (id == "composersort"_L1) return song.composersort();
   if (id == "performer"_L1) return song.performer();
+  if (id == "performersort"_L1) return song.performersort();
   if (id == "grouping"_L1) return song.grouping();
   if (id == "genre"_L1) return song.genre();
   if (id == "comment"_L1) return song.comment();
@@ -515,11 +527,17 @@ QVariant EditTagDialog::Data::value(const Song &song, const QString &id) {
 void EditTagDialog::Data::set_value(const QString &id, const QVariant &value) {
 
   if (id == "title"_L1) current_.set_title(value.toString());
+  else if (id == "titlesort"_L1) current_.set_titlesort(value.toString());
   else if (id == "artist"_L1) current_.set_artist(value.toString());
+  else if (id == "artistsort"_L1) current_.set_artistsort(value.toString());
   else if (id == "album"_L1) current_.set_album(value.toString());
+  else if (id == "albumsort"_L1) current_.set_albumsort(value.toString());
   else if (id == "albumartist"_L1) current_.set_albumartist(value.toString());
+  else if (id == "albumartistsort"_L1) current_.set_albumartistsort(value.toString());
   else if (id == "composer"_L1) current_.set_composer(value.toString());
+  else if (id == "composersort"_L1) current_.set_composersort(value.toString());
   else if (id == "performer"_L1) current_.set_performer(value.toString());
+  else if (id == "performersort"_L1) current_.set_performersort(value.toString());
   else if (id == "grouping"_L1) current_.set_grouping(value.toString());
   else if (id == "genre"_L1) current_.set_genre(value.toString());
   else if (id == "comment"_L1) current_.set_comment(value.toString());
@@ -675,14 +693,20 @@ void EditTagDialog::SelectionChanged() {
   bool art_different = false;
   bool action_different = false;
   bool albumartist_enabled = false;
+  bool albumartistsort_enabled = false;
   bool composer_enabled = false;
+  bool composersort_enabled = false;
   bool performer_enabled = false;
+  bool performersort_enabled = false;
   bool grouping_enabled = false;
   bool genre_enabled = false;
   bool compilation_enabled = false;
   bool rating_enabled = false;
   bool comment_enabled = false;
   bool lyrics_enabled = false;
+  bool titlesort_enabled = false;
+  bool artistsort_enabled = false;
+  bool albumsort_enabled = false;
   for (const QModelIndex &idx : indexes) {
     if (data_.value(idx.row()).cover_action_ == UpdateCoverAction::None) {
       data_[idx.row()].cover_result_ = AlbumCoverImageResult();
@@ -702,11 +726,20 @@ void EditTagDialog::SelectionChanged() {
     if (song.albumartist_supported()) {
       albumartist_enabled = true;
     }
+    if (song.albumartistsort_supported()) {
+      albumartistsort_enabled = true;
+    }
     if (song.composer_supported()) {
       composer_enabled = true;
     }
+    if (song.composersort_supported()) {
+      composersort_enabled = true;
+    }
     if (song.performer_supported()) {
       performer_enabled = true;
+    }
+    if (song.performersort_supported()) {
+      performersort_enabled = true;
     }
     if (song.grouping_supported()) {
       grouping_enabled = true;
@@ -725,6 +758,15 @@ void EditTagDialog::SelectionChanged() {
     }
     if (song.lyrics_supported()) {
       lyrics_enabled = true;
+    }
+    if (song.titlesort_supported()) {
+      titlesort_enabled = true;
+    }
+    if (song.artistsort_supported()) {
+      artistsort_enabled = true;
+    }
+    if (song.albumsort_supported()) {
+      albumsort_enabled = true;
     }
   }
 
@@ -782,14 +824,20 @@ void EditTagDialog::SelectionChanged() {
   album_cover_choice_controller_->set_save_embedded_cover_override(embedded_cover);
 
   ui_->albumartist->setEnabled(albumartist_enabled);
+  ui_->albumartistsort->setEnabled(albumartistsort_enabled);
   ui_->composer->setEnabled(composer_enabled);
+  ui_->composersort->setEnabled(composersort_enabled);
   ui_->performer->setEnabled(performer_enabled);
+  ui_->performersort->setEnabled(performersort_enabled);
   ui_->grouping->setEnabled(grouping_enabled);
   ui_->genre->setEnabled(genre_enabled);
   ui_->compilation->setEnabled(compilation_enabled);
   ui_->rating->setEnabled(rating_enabled);
   ui_->comment->setEnabled(comment_enabled);
   ui_->lyrics->setEnabled(lyrics_enabled);
+  ui_->titlesort->setEnabled(titlesort_enabled);
+  ui_->artistsort->setEnabled(artistsort_enabled);
+  ui_->albumsort->setEnabled(albumsort_enabled);
 
 }
 

--- a/src/dialogs/edittagdialog.ui
+++ b/src/dialogs/edittagdialog.ui
@@ -31,8 +31,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>801</width>
-        <height>918</height>
+        <width>781</width>
+        <height>1047</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -700,54 +700,35 @@
               <property name="sizeConstraint">
                <enum>QLayout::SetMinimumSize</enum>
               </property>
-              <item row="4" column="3">
-               <widget class="SpinBox" name="year">
-                <property name="correctionMode">
-                 <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
-                </property>
-                <property name="maximum">
-                 <number>9999</number>
-                </property>
-                <property name="has_clear_button" stdset="0">
-                 <bool>false</bool>
-                </property>
-                <property name="has_reset_button" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="14" column="1">
-               <widget class="LineEdit" name="genre">
-                <property name="has_reset_button" stdset="0">
-                 <bool>true</bool>
-                </property>
-                <property name="has_clear_button" stdset="0">
-                 <bool>false</bool>
-                </property>
-               </widget>
-              </item>
               <item row="3" column="2">
-               <widget class="QLabel" name="label_disc">
+               <widget class="QLabel" name="label_year">
                 <property name="text">
-                 <string>Disc</string>
+                 <string>Year</string>
                 </property>
                 <property name="buddy">
-                 <cstring>disc</cstring>
+                 <cstring>year</cstring>
                 </property>
                </widget>
               </item>
-              <item row="8" column="1">
-               <widget class="LineEdit" name="composer">
-                <property name="has_reset_button" stdset="0">
-                 <bool>true</bool>
+              <item row="25" column="1">
+               <widget class="QPushButton" name="fetch_tag">
+                <property name="text">
+                 <string>Complete tags automatically</string>
                 </property>
-                <property name="has_clear_button" stdset="0">
-                 <bool>false</bool>
+                <property name="icon">
+                 <iconset resource="../../data/data.qrc">
+                  <normaloff>:/pictures/musicbrainz.png</normaloff>:/pictures/musicbrainz.png</iconset>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>38</width>
+                  <height>22</height>
+                 </size>
                 </property>
                </widget>
               </item>
               <item row="13" column="0">
-               <widget class="QLabel" name="label_grouping">
+               <widget class="QLabel" name="label_performersort">
                 <property name="minimumSize">
                  <size>
                   <width>80</width>
@@ -755,14 +736,56 @@
                  </size>
                 </property>
                 <property name="text">
-                 <string>Grouping</string>
+                 <string>Performer sort</string>
                 </property>
                 <property name="buddy">
-                 <cstring>grouping</cstring>
+                 <cstring>performersort</cstring>
                 </property>
                </widget>
               </item>
-              <item row="5" column="0">
+              <item row="19" column="0">
+               <widget class="QLabel" name="label_compilation">
+                <property name="minimumSize">
+                 <size>
+                  <width>80</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string>Compilation</string>
+                </property>
+                <property name="buddy">
+                 <cstring>compilation</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="8" column="1">
+               <widget class="LineEdit" name="albumartistsort">
+                <property name="has_reset_button" stdset="0">
+                 <bool>true</bool>
+                </property>
+                <property name="has_clear_button" stdset="0">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_titlesort">
+                <property name="minimumSize">
+                 <size>
+                  <width>80</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string>Title sort</string>
+                </property>
+                <property name="buddy">
+                 <cstring>titlesort</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="7" column="0">
                <widget class="QLabel" name="label_albumartist">
                 <property name="minimumSize">
                  <size>
@@ -778,7 +801,130 @@
                 </property>
                </widget>
               </item>
-              <item row="13" column="1">
+              <item row="0" column="1">
+               <widget class="LineEdit" name="title">
+                <property name="has_reset_button" stdset="0">
+                 <bool>true</bool>
+                </property>
+                <property name="has_clear_button" stdset="0">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="12" column="0">
+               <widget class="QLabel" name="label_performer">
+                <property name="minimumSize">
+                 <size>
+                  <width>80</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string>Performer</string>
+                </property>
+                <property name="buddy">
+                 <cstring>performer</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="18" column="1">
+               <widget class="LineEdit" name="genre">
+                <property name="has_reset_button" stdset="0">
+                 <bool>true</bool>
+                </property>
+                <property name="has_clear_button" stdset="0">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="3">
+               <widget class="SpinBox" name="year">
+                <property name="correctionMode">
+                 <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+                </property>
+                <property name="maximum">
+                 <number>9999</number>
+                </property>
+                <property name="has_clear_button" stdset="0">
+                 <bool>false</bool>
+                </property>
+                <property name="has_reset_button" stdset="0">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="20" column="1">
+               <widget class="RatingBox" name="rating" native="true">
+                <property name="maximumSize">
+                 <size>
+                  <width>140</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="has_reset_button" stdset="0">
+                 <bool>true</bool>
+                </property>
+                <property name="has_clear_button" stdset="0">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="1">
+               <widget class="LineEdit" name="album">
+                <property name="has_reset_button" stdset="0">
+                 <bool>true</bool>
+                </property>
+                <property name="has_clear_button" stdset="0">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="26" column="1">
+               <widget class="TextEdit" name="comment">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="tabChangesFocus">
+                 <bool>true</bool>
+                </property>
+                <property name="has_reset_button" stdset="0">
+                 <bool>true</bool>
+                </property>
+                <property name="has_clear_button" stdset="0">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="1">
+               <widget class="LineEdit" name="artistsort">
+                <property name="has_reset_button" stdset="0">
+                 <bool>true</bool>
+                </property>
+                <property name="has_clear_button" stdset="0">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_title">
+                <property name="minimumSize">
+                 <size>
+                  <width>80</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string>Title</string>
+                </property>
+                <property name="buddy">
+                 <cstring>title</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="17" column="1">
                <widget class="LineEdit" name="grouping">
                 <property name="has_reset_button" stdset="0">
                  <bool>true</bool>
@@ -788,28 +934,64 @@
                 </property>
                </widget>
               </item>
-              <item row="9" column="1">
+              <item row="1" column="3">
+               <widget class="SpinBox" name="disc">
+                <property name="correctionMode">
+                 <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+                </property>
+                <property name="maximum">
+                 <number>9999</number>
+                </property>
+                <property name="has_clear_button" stdset="0">
+                 <bool>false</bool>
+                </property>
+                <property name="has_reset_button" stdset="0">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="19" column="1">
+               <widget class="CheckBox" name="compilation">
+                <property name="has_reset_button" stdset="0">
+                 <bool>true</bool>
+                </property>
+                <property name="has_clear_button" stdset="0">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="LineEdit" name="titlesort">
+                <property name="has_reset_button" stdset="0">
+                 <bool>true</bool>
+                </property>
+                <property name="has_clear_button" stdset="0">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="20" column="0">
+               <widget class="QLabel" name="label_rating">
+                <property name="text">
+                 <string>Rating</string>
+                </property>
+                <property name="buddy">
+                 <cstring>rating</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="2">
+               <widget class="QLabel" name="label_disc">
+                <property name="text">
+                 <string>Disc</string>
+                </property>
+                <property name="buddy">
+                 <cstring>disc</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="12" column="1">
                <widget class="LineEdit" name="performer">
-                <property name="has_reset_button" stdset="0">
-                 <bool>true</bool>
-                </property>
-                <property name="has_clear_button" stdset="0">
-                 <bool>false</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="LineEdit" name="artist">
-                <property name="has_reset_button" stdset="0">
-                 <bool>true</bool>
-                </property>
-                <property name="has_clear_button" stdset="0">
-                 <bool>false</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="LineEdit" name="title">
                 <property name="has_reset_button" stdset="0">
                  <bool>true</bool>
                 </property>
@@ -834,7 +1016,49 @@
                 </property>
                </widget>
               </item>
+              <item row="8" column="0">
+               <widget class="QLabel" name="label_albumartistsort">
+                <property name="minimumSize">
+                 <size>
+                  <width>80</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string>Album artist sort</string>
+                </property>
+                <property name="buddy">
+                 <cstring>albumartistsort</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="LineEdit" name="artist">
+                <property name="has_reset_button" stdset="0">
+                 <bool>true</bool>
+                </property>
+                <property name="has_clear_button" stdset="0">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
               <item row="4" column="0">
+               <widget class="QLabel" name="label_artistsort">
+                <property name="minimumSize">
+                 <size>
+                  <width>80</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string>Artist sort</string>
+                </property>
+                <property name="buddy">
+                 <cstring>artistsort</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="0">
                <widget class="QLabel" name="label_album">
                 <property name="minimumSize">
                  <size>
@@ -850,18 +1074,18 @@
                 </property>
                </widget>
               </item>
-              <item row="4" column="2">
-               <widget class="QLabel" name="label_year">
+              <item row="0" column="2">
+               <widget class="QLabel" name="label_track">
                 <property name="text">
-                 <string>Year</string>
+                 <string>Track</string>
                 </property>
                 <property name="buddy">
-                 <cstring>year</cstring>
+                 <cstring>track</cstring>
                 </property>
                </widget>
               </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_title">
+              <item row="10" column="0">
+               <widget class="QLabel" name="label_composer">
                 <property name="minimumSize">
                  <size>
                   <width>80</width>
@@ -869,10 +1093,72 @@
                  </size>
                 </property>
                 <property name="text">
-                 <string>Title</string>
+                 <string>Composer</string>
                 </property>
                 <property name="buddy">
-                 <cstring>title</cstring>
+                 <cstring>composer</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="7" column="1">
+               <widget class="LineEdit" name="albumartist">
+                <property name="has_reset_button" stdset="0">
+                 <bool>true</bool>
+                </property>
+                <property name="has_clear_button" stdset="0">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="11" column="1">
+               <widget class="LineEdit" name="composersort">
+                <property name="has_reset_button" stdset="0">
+                 <bool>true</bool>
+                </property>
+                <property name="has_clear_button" stdset="0">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="13" column="1">
+               <widget class="LineEdit" name="performersort">
+                <property name="has_reset_button" stdset="0">
+                 <bool>true</bool>
+                </property>
+                <property name="has_clear_button" stdset="0">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="17" column="0">
+               <widget class="QLabel" name="label_grouping">
+                <property name="minimumSize">
+                 <size>
+                  <width>80</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string>Grouping</string>
+                </property>
+                <property name="buddy">
+                 <cstring>grouping</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="6" column="0">
+               <widget class="QLabel" name="label_albumsort">
+                <property name="minimumSize">
+                 <size>
+                  <width>80</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string>Album sort</string>
+                </property>
+                <property name="buddy">
+                 <cstring>albumsort</cstring>
                 </property>
                </widget>
               </item>
@@ -892,66 +1178,7 @@
                 </property>
                </widget>
               </item>
-              <item row="8" column="0">
-               <widget class="QLabel" name="label_composer">
-                <property name="minimumSize">
-                 <size>
-                  <width>80</width>
-                  <height>0</height>
-                 </size>
-                </property>
-                <property name="text">
-                 <string>Composer</string>
-                </property>
-                <property name="buddy">
-                 <cstring>composer</cstring>
-                </property>
-               </widget>
-              </item>
-              <item row="21" column="1">
-               <widget class="QPushButton" name="fetch_tag">
-                <property name="text">
-                 <string>Complete tags automatically</string>
-                </property>
-                <property name="icon">
-                 <iconset resource="../../data/data.qrc">
-                  <normaloff>:/pictures/musicbrainz.png</normaloff>:/pictures/musicbrainz.png</iconset>
-                </property>
-                <property name="iconSize">
-                 <size>
-                  <width>38</width>
-                  <height>22</height>
-                 </size>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="3">
-               <widget class="SpinBox" name="disc">
-                <property name="correctionMode">
-                 <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
-                </property>
-                <property name="maximum">
-                 <number>9999</number>
-                </property>
-                <property name="has_clear_button" stdset="0">
-                 <bool>false</bool>
-                </property>
-                <property name="has_reset_button" stdset="0">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="15" column="1">
-               <widget class="CheckBox" name="compilation">
-                <property name="has_reset_button" stdset="0">
-                 <bool>true</bool>
-                </property>
-                <property name="has_clear_button" stdset="0">
-                 <bool>false</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="14" column="0">
+              <item row="18" column="0">
                <widget class="QLabel" name="label_genre">
                 <property name="minimumSize">
                  <size>
@@ -967,7 +1194,17 @@
                 </property>
                </widget>
               </item>
-              <item row="22" column="0">
+              <item row="10" column="1">
+               <widget class="LineEdit" name="composer">
+                <property name="has_reset_button" stdset="0">
+                 <bool>true</bool>
+                </property>
+                <property name="has_clear_button" stdset="0">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="26" column="0">
                <widget class="QLabel" name="label_comment">
                 <property name="minimumSize">
                  <size>
@@ -983,47 +1220,8 @@
                 </property>
                </widget>
               </item>
-              <item row="4" column="1">
-               <widget class="LineEdit" name="album">
-                <property name="has_reset_button" stdset="0">
-                 <bool>true</bool>
-                </property>
-                <property name="has_clear_button" stdset="0">
-                 <bool>false</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="1">
-               <widget class="LineEdit" name="albumartist">
-                <property name="has_reset_button" stdset="0">
-                 <bool>true</bool>
-                </property>
-                <property name="has_clear_button" stdset="0">
-                 <bool>false</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="22" column="1">
-               <widget class="TextEdit" name="comment">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="tabChangesFocus">
-                 <bool>true</bool>
-                </property>
-                <property name="has_reset_button" stdset="0">
-                 <bool>true</bool>
-                </property>
-                <property name="has_clear_button" stdset="0">
-                 <bool>false</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="9" column="0">
-               <widget class="QLabel" name="label_performer">
+              <item row="11" column="0">
+               <widget class="QLabel" name="label_composersort">
                 <property name="minimumSize">
                  <size>
                   <width>80</width>
@@ -1031,57 +1229,15 @@
                  </size>
                 </property>
                 <property name="text">
-                 <string>Performer</string>
+                 <string>Composer sort</string>
                 </property>
                 <property name="buddy">
-                 <cstring>performer</cstring>
+                 <cstring>composersort</cstring>
                 </property>
                </widget>
               </item>
-              <item row="15" column="0">
-               <widget class="QLabel" name="label_compilation">
-                <property name="minimumSize">
-                 <size>
-                  <width>80</width>
-                  <height>0</height>
-                 </size>
-                </property>
-                <property name="text">
-                 <string>Compilation</string>
-                </property>
-                <property name="buddy">
-                 <cstring>compilation</cstring>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="2">
-               <widget class="QLabel" name="label_track">
-                <property name="text">
-                 <string>Track</string>
-                </property>
-                <property name="buddy">
-                 <cstring>track</cstring>
-                </property>
-               </widget>
-              </item>
-              <item row="16" column="0">
-               <widget class="QLabel" name="label_rating">
-                <property name="text">
-                 <string>Rating</string>
-                </property>
-                <property name="buddy">
-                 <cstring>rating</cstring>
-                </property>
-               </widget>
-              </item>
-              <item row="16" column="1">
-               <widget class="RatingBox" name="rating" native="true">
-                <property name="maximumSize">
-                 <size>
-                  <width>140</width>
-                  <height>16777215</height>
-                 </size>
-                </property>
+              <item row="6" column="1">
+               <widget class="LineEdit" name="albumsort">
                 <property name="has_reset_button" stdset="0">
                  <bool>true</bool>
                 </property>
@@ -1147,12 +1303,12 @@
               </property>
              </widget>
             </item>
-            <item row="21" column="1">
-              <widget class="QPushButton" name="fetch_lyrics">
-                <property name="text">
-                  <string>Complete lyrics automatically</string>
-                </property>
-              </widget>
+            <item>
+             <widget class="QPushButton" name="fetch_lyrics">
+              <property name="text">
+               <string>Complete lyrics automatically</string>
+              </property>
+             </widget>
             </item>
            </layout>
           </widget>
@@ -1215,25 +1371,32 @@
   <tabstop>summary</tabstop>
   <tabstop>filename</tabstop>
   <tabstop>path</tabstop>
+  <tabstop>art_embedded</tabstop>
   <tabstop>art_manual</tabstop>
   <tabstop>art_automatic</tabstop>
+  <tabstop>art_unset</tabstop>
   <tabstop>playcount_reset</tabstop>
   <tabstop>tags_summary</tabstop>
   <tabstop>tags_art_button</tabstop>
   <tabstop>checkbox_embedded_cover</tabstop>
   <tabstop>title</tabstop>
   <tabstop>track</tabstop>
-  <tabstop>artist</tabstop>
+  <tabstop>titlesort</tabstop>
   <tabstop>disc</tabstop>
-  <tabstop>album</tabstop>
+  <tabstop>artist</tabstop>
   <tabstop>year</tabstop>
+  <tabstop>artistsort</tabstop>
+  <tabstop>album</tabstop>
+  <tabstop>albumsort</tabstop>
   <tabstop>albumartist</tabstop>
+  <tabstop>albumartistsort</tabstop>
   <tabstop>composer</tabstop>
+  <tabstop>composersort</tabstop>
   <tabstop>performer</tabstop>
+  <tabstop>performersort</tabstop>
   <tabstop>grouping</tabstop>
   <tabstop>genre</tabstop>
   <tabstop>compilation</tabstop>
-  <tabstop>rating</tabstop>
   <tabstop>fetch_tag</tabstop>
   <tabstop>comment</tabstop>
   <tabstop>lyrics</tabstop>

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -219,11 +219,17 @@ bool Playlist::column_is_editable(const Playlist::Column column) {
 
   switch (column) {
     case Column::Title:
+    case Column::TitleSort:
     case Column::Artist:
+    case Column::ArtistSort:
     case Column::Album:
+    case Column::AlbumSort:
     case Column::AlbumArtist:
+    case Column::AlbumArtistSort:
     case Column::Composer:
+    case Column::ComposerSort:
     case Column::Performer:
+    case Column::PerformerSort:
     case Column::Grouping:
     case Column::Track:
     case Column::Disc:
@@ -247,20 +253,38 @@ bool Playlist::set_column_value(Song &song, const Playlist::Column column, const
     case Column::Title:
       song.set_title(value.toString());
       break;
+    case Column::TitleSort:
+      song.set_titlesort(value.toString());
+      break;
     case Column::Artist:
       song.set_artist(value.toString());
+      break;
+    case Column::ArtistSort:
+      song.set_artistsort(value.toString());
       break;
     case Column::Album:
       song.set_album(value.toString());
       break;
+    case Column::AlbumSort:
+      song.set_albumsort(value.toString());
+      break;
     case Column::AlbumArtist:
       song.set_albumartist(value.toString());
+      break;
+    case Column::AlbumArtistSort:
+      song.set_albumartistsort(value.toString());
       break;
     case Column::Composer:
       song.set_composer(value.toString());
       break;
+    case Column::ComposerSort:
+      song.set_composersort(value.toString());
+      break;
     case Column::Performer:
       song.set_performer(value.toString());
+      break;
+    case Column::PerformerSort:
+      song.set_performersort(value.toString());
       break;
     case Column::Grouping:
       song.set_grouping(value.toString());
@@ -319,8 +343,11 @@ QVariant Playlist::data(const QModelIndex &idx, const int role) const {
       // Don't forget to change Playlist::CompareItems when adding new columns
       switch (static_cast<Column>(idx.column())) {
         case Column::Title:              return song.PrettyTitle();
+        case Column::TitleSort:          return song.titlesort();
         case Column::Artist:             return song.artist();
+        case Column::ArtistSort:         return song.artistsort();
         case Column::Album:              return song.album();
+        case Column::AlbumSort:          return song.albumsort();
         case Column::Length:             return song.length_nanosec();
         case Column::Track:              return song.track();
         case Column::Disc:               return song.disc();
@@ -328,8 +355,11 @@ QVariant Playlist::data(const QModelIndex &idx, const int role) const {
         case Column::OriginalYear:       return song.effective_originalyear();
         case Column::Genre:              return song.genre();
         case Column::AlbumArtist:        return song.playlist_albumartist();
+        case Column::AlbumArtistSort:    return song.albumartistsort();
         case Column::Composer:           return song.composer();
+        case Column::ComposerSort:       return song.composersort();
         case Column::Performer:          return song.performer();
+        case Column::PerformerSort:      return song.performersort();
         case Column::Grouping:           return song.grouping();
 
         case Column::PlayCount:          return song.playcount();
@@ -1326,8 +1356,11 @@ bool Playlist::CompareItems(const Column column, const Qt::SortOrder order, Play
 
   switch (column) {
     case Column::Title:        strcmp(title_sortable);
+    case Column::TitleSort:    strcmp(titlesort);
     case Column::Artist:       strcmp(artist_sortable);
+    case Column::ArtistSort:   strcmp(artistsort);
     case Column::Album:        strcmp(album_sortable);
+    case Column::AlbumSort:    strcmp(albumsort);
     case Column::Length:       cmp(length_nanosec);
     case Column::Track:        cmp(track);
     case Column::Disc:         cmp(disc);
@@ -1335,8 +1368,11 @@ bool Playlist::CompareItems(const Column column, const Qt::SortOrder order, Play
     case Column::OriginalYear: cmp(effective_originalyear);
     case Column::Genre:        strcmp(genre);
     case Column::AlbumArtist:  strcmp(playlist_albumartist_sortable);
+    case Column::AlbumArtistSort:  strcmp(albumartistsort);
     case Column::Composer:     strcmp(composer);
+    case Column::ComposerSort: strcmp(composersort);
     case Column::Performer:    strcmp(performer);
+    case Column::PerformerSort: strcmp(performersort);
     case Column::Grouping:     strcmp(grouping);
 
     case Column::PlayCount:    cmp(playcount);
@@ -1380,8 +1416,11 @@ QString Playlist::column_name(const Column column) {
 
   switch (column) {
     case Column::Title:        return tr("Title");
+    case Column::TitleSort:    return tr("Title Sort");
     case Column::Artist:       return tr("Artist");
+    case Column::ArtistSort:   return tr("Artist Sort");
     case Column::Album:        return tr("Album");
+    case Column::AlbumSort:    return tr("Album Sort");
     case Column::Track:        return tr("Track");
     case Column::Disc:         return tr("Disc");
     case Column::Length:       return tr("Length");
@@ -1389,8 +1428,11 @@ QString Playlist::column_name(const Column column) {
     case Column::OriginalYear: return tr("Original Year");
     case Column::Genre:        return tr("Genre");
     case Column::AlbumArtist:  return tr("Album Artist");
+    case Column::AlbumArtistSort: return tr("Album Artist Sort");
     case Column::Composer:     return tr("Composer");
+    case Column::ComposerSort: return tr("Composer Sort");
     case Column::Performer:    return tr("Performer");
+    case Column::PerformerSort: return tr("Performer Sort");
     case Column::Grouping:     return tr("Grouping");
 
     case Column::PlayCount:    return tr("Play Count");
@@ -2109,20 +2151,38 @@ Playlist::Columns Playlist::ChangedColumns(const Song &metadata1, const Song &me
   if (metadata1.title() != metadata2.title()) {
     columns << Column::Title;
   }
+  if (metadata1.titlesort() != metadata2.titlesort()) {
+    columns << Column::TitleSort;
+  }
   if (metadata1.artist() != metadata2.artist()) {
     columns << Column::Artist;
+  }
+  if (metadata1.artistsort() != metadata2.artistsort()) {
+    columns << Column::ArtistSort;
   }
   if (metadata1.album() != metadata2.album()) {
     columns << Column::Album;
   }
+  if (metadata1.albumsort() != metadata2.albumsort()) {
+    columns << Column::AlbumSort;
+  }
   if (metadata1.effective_albumartist() != metadata2.effective_albumartist()) {
     columns << Column::AlbumArtist;
+  }
+  if (metadata1.albumartistsort() != metadata2.albumartistsort()) {
+    columns << Column::AlbumArtistSort;
   }
   if (metadata1.performer() != metadata2.performer()) {
     columns << Column::Performer;
   }
+  if (metadata1.performersort() != metadata2.performersort()) {
+    columns << Column::PerformerSort;
+  }
   if (metadata1.composer() != metadata2.composer()) {
     columns << Column::Composer;
+  }
+  if (metadata1.composersort() != metadata2.composersort()) {
+    columns << Column::ComposerSort;
   }
   if (metadata1.year() != metadata2.year()) {
     columns << Column::Year;

--- a/src/playlist/playlist.h
+++ b/src/playlist/playlist.h
@@ -101,11 +101,17 @@ class Playlist : public QAbstractListModel {
   // Always add new columns to the end of this enum - the values are persisted
   enum class Column {
     Title = 0,
+    TitleSort,
     Artist,
+    ArtistSort,
     Album,
+    AlbumSort,
     AlbumArtist,
+    AlbumArtistSort,
     Performer,
+    PerformerSort,
     Composer,
+    ComposerSort,
     Year,
     OriginalYear,
     Track,

--- a/src/playlist/playlistdelegates.cpp
+++ b/src/playlist/playlistdelegates.cpp
@@ -387,13 +387,19 @@ TagCompletionModel::TagCompletionModel(SharedPtr<CollectionBackend> backend, con
 QString TagCompletionModel::database_column(const Playlist::Column column) {
 
   switch (column) {
-    case Playlist::Column::Artist:       return u"artist"_s;
-    case Playlist::Column::Album:        return u"album"_s;
-    case Playlist::Column::AlbumArtist:  return u"albumartist"_s;
-    case Playlist::Column::Composer:     return u"composer"_s;
-    case Playlist::Column::Performer:    return u"performer"_s;
-    case Playlist::Column::Grouping:     return u"grouping"_s;
-    case Playlist::Column::Genre:        return u"genre"_s;
+    case Playlist::Column::Artist:          return u"artist"_s;
+    case Playlist::Column::ArtistSort:      return u"artistsort"_s;
+    case Playlist::Column::Album:           return u"album"_s;
+    case Playlist::Column::AlbumSort:       return u"albumsort"_s;
+    case Playlist::Column::AlbumArtist:     return u"albumartist"_s;
+    case Playlist::Column::AlbumArtistSort: return u"albumartistsort"_s;
+    case Playlist::Column::Composer:        return u"composer"_s;
+    case Playlist::Column::ComposerSort:    return u"composersort"_s;
+    case Playlist::Column::Performer:       return u"performer"_s;
+    case Playlist::Column::PerformerSort:   return u"performersort"_s;
+    case Playlist::Column::Grouping:        return u"grouping"_s;
+    case Playlist::Column::Genre:           return u"genre"_s;
+    case Playlist::Column::TitleSort:       return u"titlesort"_s;
     default:
       qLog(Warning) << "Unknown column" << static_cast<int>(column);
       return QString();

--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -87,6 +87,7 @@ constexpr int kGlowIntensitySteps = 24;
 constexpr int kAutoscrollGraceTimeout = 30;  // seconds
 constexpr int kDropIndicatorWidth = 2;
 constexpr int kDropIndicatorGradientWidth = 5;
+constexpr int kHeaderStateVersion = 2;
 }  // namespace
 
 PlaylistView::PlaylistView(QWidget *parent)
@@ -131,7 +132,6 @@ PlaylistView::PlaylistView(QWidget *parent)
       cached_current_row_row_(-1),
       drop_indicator_row_(-1),
       drag_over_(false),
-      header_state_version_(1),
       column_alignment_(DefaultColumnAlignment()),
       rating_locked_(false),
       dynamic_controls_(new DynamicPlaylistControls(this)),
@@ -217,12 +217,18 @@ void PlaylistView::SetItemDelegates() {
   setItemDelegate(new PlaylistDelegateBase(this));
 
   setItemDelegateForColumn(static_cast<int>(Playlist::Column::Title), new TextItemDelegate(this));
+  setItemDelegateForColumn(static_cast<int>(Playlist::Column::TitleSort), new TagCompletionItemDelegate(this, collection_backend_, Playlist::Column::TitleSort));
   setItemDelegateForColumn(static_cast<int>(Playlist::Column::Album), new TagCompletionItemDelegate(this, collection_backend_, Playlist::Column::Album));
+  setItemDelegateForColumn(static_cast<int>(Playlist::Column::AlbumSort), new TagCompletionItemDelegate(this, collection_backend_, Playlist::Column::AlbumSort));
   setItemDelegateForColumn(static_cast<int>(Playlist::Column::Artist), new TagCompletionItemDelegate(this, collection_backend_, Playlist::Column::Artist));
+  setItemDelegateForColumn(static_cast<int>(Playlist::Column::ArtistSort), new TagCompletionItemDelegate(this, collection_backend_, Playlist::Column::ArtistSort));
   setItemDelegateForColumn(static_cast<int>(Playlist::Column::AlbumArtist), new TagCompletionItemDelegate(this, collection_backend_, Playlist::Column::AlbumArtist));
+  setItemDelegateForColumn(static_cast<int>(Playlist::Column::AlbumArtistSort), new TagCompletionItemDelegate(this, collection_backend_, Playlist::Column::AlbumArtistSort));
   setItemDelegateForColumn(static_cast<int>(Playlist::Column::Genre), new TagCompletionItemDelegate(this, collection_backend_, Playlist::Column::Genre));
   setItemDelegateForColumn(static_cast<int>(Playlist::Column::Composer), new TagCompletionItemDelegate(this, collection_backend_, Playlist::Column::Composer));
+  setItemDelegateForColumn(static_cast<int>(Playlist::Column::ComposerSort), new TagCompletionItemDelegate(this, collection_backend_, Playlist::Column::ComposerSort));
   setItemDelegateForColumn(static_cast<int>(Playlist::Column::Performer), new TagCompletionItemDelegate(this, collection_backend_, Playlist::Column::Performer));
+  setItemDelegateForColumn(static_cast<int>(Playlist::Column::PerformerSort), new TagCompletionItemDelegate(this, collection_backend_, Playlist::Column::PerformerSort));
   setItemDelegateForColumn(static_cast<int>(Playlist::Column::Grouping), new TagCompletionItemDelegate(this, collection_backend_, Playlist::Column::Grouping));
   setItemDelegateForColumn(static_cast<int>(Playlist::Column::Length), new LengthItemDelegate(this));
   setItemDelegateForColumn(static_cast<int>(Playlist::Column::Filesize), new SizeItemDelegate(this));
@@ -304,11 +310,24 @@ void PlaylistView::LoadHeaderState() {
 
   Settings s;
   s.beginGroup(PlaylistSettings::kSettingsGroup);
+  // since we use serialized internal data structures, we cannot read anything but the current version
+  const int header_state_version_ = s.value(PlaylistSettings::kStateVersion, 0).toInt();
   if (s.contains(PlaylistSettings::kState)) {
-    header_state_version_ = s.value(PlaylistSettings::kStateVersion, 0).toInt();
-    header_state_ = s.value(PlaylistSettings::kState).toByteArray();
+    if (header_state_version_ == kHeaderStateVersion) {
+      header_state_ = s.value(PlaylistSettings::kState).toByteArray();
+    } else {
+      // force header state reset since column indices may have changed between versions
+      header_state_.clear();
+    }
   }
-  if (s.contains(PlaylistSettings::kColumnAlignments)) column_alignment_ = s.value(PlaylistSettings::kColumnAlignments).value<ColumnAlignmentMap>();
+  if (s.contains(PlaylistSettings::kColumnAlignments)) {
+    if (header_state_version_ == kHeaderStateVersion) {
+      column_alignment_ = s.value(PlaylistSettings::kColumnAlignments).value<ColumnAlignmentMap>();
+    } else {
+      // force column alignment reset since column indices may have changed between versions
+      column_alignment_.clear();
+    }
+  }
   s.endGroup();
 
   if (column_alignment_.isEmpty()) {
@@ -329,7 +348,6 @@ void PlaylistView::SetHeaderState() {
 void PlaylistView::ResetHeaderState() {
 
   set_initial_header_layout_ = true;
-  header_state_version_ = 1;
   header_state_ = header_->ResetState();
   RestoreHeaderState();
 
@@ -347,9 +365,15 @@ void PlaylistView::RestoreHeaderState() {
 
     header_->SetStretchEnabled(true);
 
+    header_->HideSection(static_cast<int>(Playlist::Column::TitleSort));
+    header_->HideSection(static_cast<int>(Playlist::Column::ArtistSort));
+    header_->HideSection(static_cast<int>(Playlist::Column::AlbumSort));
     header_->HideSection(static_cast<int>(Playlist::Column::AlbumArtist));
+    header_->HideSection(static_cast<int>(Playlist::Column::AlbumArtistSort));
     header_->HideSection(static_cast<int>(Playlist::Column::Performer));
+    header_->HideSection(static_cast<int>(Playlist::Column::PerformerSort));
     header_->HideSection(static_cast<int>(Playlist::Column::Composer));
+    header_->HideSection(static_cast<int>(Playlist::Column::ComposerSort));
     header_->HideSection(static_cast<int>(Playlist::Column::Year));
     header_->HideSection(static_cast<int>(Playlist::Column::OriginalYear));
     header_->HideSection(static_cast<int>(Playlist::Column::Disc));
@@ -398,11 +422,6 @@ void PlaylistView::RestoreHeaderState() {
 
     set_initial_header_layout_ = false;
 
-  }
-
-  if (header_state_version_ < 1) {
-    header_->HideSection(static_cast<int>(Playlist::Column::Rating));
-    header_state_version_ = 1;
   }
 
   // Make sure at least one column is visible
@@ -1305,7 +1324,7 @@ void PlaylistView::SaveSettings() {
 
   Settings s;
   s.beginGroup(PlaylistSettings::kSettingsGroup);
-  s.setValue(PlaylistSettings::kStateVersion, header_state_version_);
+  s.setValue(PlaylistSettings::kStateVersion, kHeaderStateVersion);
   s.setValue(PlaylistSettings::kState, header_->SaveState());
   s.setValue(PlaylistSettings::kColumnAlignments, QVariant::fromValue<ColumnAlignmentMap>(column_alignment_));
   s.setValue(PlaylistSettings::kRatingLocked, rating_locked_);

--- a/src/playlist/playlistview.h
+++ b/src/playlist/playlistview.h
@@ -284,7 +284,6 @@ class PlaylistView : public QTreeView {
   int drop_indicator_row_;
   bool drag_over_;
 
-  int header_state_version_;
   QByteArray header_state_;
   ColumnAlignmentMap column_alignment_;
   bool rating_locked_;

--- a/src/settings/collectionsettingspage.cpp
+++ b/src/settings/collectionsettingspage.cpp
@@ -87,6 +87,11 @@ CollectionSettingsPage::CollectionSettingsPage(SettingsDialog *dialog,
   setWindowIcon(IconLoader::Load(u"library-music"_s, true, 0, 32));
   ui_->add_directory->setIcon(IconLoader::Load(u"document-open-folder"_s));
 
+  ui_->combobox_sort->setItemData(0, static_cast<int>(SortBehaviour::AsIs));
+  ui_->combobox_sort->setItemData(1, static_cast<int>(SortBehaviour::SkipArticles));
+  ui_->combobox_sort->setItemData(2, static_cast<int>(SortBehaviour::UseSortTagForSort));
+  ui_->combobox_sort->setItemData(3, static_cast<int>(SortBehaviour::UseSortTagForDisplayAndSort));
+
   ui_->combobox_cache_size->addItem(u"KB"_s, static_cast<int>(CacheSizeUnit::KB));
   ui_->combobox_cache_size->addItem(u"MB"_s, static_cast<int>(CacheSizeUnit::MB));
 
@@ -152,7 +157,7 @@ void CollectionSettingsPage::Load() {
   ui_->show_dividers->setChecked(s.value(kShowDividers, true).toBool());
   ui_->pretty_covers->setChecked(s.value(kPrettyCovers, true).toBool());
   ui_->various_artists->setChecked(s.value(kVariousArtists, true).toBool());
-  ui_->sort_skips_articles->setChecked(s.value(kSortSkipsArticles, true).toBool());
+  ui_->combobox_sort->setCurrentIndex(ui_->combobox_sort->findData(s.value(kSortBehaviour, static_cast<int>(SortBehaviour::SkipArticles)).toInt()));
   ui_->startup_scan->setChecked(s.value(kStartupScan, true).toBool());
   ui_->monitor->setChecked(s.value(kMonitor, true).toBool());
   ui_->song_tracking->setChecked(s.value(kSongTracking, false).toBool());
@@ -196,7 +201,8 @@ void CollectionSettingsPage::Save() {
   s.setValue(kShowDividers, ui_->show_dividers->isChecked());
   s.setValue(kPrettyCovers, ui_->pretty_covers->isChecked());
   s.setValue(kVariousArtists, ui_->various_artists->isChecked());
-  s.setValue(kSortSkipsArticles, ui_->sort_skips_articles->isChecked());
+  const SortBehaviour menu_sort = static_cast<SortBehaviour>(ui_->combobox_sort->currentData().toInt());
+  s.setValue(kSortBehaviour, static_cast<int>(menu_sort));
   s.setValue(kStartupScan, ui_->startup_scan->isChecked());
   s.setValue(kMonitor, ui_->monitor->isChecked());
   s.setValue(kSongTracking, ui_->song_tracking->isChecked());

--- a/src/settings/collectionsettingspage.ui
+++ b/src/settings/collectionsettingspage.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>565</width>
-    <height>1003</height>
+    <width>604</width>
+    <height>1035</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -235,11 +235,37 @@ If there are no matches then it will use the largest image in the directory.</st
         </property>
        </widget>
       </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupbox_sort">
+     <property name="title">
+      <string>When sorting names like &quot;The Beatles&quot;...</string>
+     </property>
+     <layout class="QVBoxLayout" name="layout_sort">
       <item>
-       <widget class="QCheckBox" name="sort_skips_articles">
-        <property name="text">
-         <string>Skip leading articles (&quot;the&quot;, &quot;a&quot;, &quot;an&quot;) when sorting artist names</string>
-        </property>
+       <widget class="QComboBox" name="combobox_sort">
+        <item>
+         <property name="text">
+          <string>Sort and show name as is</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Skip articles &quot;The, A, An&quot; for sorting but show name as is</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Use sort tag for sorting and show name as is</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Use sort tag for sorting and display</string>
+         </property>
+        </item>
        </widget>
       </item>
      </layout>
@@ -525,7 +551,7 @@ If there are no matches then it will use the largest image in the directory.</st
   <tabstop>show_dividers</tabstop>
   <tabstop>pretty_covers</tabstop>
   <tabstop>various_artists</tabstop>
-  <tabstop>sort_skips_articles</tabstop>
+  <tabstop>combobox_sort</tabstop>
   <tabstop>spinbox_cache_size</tabstop>
   <tabstop>combobox_cache_size</tabstop>
   <tabstop>checkbox_disk_cache</tabstop>

--- a/src/settings/contextsettingspage.cpp
+++ b/src/settings/contextsettingspage.cpp
@@ -64,15 +64,21 @@ ContextSettingsPage::ContextSettingsPage(SettingsDialog *dialog, QWidget *parent
   // Create and populate the helper menus
   QMenu *menu = new QMenu(this);
   menu->addAction(ui_->action_title);
+  menu->addAction(ui_->action_titlesort);
   menu->addAction(ui_->action_album);
+  menu->addAction(ui_->action_albumsort);
   menu->addAction(ui_->action_artist);
+  menu->addAction(ui_->action_artistsort);
   menu->addAction(ui_->action_albumartist);
+  menu->addAction(ui_->action_albumartistsort);
   menu->addAction(ui_->action_track);
   menu->addAction(ui_->action_disc);
   menu->addAction(ui_->action_year);
   menu->addAction(ui_->action_originalyear);
   menu->addAction(ui_->action_composer);
+  menu->addAction(ui_->action_composersort);
   menu->addAction(ui_->action_performer);
+  menu->addAction(ui_->action_performersort);
   menu->addAction(ui_->action_grouping);
   menu->addAction(ui_->action_filename);
   menu->addAction(ui_->action_url);

--- a/src/settings/contextsettingspage.ui
+++ b/src/settings/contextsettingspage.ui
@@ -486,6 +486,54 @@
     <string>Add song original year tag</string>
    </property>
   </action>
+  <action name="action_artistsort">
+   <property name="text">
+    <string>%artistsort%</string>
+   </property>
+   <property name="toolTip">
+    <string>Add song artistsort tag</string>
+   </property>
+  </action>
+  <action name="action_albumartistsort">
+   <property name="text">
+    <string>%albumartistsort%</string>
+   </property>
+   <property name="toolTip">
+    <string>Add song albumartistsort tag</string>
+   </property>
+  </action>
+  <action name="action_titlesort">
+   <property name="text">
+    <string>%titlesort%</string>
+   </property>
+   <property name="toolTip">
+    <string>Add song titlesort tag</string>
+   </property>
+  </action>
+  <action name="action_composersort">
+   <property name="text">
+    <string>%composersort%</string>
+   </property>
+   <property name="toolTip">
+    <string>Add song composersort tag</string>
+   </property>
+  </action>
+  <action name="action_performersort">
+   <property name="text">
+    <string>%performersort%</string>
+   </property>
+   <property name="toolTip">
+    <string>Add song performersort tag</string>
+   </property>
+  </action>
+  <action name="action_albumsort">
+   <property name="text">
+    <string>%albumsort%</string>
+   </property>
+   <property name="toolTip">
+    <string>Add song albumsort tag</string>
+   </property>
+  </action>
  </widget>
  <resources/>
  <connections/>

--- a/src/smartplaylists/smartplaylistsearchterm.cpp
+++ b/src/smartplaylists/smartplaylistsearchterm.cpp
@@ -353,6 +353,18 @@ QString SmartPlaylistSearchTerm::FieldColumnName(const Field field) {
       return u"bitdepth"_s;
     case Field::Bitrate:
       return u"bitrate"_s;
+    case Field::ArtistSort:
+      return u"artistsort"_s;
+    case Field::AlbumArtistSort:
+      return u"albumartistsort"_s;
+    case Field::AlbumSort:
+      return u"albumsort"_s;
+    case Field::ComposerSort:
+      return u"composersort"_s;
+    case Field::PerformerSort:
+      return u"performersort"_s;
+    case Field::TitleSort:
+      return u"titlesort"_s;
     case Field::FieldCount:
       Q_ASSERT(0);
   }
@@ -415,6 +427,18 @@ QString SmartPlaylistSearchTerm::FieldName(const Field field) {
       return Playlist::column_name(Playlist::Column::Bitdepth);
     case Field::Bitrate:
       return Playlist::column_name(Playlist::Column::Bitrate);
+    case Field::ArtistSort:
+      return Playlist::column_name(Playlist::Column::ArtistSort);
+    case Field::AlbumArtistSort:
+      return Playlist::column_name(Playlist::Column::AlbumArtistSort);
+    case Field::AlbumSort:
+      return Playlist::column_name(Playlist::Column::AlbumSort);
+    case Field::ComposerSort:
+      return Playlist::column_name(Playlist::Column::ComposerSort);
+    case Field::PerformerSort:
+      return Playlist::column_name(Playlist::Column::PerformerSort);
+    case Field::TitleSort:
+      return Playlist::column_name(Playlist::Column::TitleSort);
     case Field::FieldCount:
       Q_ASSERT(0);
   }

--- a/src/smartplaylists/smartplaylistsearchterm.h
+++ b/src/smartplaylists/smartplaylistsearchterm.h
@@ -59,6 +59,12 @@ class SmartPlaylistSearchTerm {
     Samplerate,
     Bitdepth,
     Bitrate,
+    ArtistSort,
+    AlbumArtistSort,
+    AlbumSort,
+    ComposerSort,
+    PerformerSort,
+    TitleSort,
     FieldCount
   };
 

--- a/src/smartplaylists/smartplaylistsearchtermwidget.cpp
+++ b/src/smartplaylists/smartplaylistsearchtermwidget.cpp
@@ -162,11 +162,30 @@ void SmartPlaylistSearchTermWidget::FieldChanged(int index) {
     case SmartPlaylistSearchTerm::Field::Artist:
       new TagCompleter(collection_backend_, Playlist::Column::Artist, ui_->value_text);
       break;
-
+    case SmartPlaylistSearchTerm::Field::ArtistSort:
+      new TagCompleter(collection_backend_, Playlist::Column::ArtistSort, ui_->value_text);
+      break;
     case SmartPlaylistSearchTerm::Field::Album:
       new TagCompleter(collection_backend_, Playlist::Column::Album, ui_->value_text);
       break;
-
+    case SmartPlaylistSearchTerm::Field::AlbumSort:
+      new TagCompleter(collection_backend_, Playlist::Column::AlbumSort, ui_->value_text);
+      break;
+    case SmartPlaylistSearchTerm::Field::AlbumArtist:
+      new TagCompleter(collection_backend_, Playlist::Column::AlbumArtist, ui_->value_text);
+      break;
+    case SmartPlaylistSearchTerm::Field::AlbumArtistSort:
+      new TagCompleter(collection_backend_, Playlist::Column::AlbumArtistSort, ui_->value_text);
+      break;
+    case SmartPlaylistSearchTerm::Field::ComposerSort:
+      new TagCompleter(collection_backend_, Playlist::Column::ComposerSort, ui_->value_text);
+      break;
+    case SmartPlaylistSearchTerm::Field::PerformerSort:
+      new TagCompleter(collection_backend_, Playlist::Column::PerformerSort, ui_->value_text);
+      break;
+    case SmartPlaylistSearchTerm::Field::TitleSort:
+      new TagCompleter(collection_backend_, Playlist::Column::TitleSort, ui_->value_text);
+      break;
     default:
       ui_->value_text->setCompleter(nullptr);
   }

--- a/src/streaming/streamingsearchmodel.cpp
+++ b/src/streaming/streamingsearchmodel.cpp
@@ -97,7 +97,7 @@ QStandardItem *StreamingSearchModel::BuildContainers(const Song &s, QStandardIte
       }
       else {
         display_text = CollectionModel::TextOrUnknown(s.effective_albumartist());
-        sort_text = CollectionModel::SortTextForArtist(s.effective_albumartist(), true);
+        sort_text = CollectionModel::SortTextSkipArticles(s.effective_albumartist());
       }
       has_artist_icon = true;
       break;
@@ -109,14 +109,14 @@ QStandardItem *StreamingSearchModel::BuildContainers(const Song &s, QStandardIte
       }
       else {
         display_text = CollectionModel::TextOrUnknown(s.artist());
-        sort_text = CollectionModel::SortTextForArtist(s.artist(), true);
+        sort_text = CollectionModel::SortTextSkipArticles(s.artist());
       }
       has_artist_icon = true;
       break;
 
     case CollectionModel::GroupBy::Album:
       display_text = CollectionModel::TextOrUnknown(s.album());
-      sort_text = CollectionModel::SortTextForArtist(s.album(), true);
+      sort_text = CollectionModel::SortTextSkipArticles(s.album());
       unique_tag = s.album_id();
       has_album_icon = true;
       break;
@@ -170,7 +170,7 @@ QStandardItem *StreamingSearchModel::BuildContainers(const Song &s, QStandardIte
 
     case CollectionModel::GroupBy::Disc:
       display_text = CollectionModel::PrettyDisc(s.disc());
-      sort_text = CollectionModel::SortTextForArtist(display_text, true);
+      sort_text = CollectionModel::SortTextSkipArticles(display_text);
       has_album_icon = true;
       break;
 
@@ -190,25 +190,25 @@ QStandardItem *StreamingSearchModel::BuildContainers(const Song &s, QStandardIte
 
     case CollectionModel::GroupBy::Genre:
       display_text = CollectionModel::TextOrUnknown(s.genre());
-      sort_text = CollectionModel::SortTextForArtist(s.genre(), true);
+      sort_text = CollectionModel::SortTextSkipArticles(s.genre());
       has_album_icon = true;
       break;
 
     case CollectionModel::GroupBy::Composer:
       display_text = CollectionModel::TextOrUnknown(s.composer());
-      sort_text = CollectionModel::SortTextForArtist(s.composer(), true);
+      sort_text = CollectionModel::SortTextSkipArticles(s.composer());
       has_album_icon = true;
       break;
 
     case CollectionModel::GroupBy::Performer:
       display_text = CollectionModel::TextOrUnknown(s.performer());
-      sort_text = CollectionModel::SortTextForArtist(s.performer(), true);
+      sort_text = CollectionModel::SortTextSkipArticles(s.performer());
       has_album_icon = true;
       break;
 
     case CollectionModel::GroupBy::Grouping:
       display_text = CollectionModel::TextOrUnknown(s.grouping());
-      sort_text = CollectionModel::SortTextForArtist(s.grouping(), true);
+      sort_text = CollectionModel::SortTextSkipArticles(s.grouping());
       has_album_icon = true;
       break;
 

--- a/src/tagreader/tagreadertaglib.cpp
+++ b/src/tagreader/tagreadertaglib.cpp
@@ -114,8 +114,13 @@ using namespace Qt::Literals::StringLiterals;
 namespace {
 
 constexpr char kID3v2_AlbumArtist[] = "TPE2";
+constexpr char kID3v2_AlbumArtistSort[] = "TSO2";
+constexpr char kID3v2_AlbumSort[] = "TSOA";
+constexpr char kID3v2_ArtistSort[] = "TSOP";
+constexpr char kID3v2_TitleSort[] = "TSOT";
 constexpr char kID3v2_Disc[] = "TPOS";
 constexpr char kID3v2_Composer[] = "TCOM";
+constexpr char kID3v2_ComposerSort[] = "TSOC";
 constexpr char kID3v2_Performer[] = "TOPE";
 constexpr char kID3v2_Grouping[] = "TIT1";
 constexpr char kID3v2_Compilation[] = "TCMP";
@@ -143,8 +148,14 @@ constexpr char kID3v2_MusicBrainz_WorkId[] = "MusicBrainz Work Id";
 
 constexpr char kVorbisComment_AlbumArtist1[] = "ALBUMARTIST";
 constexpr char kVorbisComment_AlbumArtist2[] = "ALBUM ARTIST";
+constexpr char kVorbisComment_AlbumArtistSort[] = "ALBUMARTISTSORT";
+constexpr char kVorbisComment_AlbumSort[] = "ALBUMSORT";
+constexpr char kVorbisComment_ArtistSort[] = "ARTISTSORT";
+constexpr char kVorbisComment_TitleSort[] = "TITLESORT";
 constexpr char kVorbisComment_Composer[] = "COMPOSER";
+constexpr char kVorbisComment_ComposerSort[] = "COMPOSERSORT";
 constexpr char kVorbisComment_Performer[] = "PERFORMER";
+constexpr char kVorbisComment_PerformerSort[] = "PERFORMERSORT";
 constexpr char kVorbisComment_Grouping1[] = "GROUPING";
 constexpr char kVorbisComment_Grouping2[] = "CONTENT GROUP";
 constexpr char kVorbisComment_OriginalYear1[] = "ORIGINALDATE";
@@ -589,6 +600,7 @@ void TagReaderTagLib::ParseID3v2Tags(TagLib::ID3v2::Tag *tag, QString *disc, QSt
 
   if (map.contains(kID3v2_Disc)) *disc = TagLibStringToQString(map[kID3v2_Disc].front()->toString()).trimmed();
   if (map.contains(kID3v2_Composer)) song->set_composer(map[kID3v2_Composer].front()->toString());
+  if (map.contains(kID3v2_ComposerSort)) song->set_composersort(map[kID3v2_ComposerSort].front()->toString());
 
   // content group
   if (map.contains(kID3v2_Grouping)) song->set_grouping(map[kID3v2_Grouping].front()->toString());
@@ -600,6 +612,11 @@ void TagReaderTagLib::ParseID3v2Tags(TagLib::ID3v2::Tag *tag, QString *disc, QSt
 
   // non-standard: Apple, Microsoft
   if (map.contains(kID3v2_AlbumArtist)) song->set_albumartist(map[kID3v2_AlbumArtist].front()->toString());
+
+  if (map.contains(kID3v2_AlbumArtistSort)) song->set_albumartistsort(map[kID3v2_AlbumArtistSort].front()->toString());
+  if (map.contains(kID3v2_AlbumSort)) song->set_albumsort(map[kID3v2_AlbumSort].front()->toString());
+  if (map.contains(kID3v2_ArtistSort)) song->set_artistsort(map[kID3v2_ArtistSort].front()->toString());
+  if (map.contains(kID3v2_TitleSort)) song->set_titlesort(map[kID3v2_TitleSort].front()->toString());
 
   if (map.contains(kID3v2_Compilation)) *compilation = TagLibStringToQString(map[kID3v2_Compilation].front()->toString()).trimmed();
 
@@ -706,12 +723,19 @@ void TagReaderTagLib::ParseID3v2Tags(TagLib::ID3v2::Tag *tag, QString *disc, QSt
 void TagReaderTagLib::ParseVorbisComments(const TagLib::Ogg::FieldListMap &map, QString *disc, QString *compilation, Song *song) const {
 
   if (map.contains(kVorbisComment_Composer)) song->set_composer(map[kVorbisComment_Composer].front());
+  if (map.contains(kVorbisComment_ComposerSort)) song->set_composersort(map[kVorbisComment_ComposerSort].front());
   if (map.contains(kVorbisComment_Performer)) song->set_performer(map[kVorbisComment_Performer].front());
+  if (map.contains(kVorbisComment_PerformerSort)) song->set_performersort(map[kVorbisComment_PerformerSort].front());
   if (map.contains(kVorbisComment_Grouping2)) song->set_grouping(map[kVorbisComment_Grouping2].front());
   if (map.contains(kVorbisComment_Grouping1)) song->set_grouping(map[kVorbisComment_Grouping1].front());
 
   if (map.contains(kVorbisComment_AlbumArtist1)) song->set_albumartist(map[kVorbisComment_AlbumArtist1].front());
   else if (map.contains(kVorbisComment_AlbumArtist2)) song->set_albumartist(map[kVorbisComment_AlbumArtist2].front());
+
+  if (map.contains(kVorbisComment_AlbumArtistSort)) song->set_albumartistsort(map[kVorbisComment_AlbumArtistSort].front());
+  if (map.contains(kVorbisComment_AlbumSort)) song->set_albumsort(map[kVorbisComment_AlbumSort].front());
+  if (map.contains(kVorbisComment_ArtistSort)) song->set_artistsort(map[kVorbisComment_ArtistSort].front());
+  if (map.contains(kVorbisComment_TitleSort)) song->set_titlesort(map[kVorbisComment_TitleSort].front());
 
   if (map.contains(kVorbisComment_OriginalYear1)) song->set_originalyear(TagLibStringToQString(map[kVorbisComment_OriginalYear1].front()).left(4).toInt());
   else if (map.contains(kVorbisComment_OriginalYear2)) song->set_originalyear(TagLibStringToQString(map[kVorbisComment_OriginalYear2].front()).toInt());
@@ -1227,10 +1251,15 @@ void TagReaderTagLib::SetID3v2Tag(TagLib::ID3v2::Tag *tag, const Song &song) con
 
   SetTextFrame(kID3v2_Disc, song.disc() <= 0 ? QString() : QString::number(song.disc()), tag);
   SetTextFrame(kID3v2_Composer, song.composer().isEmpty() ? QString() : song.composer(), tag);
+  SetTextFrame(kID3v2_ComposerSort, song.composersort().isEmpty() ? QString() : song.composersort(), tag);
   SetTextFrame(kID3v2_Grouping, song.grouping().isEmpty() ? QString() : song.grouping(), tag);
   SetTextFrame(kID3v2_Performer, song.performer().isEmpty() ? QString() : song.performer(), tag);
   // Skip TPE1 (which is the artist) here because we already set it
   SetTextFrame(kID3v2_AlbumArtist, song.albumartist().isEmpty() ? QString() : song.albumartist(), tag);
+  SetTextFrame(kID3v2_AlbumArtistSort, song.albumartistsort().isEmpty() ? QString() : song.albumartistsort(), tag);
+  SetTextFrame(kID3v2_AlbumSort, song.albumsort().isEmpty() ? QString() : song.albumsort(), tag);
+  SetTextFrame(kID3v2_ArtistSort, song.artistsort().isEmpty() ? QString() : song.artistsort(), tag);
+  SetTextFrame(kID3v2_TitleSort, song.titlesort().isEmpty() ? QString() : song.titlesort(), tag);
   SetTextFrame(kID3v2_Compilation, song.compilation() ? QString::number(1) : QString(), tag);
   SetUnsyncLyricsFrame(song.lyrics().isEmpty() ? QString() : song.lyrics(), tag);
 
@@ -1318,7 +1347,9 @@ void TagReaderTagLib::SetUnsyncLyricsFrame(const QString &value, TagLib::ID3v2::
 void TagReaderTagLib::SetVorbisComments(TagLib::Ogg::XiphComment *vorbis_comment, const Song &song) const {
 
   vorbis_comment->addField(kVorbisComment_Composer, QStringToTagLibString(song.composer()), true);
+  vorbis_comment->addField(kVorbisComment_ComposerSort, QStringToTagLibString(song.composersort()), true);
   vorbis_comment->addField(kVorbisComment_Performer, QStringToTagLibString(song.performer()), true);
+  vorbis_comment->addField(kVorbisComment_PerformerSort, QStringToTagLibString(song.performersort()), true);
   vorbis_comment->addField(kVorbisComment_Grouping1, QStringToTagLibString(song.grouping()), true);
   vorbis_comment->addField(kVorbisComment_Disc, QStringToTagLibString(song.disc() <= 0 ? QString() : QString::number(song.disc())), true);
   vorbis_comment->addField(kVorbisComment_Compilation, QStringToTagLibString(song.compilation() ? u"1"_s : QString()), true);
@@ -1327,6 +1358,10 @@ void TagReaderTagLib::SetVorbisComments(TagLib::Ogg::XiphComment *vorbis_comment
 
   vorbis_comment->addField(kVorbisComment_AlbumArtist1, QStringToTagLibString(song.albumartist()), true);
   vorbis_comment->removeFields(kVorbisComment_AlbumArtist2);
+  vorbis_comment->addField(kVorbisComment_AlbumArtistSort, QStringToTagLibString(song.albumartistsort()), true);
+  vorbis_comment->addField(kVorbisComment_AlbumSort, QStringToTagLibString(song.albumsort()), true);
+  vorbis_comment->addField(kVorbisComment_ArtistSort, QStringToTagLibString(song.artistsort()), true);
+  vorbis_comment->addField(kVorbisComment_TitleSort, QStringToTagLibString(song.titlesort()), true);
 
   vorbis_comment->addField(kVorbisComment_Lyrics, QStringToTagLibString(song.lyrics()), true);
   vorbis_comment->removeFields(kVorbisComment_UnsyncedLyrics);

--- a/src/utilities/strutils.cpp
+++ b/src/utilities/strutils.cpp
@@ -142,14 +142,26 @@ QString ReplaceVariable(const QString &variable, const Song &song, const QString
   if (variable == "%title%"_L1) {
     value = song.PrettyTitle();
   }
+  else if (variable == "%titlesort%"_L1) {
+    value = song.titlesort();
+  }
   else if (variable == "%album%"_L1) {
     value = song.album();
+  }
+  else if (variable == "%albumsort%"_L1) {
+    value = song.albumsort();
   }
   else if (variable == "%artist%"_L1) {
     value = song.artist();
   }
+  else if (variable == "%artistsort%"_L1) {
+    value = song.artistsort();
+  }
   else if (variable == "%albumartist%"_L1) {
     value = song.effective_albumartist();
+  }
+  else if (variable == "%albumartistsort%"_L1) {
+    value = song.albumartistsort();
   }
   else if (variable == "%track%"_L1) {
     value.setNum(song.track());
@@ -169,8 +181,14 @@ QString ReplaceVariable(const QString &variable, const Song &song, const QString
   else if (variable == "%composer%"_L1) {
     value = song.composer();
   }
+  else if (variable == "%composersort%"_L1) {
+    value = song.composersort();
+  }
   else if (variable == "%performer%"_L1) {
     value = song.performer();
+  }
+  else if (variable == "%performersort%"_L1) {
+    value = song.performersort();
   }
   else if (variable == "%grouping%"_L1) {
     value = song.grouping();

--- a/tests/src/tagreader_test.cpp
+++ b/tests/src/tagreader_test.cpp
@@ -185,11 +185,17 @@ TEST_F(TagReaderTest, TestFLACAudioFileTagging) {
   {  // Write tags
     Song song;
     song.set_title(u"strawberry title"_s);
+    song.set_titlesort(u"strawberry title sort"_s);
     song.set_artist(u"strawberry artist"_s);
+    song.set_artistsort(u"strawberry artist sort"_s);
     song.set_album(u"strawberry album"_s);
+    song.set_albumsort(u"strawberry album sort"_s);
     song.set_albumartist(u"strawberry album artist"_s);
+    song.set_albumartistsort(u"strawberry album artist sort"_s);
     song.set_composer(u"strawberry composer"_s);
+    song.set_composersort(u"strawberry composer sort"_s);
     song.set_performer(u"strawberry performer"_s);
+    song.set_performersort(u"strawberry performer sort"_s);
     song.set_grouping(u"strawberry grouping"_s);
     song.set_genre(u"strawberry genre"_s);
     song.set_comment(u"strawberry comment"_s);
@@ -208,11 +214,17 @@ TEST_F(TagReaderTest, TestFLACAudioFileTagging) {
   { // Read tags
     Song song = ReadSongFromFile(r.fileName());
     EXPECT_EQ(u"strawberry title"_s, song.title());
+    EXPECT_EQ(u"strawberry title sort"_s, song.titlesort());
     EXPECT_EQ(u"strawberry artist"_s, song.artist());
+    EXPECT_EQ(u"strawberry artist sort"_s, song.artistsort());
     EXPECT_EQ(u"strawberry album"_s, song.album());
+    EXPECT_EQ(u"strawberry album sort"_s, song.albumsort());
     EXPECT_EQ(u"strawberry album artist"_s, song.albumartist());
+    EXPECT_EQ(u"strawberry album artist sort"_s, song.albumartistsort());
     EXPECT_EQ(u"strawberry composer"_s, song.composer());
+    EXPECT_EQ(u"strawberry composer sort"_s, song.composersort());
     EXPECT_EQ(u"strawberry performer"_s, song.performer());
+    EXPECT_EQ(u"strawberry performer sort"_s, song.performersort());
     EXPECT_EQ(u"strawberry grouping"_s, song.grouping());
     EXPECT_EQ(u"strawberry genre"_s, song.genre());
     EXPECT_EQ(u"strawberry comment"_s, song.comment());
@@ -226,11 +238,17 @@ TEST_F(TagReaderTest, TestFLACAudioFileTagging) {
   { // Write new tags
     Song song;
     song.set_title(u"new title"_s);
+    song.set_titlesort(u"new title sort"_s);
     song.set_artist(u"new artist"_s);
+    song.set_artistsort(u"new artist sort"_s);
     song.set_album(u"new album"_s);
+    song.set_albumsort(u"new album sort"_s);
     song.set_albumartist(u"new album artist"_s);
+    song.set_albumartistsort(u"new album artist sort"_s);
     song.set_composer(u"new composer"_s);
+    song.set_composersort(u"new composer sort"_s);
     song.set_performer(u"new performer"_s);
+    song.set_performersort(u"new performer sort"_s);
     song.set_grouping(u"new grouping"_s);
     song.set_genre(u"new genre"_s);
     song.set_comment(u"new comment"_s);
@@ -245,11 +263,17 @@ TEST_F(TagReaderTest, TestFLACAudioFileTagging) {
   { // Read new tags
     Song song = ReadSongFromFile(r.fileName());
     EXPECT_EQ(u"new title"_s, song.title());
+    EXPECT_EQ(u"new title sort"_s, song.titlesort());
     EXPECT_EQ(u"new artist"_s, song.artist());
+    EXPECT_EQ(u"new artist sort"_s, song.artistsort());
     EXPECT_EQ(u"new album"_s, song.album());
+    EXPECT_EQ(u"new album sort"_s, song.albumsort());
     EXPECT_EQ(u"new album artist"_s, song.albumartist());
+    EXPECT_EQ(u"new album artist sort"_s, song.albumartistsort());
     EXPECT_EQ(u"new composer"_s, song.composer());
+    EXPECT_EQ(u"new composer sort"_s, song.composersort());
     EXPECT_EQ(u"new performer"_s, song.performer());
+    EXPECT_EQ(u"new performer sort"_s, song.performersort());
     EXPECT_EQ(u"new grouping"_s, song.grouping());
     EXPECT_EQ(u"new genre"_s, song.genre());
     EXPECT_EQ(u"new comment"_s, song.comment());
@@ -263,11 +287,17 @@ TEST_F(TagReaderTest, TestFLACAudioFileTagging) {
   { // Write original tags
     Song song;
     song.set_title(u"strawberry title"_s);
+    song.set_titlesort(u"strawberry title sort"_s);
     song.set_artist(u"strawberry artist"_s);
+    song.set_artistsort(u"strawberry artist sort"_s);
     song.set_album(u"strawberry album"_s);
+    song.set_albumsort(u"strawberry album sort"_s);
     song.set_albumartist(u"strawberry album artist"_s);
+    song.set_albumartistsort(u"strawberry album artist sort"_s);
     song.set_composer(u"strawberry composer"_s);
+    song.set_composersort(u"strawberry composer sort"_s);
     song.set_performer(u"strawberry performer"_s);
+    song.set_performersort(u"strawberry performer sort"_s);
     song.set_grouping(u"strawberry grouping"_s);
     song.set_genre(u"strawberry genre"_s);
     song.set_comment(u"strawberry comment"_s);
@@ -282,11 +312,17 @@ TEST_F(TagReaderTest, TestFLACAudioFileTagging) {
   { // Read original tags
     Song song = ReadSongFromFile(r.fileName());
     EXPECT_EQ(u"strawberry title"_s, song.title());
+    EXPECT_EQ(u"strawberry title sort"_s, song.titlesort());
     EXPECT_EQ(u"strawberry artist"_s, song.artist());
+    EXPECT_EQ(u"strawberry artist sort"_s, song.artistsort());
     EXPECT_EQ(u"strawberry album"_s, song.album());
+    EXPECT_EQ(u"strawberry album sort"_s, song.albumsort());
     EXPECT_EQ(u"strawberry album artist"_s, song.albumartist());
+    EXPECT_EQ(u"strawberry album artist sort"_s, song.albumartistsort());
     EXPECT_EQ(u"strawberry composer"_s, song.composer());
+    EXPECT_EQ(u"strawberry composer sort"_s, song.composersort());
     EXPECT_EQ(u"strawberry performer"_s, song.performer());
+    EXPECT_EQ(u"strawberry performer sort"_s, song.performersort());
     EXPECT_EQ(u"strawberry grouping"_s, song.grouping());
     EXPECT_EQ(u"strawberry genre"_s, song.genre());
     EXPECT_EQ(u"strawberry comment"_s, song.comment());
@@ -1505,10 +1541,15 @@ TEST_F(TagReaderTest, TestMP3AudioFileTagging) {
   { // Write tags
     Song song;
     song.set_title(u"strawberry title"_s);
+    song.set_titlesort(u"strawberry title sort"_s);
     song.set_artist(u"strawberry artist"_s);
+    song.set_artistsort(u"strawberry artist sort"_s);
     song.set_album(u"strawberry album"_s);
+    song.set_albumsort(u"strawberry album sort"_s);
     song.set_albumartist(u"strawberry album artist"_s);
+    song.set_albumartistsort(u"strawberry album artist sort"_s);
     song.set_composer(u"strawberry composer"_s);
+    song.set_composersort(u"strawberry composer sort"_s);
     song.set_performer(u"strawberry performer"_s);
     song.set_grouping(u"strawberry grouping"_s);
     song.set_genre(u"strawberry genre"_s);
@@ -1528,10 +1569,15 @@ TEST_F(TagReaderTest, TestMP3AudioFileTagging) {
   { // Read tags
     Song song = ReadSongFromFile(r.fileName());
     EXPECT_EQ(u"strawberry title"_s, song.title());
+    EXPECT_EQ(u"strawberry title sort"_s, song.titlesort());
     EXPECT_EQ(u"strawberry artist"_s, song.artist());
+    EXPECT_EQ(u"strawberry artist sort"_s, song.artistsort());
     EXPECT_EQ(u"strawberry album"_s, song.album());
+    EXPECT_EQ(u"strawberry album sort"_s, song.albumsort());
     EXPECT_EQ(u"strawberry album artist"_s, song.albumartist());
+    EXPECT_EQ(u"strawberry album artist sort"_s, song.albumartistsort());
     EXPECT_EQ(u"strawberry composer"_s, song.composer());
+    EXPECT_EQ(u"strawberry composer sort"_s, song.composersort());
     EXPECT_EQ(u"strawberry performer"_s, song.performer());
     EXPECT_EQ(u"strawberry grouping"_s, song.grouping());
     EXPECT_EQ(u"strawberry genre"_s, song.genre());
@@ -1546,10 +1592,15 @@ TEST_F(TagReaderTest, TestMP3AudioFileTagging) {
   { // Write new tags
     Song song;
     song.set_title(u"new title"_s);
+    song.set_titlesort(u"new title sort"_s);
     song.set_artist(u"new artist"_s);
+    song.set_artistsort(u"new artist sort"_s);
     song.set_album(u"new album"_s);
+    song.set_albumsort(u"new album sort"_s);
     song.set_albumartist(u"new album artist"_s);
+    song.set_albumartistsort(u"new album artist sort"_s);
     song.set_composer(u"new composer"_s);
+    song.set_composersort(u"new composer sort"_s);
     song.set_performer(u"new performer"_s);
     song.set_grouping(u"new grouping"_s);
     song.set_genre(u"new genre"_s);
@@ -1565,10 +1616,15 @@ TEST_F(TagReaderTest, TestMP3AudioFileTagging) {
   { // Read new tags
     Song song = ReadSongFromFile(r.fileName());
     EXPECT_EQ(u"new title"_s, song.title());
+    EXPECT_EQ(u"new title sort"_s, song.titlesort());
     EXPECT_EQ(u"new artist"_s, song.artist());
+    EXPECT_EQ(u"new artist sort"_s, song.artistsort());
     EXPECT_EQ(u"new album"_s, song.album());
+    EXPECT_EQ(u"new album sort"_s, song.albumsort());
     EXPECT_EQ(u"new album artist"_s, song.albumartist());
+    EXPECT_EQ(u"new album artist sort"_s, song.albumartistsort());
     EXPECT_EQ(u"new composer"_s, song.composer());
+    EXPECT_EQ(u"new composer sort"_s, song.composersort());
     EXPECT_EQ(u"new performer"_s, song.performer());
     EXPECT_EQ(u"new grouping"_s, song.grouping());
     EXPECT_EQ(4321, song.disc());
@@ -1583,10 +1639,15 @@ TEST_F(TagReaderTest, TestMP3AudioFileTagging) {
   { // Write original tags
     Song song;
     song.set_title(u"strawberry title"_s);
+    song.set_titlesort(u"strawberry title sort"_s);
     song.set_artist(u"strawberry artist"_s);
+    song.set_artistsort(u"strawberry artist sort"_s);
     song.set_album(u"strawberry album"_s);
+    song.set_albumsort(u"strawberry album sort"_s);
     song.set_albumartist(u"strawberry album artist"_s);
+    song.set_albumartistsort(u"strawberry album artist sort"_s);
     song.set_composer(u"strawberry composer"_s);
+    song.set_composersort(u"strawberry composer sort"_s);
     song.set_performer(u"strawberry performer"_s);
     song.set_grouping(u"strawberry grouping"_s);
     song.set_genre(u"strawberry genre"_s);
@@ -1602,10 +1663,15 @@ TEST_F(TagReaderTest, TestMP3AudioFileTagging) {
   { // Read original tags
     Song song = ReadSongFromFile(r.fileName());
     EXPECT_EQ(u"strawberry title"_s, song.title());
+    EXPECT_EQ(u"strawberry title sort"_s, song.titlesort());
     EXPECT_EQ(u"strawberry artist"_s, song.artist());
+    EXPECT_EQ(u"strawberry artist sort"_s, song.artistsort());
     EXPECT_EQ(u"strawberry album"_s, song.album());
+    EXPECT_EQ(u"strawberry album sort"_s, song.albumsort());
     EXPECT_EQ(u"strawberry album artist"_s, song.albumartist());
+    EXPECT_EQ(u"strawberry album artist sort"_s, song.albumartistsort());
     EXPECT_EQ(u"strawberry composer"_s, song.composer());
+    EXPECT_EQ(u"strawberry composer sort"_s, song.composersort());
     EXPECT_EQ(u"strawberry performer"_s, song.performer());
     EXPECT_EQ(u"strawberry grouping"_s, song.grouping());
     EXPECT_EQ(u"strawberry genre"_s, song.genre());

--- a/tests/src/utilities_test.cpp
+++ b/tests/src/utilities_test.cpp
@@ -186,16 +186,22 @@ TEST(UtilitiesTest, ReplaceVariable) {
 
   Song song;
   song.set_title(Utilities::GetRandomStringWithChars(8));
+  song.set_titlesort(Utilities::GetRandomStringWithChars(8));
   song.set_album(Utilities::GetRandomStringWithChars(8));
+  song.set_albumsort(Utilities::GetRandomStringWithChars(8));
   song.set_artist(Utilities::GetRandomStringWithChars(8));
+  song.set_artistsort(Utilities::GetRandomStringWithChars(8));
   song.set_albumartist(Utilities::GetRandomStringWithChars(8));
+  song.set_albumartistsort(Utilities::GetRandomStringWithChars(8));
   song.set_track(5);
   song.set_disc(2);
   song.set_year(1999);
   song.set_originalyear(2000);
   song.set_genre(Utilities::GetRandomStringWithChars(8));
   song.set_composer(Utilities::GetRandomStringWithChars(8));
+  song.set_composersort(Utilities::GetRandomStringWithChars(8));
   song.set_performer(Utilities::GetRandomStringWithChars(8));
+  song.set_performersort(Utilities::GetRandomStringWithChars(8));
   song.set_grouping(Utilities::GetRandomStringWithChars(8));
   song.set_length_nanosec(900000000000);
   song.set_url(QUrl(u"file:///home/jonas/Music/test_song.flac"_s));
@@ -204,16 +210,22 @@ TEST(UtilitiesTest, ReplaceVariable) {
   song.set_rating(1.0);
 
   ASSERT_EQ(Utilities::ReplaceVariable(u"%title%"_s, song, ""_L1), song.title());
+  ASSERT_EQ(Utilities::ReplaceVariable(u"%titlesort%"_s, song, ""_L1), song.titlesort());
   ASSERT_EQ(Utilities::ReplaceVariable(u"%album%"_s, song, ""_L1), song.album());
+  ASSERT_EQ(Utilities::ReplaceVariable(u"%albumsort%"_s, song, ""_L1), song.albumsort());
   ASSERT_EQ(Utilities::ReplaceVariable(u"%artist%"_s, song, ""_L1), song.artist());
+  ASSERT_EQ(Utilities::ReplaceVariable(u"%artistsort%"_s, song, ""_L1), song.artistsort());
   ASSERT_EQ(Utilities::ReplaceVariable(u"%albumartist%"_s, song, ""_L1), song.effective_albumartist());
+  ASSERT_EQ(Utilities::ReplaceVariable(u"%albumartistsort%"_s, song, ""_L1), song.albumartistsort());
   ASSERT_EQ(Utilities::ReplaceVariable(u"%track%"_s, song, ""_L1), QString::number(song.track()));
   ASSERT_EQ(Utilities::ReplaceVariable(u"%disc%"_s, song, ""_L1), QString::number(song.disc()));
   ASSERT_EQ(Utilities::ReplaceVariable(u"%year%"_s, song, ""_L1), QString::number(song.year()));
   ASSERT_EQ(Utilities::ReplaceVariable(u"%originalyear%"_s, song, ""_L1), QString::number(song.originalyear()));
   ASSERT_EQ(Utilities::ReplaceVariable(u"%genre%"_s, song, ""_L1), song.genre());
   ASSERT_EQ(Utilities::ReplaceVariable(u"%composer%"_s, song, ""_L1), song.composer());
+  ASSERT_EQ(Utilities::ReplaceVariable(u"%composersort%"_s, song, ""_L1), song.composersort());
   ASSERT_EQ(Utilities::ReplaceVariable(u"%performer%"_s, song, ""_L1), song.performer());
+  ASSERT_EQ(Utilities::ReplaceVariable(u"%performersort%"_s, song, ""_L1), song.performersort());
   ASSERT_EQ(Utilities::ReplaceVariable(u"%grouping%"_s, song, ""_L1), song.grouping());
   ASSERT_EQ(Utilities::ReplaceVariable(u"%length%"_s, song, ""_L1), song.PrettyLength());
   ASSERT_EQ(Utilities::ReplaceVariable(u"%filename%"_s, song, ""_L1), song.basefilename());
@@ -230,7 +242,9 @@ TEST(UtilitiesTest, ReplaceMessage) {
   song.set_title(Utilities::GetRandomStringWithChars(8));
   song.set_album(Utilities::GetRandomStringWithChars(8));
   song.set_artist(Utilities::GetRandomStringWithChars(8));
+  song.set_artistsort(Utilities::GetRandomStringWithChars(8));
   song.set_albumartist(Utilities::GetRandomStringWithChars(8));
+  song.set_albumartistsort(Utilities::GetRandomStringWithChars(8));
   song.set_track(5);
   song.set_disc(2);
   song.set_year(1999);
@@ -246,6 +260,7 @@ TEST(UtilitiesTest, ReplaceMessage) {
   song.set_rating(1.0);
 
   ASSERT_EQ(Utilities::ReplaceMessage(u"%title% - %artist%"_s, song, ""_L1), song.title() + u" - "_s + song.artist());
+  ASSERT_EQ(Utilities::ReplaceMessage(u"%artistsort% - %albumartistsort%"_s, song, ""_L1), song.artistsort() + u" - "_s + song.albumartistsort());
 
 }
 


### PR DESCRIPTION
(Note: This PR replaces https://github.com/strawberrymusicplayer/strawberry/pull/1779 which offered support for "artist sort" and "album artist sort". This new PR now adds support for **all** common sort tags, as suggested by Jonas. PR https://github.com/strawberrymusicplayer/strawberry/pull/1781 has been split off to prepare the database schema for the new fields. The remaining text and screenshots have been updated to reflect the new features.)

# Overview

This PR adds support for sorting a collection by sort names often included as special tags in song files. This allows, for example, to see "The Beatles" sorted as "Beatles, The".

Strawberry already has some support for filtering articles from artist names before sorting, but this has limitations like no support for languages other than English. A more reliable way is to use provided data since the [rules for correct sort names can be quite complex](https://musicbrainz.org/doc/Style/Artist/Sort_Name). If you tag your files with MusicBrainz, for example, then sort information is stored in tags like "artist sort", "album artist sort" or "composer sort".

Technically, the PR adds support for reading, editing, and applying the following vorbis (id3v2) sort tags:

- ALBUMARTISTSORT (TSO2)
- ALBUMSORT (TSOA)
- ARTISTSORT (TSOP)
- COMPOSERSORT (TSOC)
- PERFORMERSORT (-)
- TITLESORT (TSOT)

See e.g. https://docs.mp3tag.de/mapping-table/ or https://picard-docs.musicbrainz.org/downloads/MusicBrainz_Picard_Tag_Map.html for tag definitions.

This PR also addresses requests in the following forum posts:

- https://forum.strawberrymusicplayer.org/topic/696/articles-in-artist-names-when-sorting-library
- https://forum.strawberrymusicplayer.org/topic/5757/sort-tags
- https://forum.strawberrymusicplayer.org/topic/5803/skip-leading-articles-when-sorting-albums
- https://forum.strawberrymusicplayer.org/topic/1265/sorting-by-tsop

# User Visible Changes

## Collection

The **Settings|Collection** page now has a combo box for choosing the sort behavior. Previous versions of strawberry had a checkbox "Skip leading articles ("the", "a", "an") when sorting artist names". This has been removed, but the underlying behavior is still available as one of the combobox options. The sort behavior applies to any name tag that may have a corresponding sort tag: album, artist, album artist, title, composer, and performer.

<img width="849" height="1179" alt="collectionsettings" src="https://github.com/user-attachments/assets/384f87fd-b13c-48e6-af3f-e9881cf2b3ef" />

There are four settings available:

<img width="596" height="158" alt="combobox" src="https://github.com/user-attachments/assets/80183f75-8226-4d1f-ab0c-5143198ccbea" />

Option 1 (**Sort and show name as is**) uses the name as is. It is equivalent to the unchecked state of the "Skip leading articles..." checkbox in previous versions of strawberry. Here is an example of the result when grouping by artist name:

<img width="581" height="361" alt="option-1" src="https://github.com/user-attachments/assets/1af8f6ce-ad17-44f7-874b-3530949b0675" />

Option 2 (**Skip articles "The, A, An" for sorting but show name as is**) is the default and the same as the checkbox "Skip leading articles..." in earlier versions. Note that this option does not correctly handle non-English names as can be seen by the entry for "Die Ärzte".

<img width="581" height="361" alt="option-2" src="https://github.com/user-attachments/assets/1672c336-9f7a-4834-931f-393b9c4d2d0a" />

Options 1 and 2 provide full backwards compatibility. They can be used, for example, if your collection does not have sort tags, you do not want to use them, or you are just happy with the current behavior.

Option 3 and 4 provide the new functionality by using sort tags. Option 3 (**Use sort tag for sorting but show name as is**) uses the sort tag for sorting internally, but shows the original name.

<img width="581" height="361" alt="option-3" src="https://github.com/user-attachments/assets/e31dacb3-3756-4e9c-aa22-b6d1dee331b4" />

Option 4 (**Use sort tag for sorting and display**) uses the sort tag internally and also for display.

<img width="581" height="361" alt="option-4" src="https://github.com/user-attachments/assets/96da1abd-86de-47b8-aa0d-3ebb7fcb1c40" />

Another example: if you have a collection of classical music and want to sort by composer last name you can do so by selecting **Group by|Advanced grouping** 

<img width="1097" height="489" alt="advanced-grouping" src="https://github.com/user-attachments/assets/b6037a7b-d2a5-499e-ad67-b7ac0d0360ec" />

and "Composer" in the following dialog:

<img width="404" height="331" alt="advanced-grouping-dialog" src="https://github.com/user-attachments/assets/556e3713-821d-4897-b316-04cb1e4a1463" />

## Playlists

There are six new columns that can be enabled in the context menu of playlists:

<img width="645" height="1119" alt="playlistmenu" src="https://github.com/user-attachments/assets/02bf9b16-4cf5-4843-a580-3dbb109b02df" />

An example with two new columns enabled:

<img width="1565" height="596" alt="playlist" src="https://github.com/user-attachments/assets/19aa064f-554e-4c95-a960-5eb5543584a5" />

Some custom playlist settings like column positions or size adjustments are reset to defaults in this version. This is due to internal data structure changes.

## Smart Playlists

Smart playlists can use search terms with the new fields.

<img width="809" height="1058" alt="smartplsearch" src="https://github.com/user-attachments/assets/f5d531e4-0063-4131-825f-cba635354187" />

The new fields can then be used for sorting the results as well.

<img width="809" height="1058" alt="smartplsort" src="https://github.com/user-attachments/assets/b827b2ea-cb0d-43fb-ad43-d830b78999ae" />

## Edit Track Information

The **Edit Track Information** dialog allows to edit the new fields for supported file formats (e.g. flac and mp3). Changes are written back to the song files and the collection database is updated as well.

<img width="835" height="1021" alt="edittrack" src="https://github.com/user-attachments/assets/f57324e6-9510-49a2-bc1b-fcca8f6b5805" />

## Context View

The custom text settings for the context view can now make use of the new fields. The popup menu in the **Settings|Context** page has additional entries for that:

<img width="964" height="939" alt="contextsettings" src="https://github.com/user-attachments/assets/128ef287-8bc3-4a41-b0d8-378b325497f9" />

Here is an example setting using the **artistsort** field.

<img width="588" height="125" alt="context1" src="https://github.com/user-attachments/assets/7e18f0f2-b963-4605-8d3b-5e06b42fb06b" />

<img width="564" height="587" alt="context2" src="https://github.com/user-attachments/assets/2dff0480-acac-4d09-9431-74465332dc66" />

## Migrating Existing Collections

When the new version of strawberry detects an older collection database on startup, it offers to rescan the collection.

<img width="522" height="252" alt="rescan" src="https://github.com/user-attachments/assets/a188f537-f07b-41fc-bd56-ef53844f1ebf" />

This should be confirmed in order to read information for the new tags from song files.

# Implementation Details

The steps necessary to implement this were:

- Add new fields to database schema
- Increment database schema from 20 to 21
- Add migration script for database upgrade
- Add new fields to Song class
- Read/write vorbis and id3v2 tags in Tagreader and set/get corresponding Song fields
- Implement new sort options in CollectionModel
- Extend settings ui
- Extend playlist view
- Extend smart playlist ui
- Extend edit track dialog
- Trigger dialog offering collection rescan on startup
- Add unit tests

## View Playlist

I wanted to keep the new columns close to their related ones, i.e., "artist sort" should come next to "artist". It seems that the column positions are directly mapped to the "Column" enum in src/playlist/playlist.h. Appending to that enum as suggested by the comment on top of the enum has the effect that all sort tags by default appear at the very end of the popup menu and the right side of the playlist. I therefore merged the new fields into the enum and incremented the playlist state version from 1 to 2 to get sort columns next to their "original" column. That will discard old stored playlist state in config files.

# Limitations

- Tested only on Fedora 42
- Tested only with flac and mp3 files
- Unit tests are quite limited in scope, most tests where done manually

# Tests

I have run the following manual tests with a flac and mp3 collection of about 1,000 albums / 16,000 songs:

- Verify schema migration is triggered on start up, and adds / reads new fields
- Verify all four options for sorting the collection work
- Verify empty sort fields do not crash strawberry
- Verify playlist columns can be switched on, can be used to sort, and can be edited
- Verify edit track information dialog allows to edit new fields
- Verify smart playlist allows to use new fields for selection and sorting

In addition, I used the following two bash scripts to generate flac files with sort tags for testing.

gen-all-flac.sh

```bash
#!/usr/bin/env bash

set -euo pipefail

# 2592 songs
N_ALBUMS=2
N_ARTISTS=3
N_TRACKS=12

mkdir -p ./tmp

N=0
for letter in {Á,Ä,Å,Ã,Æ,Ġ,Ñ,Ş,Ÿ,Ž,{A..Z}}; do
    for ((artist = 1; artist <= N_ARTISTS; artist++)); do
        for ((album = 1; album <= N_ALBUMS; album++)); do
            for ((track = 1; track <= N_TRACKS; track++)); do
                echo $letter $artist $album $track
            done
        done
    done
done | xargs -n 4 -P $(nproc) ./gen-one-flac.sh
```

gen-one-flac.sh

```bash
#!/usr/bin/env bash

set -euo pipefail

letter=$1
artist=$2
album=$3
track=$4
# echo $letter $artist $album $track

full_artist="The ${letter} artist ${artist}"
full_artistsort="${letter} artist ${artist}, The"
full_album="The album ${album} by ${full_artist}"
full_albumsort="album ${album}, The by ${full_artist}"
full_title="The Title ${track} on ${full_album}"
full_titlesort="Title ${track}, The on ${full_album}"
full_composer="The ${letter} composer ${artist}"
full_composersort="${letter} composer ${artist}, The"
full_performer="The ${letter} performer ${artist} (piano)"
full_performersort="${letter} performer ${artist}, The (piano)"

exec ffmpeg -nostdin -loglevel error -y -f lavfi -t 1ms -i anullsrc=channel_layout=stereo:sample_rate=44100 \
    -metadata "ALBUMARTIST=${full_artist}" \
    -metadata "ALBUMARTISTSORT=${full_artistsort}" \
    -metadata "ALBUM=${full_album}" \
    -metadata "ALBUMSORT=${full_albumsort}" \
    -metadata "ARTIST=${full_artist}" \
    -metadata "ARTISTSORT=${full_artistsort}" \
    -metadata "COMPOSER=${full_composer}" \
    -metadata "COMPOSERSORT=${full_composersort}" \
    -metadata "PERFORMER=${full_performer}" \
    -metadata "PERFORMERSORT=${full_performersort}" \
    -metadata "DATE=2000" \
    -metadata "DISCNUMBER=1" \
    -metadata "DISCTOTAL=1" \
    -metadata "TITLE=${full_title}" \
    -metadata "TITLESORT=${full_titlesort}" \
    -metadata "TRACKNUMBER=$track" \
    ./tmp/$letter-$artist-$album-$track.flac
```

These scripts create songs that look like this:

<img width="2560" height="1408" alt="testdata" src="https://github.com/user-attachments/assets/af75dffd-be9b-4136-a8b7-4ba022f6f689" />
