### PR TITLE
discord: fixed timestamp update when seeking

### DIFF
--- a/src/discord/richpresence.cpp
+++ b/src/discord/richpresence.cpp
@@ -167,7 +167,7 @@ void RichPresence::Seeked(const qint64 seek_microseconds) {
 
   if (!initialized_) return;
 
-  SetTimestamp(seek_microseconds / 1000LL);
+  SetTimestamp(seek_microseconds / 1000000LL);
   SendPresenceUpdate();
 
 }


### PR DESCRIPTION
When seeking in a song, `RichPresence::Seeked()` receives the new position in microseconds and is supposed to update the RPC timestamp with the new position in seconds. However, it actually converts the value to milliseconds, meaning that if, for example, you seek to 0:05 in a song, Discord will think you seeked to 83:20, or 5000 seconds from the beginning of the song.

This commit fixes this by simply dividing the microseconds value by one million instead of one thousand.