### PR TITLE
Add shortcuts to ease navigation

### DIFF
--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -635,10 +635,16 @@ MainWindow::MainWindow(Application *app,
   // Playlist view actions
   ui_->action_next_playlist->setShortcuts(QList<QKeySequence>() << QKeySequence::fromString(u"Ctrl+Tab"_s) << QKeySequence::fromString(u"Ctrl+PgDown"_s));
   ui_->action_previous_playlist->setShortcuts(QList<QKeySequence>() << QKeySequence::fromString(u"Ctrl+Shift+Tab"_s) << QKeySequence::fromString(u"Ctrl+PgUp"_s));
+  ui_->action_last_playlist->setShortcut(QKeySequence::fromString(u"Ctrl+9"_s));
+  ui_->action_active_playlist->setShortcut(QKeySequence::fromString(u"Ctrl+Shift+P"_s));
+  ui_->action_close_playlist->setShortcut(QKeySequence::fromString(u"Ctrl+W"_s));
 
   // Actions for switching tabs will be global to the entire window, so adding them here
   addAction(ui_->action_next_playlist);
   addAction(ui_->action_previous_playlist);
+  addAction(ui_->action_last_playlist);
+  addAction(ui_->action_active_playlist);
+  addAction(ui_->action_close_playlist);
 
   // Give actions to buttons
   ui_->forward_button->setDefaultAction(ui_->action_next_track);
@@ -648,7 +654,19 @@ MainWindow::MainWindow(Application *app,
   ui_->button_scrobble->setDefaultAction(ui_->action_toggle_scrobbling);
   ui_->button_love->setDefaultAction(ui_->action_love);
 
-  ui_->playlist->SetActions(ui_->action_new_playlist, ui_->action_load_playlist, ui_->action_save_playlist, ui_->action_clear_playlist, ui_->action_next_playlist, /* These two actions aren't associated */ ui_->action_previous_playlist /* to a button but to the main window */, ui_->action_save_all_playlists);
+  PlaylistContainer::Actions playlist_actions;
+  playlist_actions.new_playlist = ui_->action_new_playlist;
+  playlist_actions.load_playlist = ui_->action_load_playlist;
+  playlist_actions.save_playlist = ui_->action_save_playlist;
+  playlist_actions.clear_playlist = ui_->action_clear_playlist;
+  playlist_actions.next_playlist = ui_->action_next_playlist;
+  // These aren't associated to a button but to the main window
+  playlist_actions.previous_playlist = ui_->action_previous_playlist;
+  playlist_actions.last_playlist = ui_->action_last_playlist;
+  playlist_actions.active_playlist = ui_->action_active_playlist;
+  playlist_actions.close_playlist = ui_->action_close_playlist;
+  playlist_actions.save_all_playlists = ui_->action_save_all_playlists;
+  ui_->playlist->SetActions(playlist_actions);
   // Add the shuffle and repeat action groups to the menu
   ui_->action_shuffle_mode->setMenu(ui_->playlist_sequence->shuffle_menu());
   ui_->action_repeat_mode->setMenu(ui_->playlist_sequence->repeat_menu());
@@ -876,10 +894,6 @@ MainWindow::MainWindow(Application *app,
   playlist_menu_->addAction(ui_->action_shuffle);
   playlist_menu_->addAction(ui_->action_remove_duplicates);
   playlist_menu_->addAction(ui_->action_remove_unavailable);
-
-#ifdef Q_OS_MACOS
-  ui_->action_shuffle->setShortcut(QKeySequence());
-#endif
 
   // We have to add the actions on the playlist menu to this QWidget otherwise their shortcut keys don't work
   addActions(playlist_menu_->actions());
@@ -1114,8 +1128,11 @@ MainWindow::MainWindow(Application *app,
   ui_->action_toggle_show_sidebar->setChecked(show_sidebar);
 
   QShortcut *close_window_shortcut = new QShortcut(this);
-  close_window_shortcut->setKey(Qt::CTRL | Qt::Key_W);
+  close_window_shortcut->setKey(Qt::CTRL | Qt::SHIFT | Qt::Key_W);
   QObject::connect(close_window_shortcut, &QShortcut::activated, this, &MainWindow::ToggleHide);
+
+  // Ctrl+W closes the current playlist tab, but falls back to hiding the window when there is only one tab left, matching the "close tab, or the window if it's the last one" convention used by tabbed browsers.
+  QObject::connect(ui_->playlist, &PlaylistContainer::LastTabCloseRequested, this, &MainWindow::ToggleHide);
 
   QAction *action_focus_search = new QAction(this);
   action_focus_search->setShortcuts(QList<QKeySequence>() << QKeySequence(u"Ctrl+F"_s));

--- a/src/core/mainwindow.ui
+++ b/src/core/mainwindow.ui
@@ -662,7 +662,7 @@
     <string>S&amp;huffle playlist</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+H</string>
+    <string>Ctrl+Shift+H</string>
    </property>
   </action>
   <action name="action_add_file">
@@ -768,6 +768,21 @@
   <action name="action_previous_playlist">
    <property name="text">
     <string>Go to previous playlist tab</string>
+   </property>
+  </action>
+  <action name="action_last_playlist">
+   <property name="text">
+    <string>Go to last playlist tab</string>
+   </property>
+  </action>
+  <action name="action_active_playlist">
+   <property name="text">
+    <string>Go to active playlist tab</string>
+   </property>
+  </action>
+  <action name="action_close_playlist">
+   <property name="text">
+    <string>Close current playlist tab</string>
    </property>
   </action>
   <action name="action_update_collection">

--- a/src/playlist/playlistcontainer.cpp
+++ b/src/playlist/playlistcontainer.cpp
@@ -140,22 +140,26 @@ PlaylistContainer::~PlaylistContainer() { delete ui_; }
 
 PlaylistView *PlaylistContainer::view() const { return ui_->playlist; }
 
-void PlaylistContainer::SetActions(QAction *new_playlist, QAction *load_playlist, QAction *save_playlist, QAction *clear_playlist, QAction *next_playlist, QAction *previous_playlist, QAction *save_all_playlists) {
+void PlaylistContainer::SetActions(const Actions &actions) {
 
-  ui_->create_new->setDefaultAction(new_playlist);
-  ui_->load->setDefaultAction(load_playlist);
-  ui_->save->setDefaultAction(save_playlist);
-  ui_->clear->setDefaultAction(clear_playlist);
+  ui_->create_new->setDefaultAction(actions.new_playlist);
+  ui_->load->setDefaultAction(actions.load_playlist);
+  ui_->save->setDefaultAction(actions.save_playlist);
+  ui_->clear->setDefaultAction(actions.clear_playlist);
 
-  ui_->tab_bar->SetActions(new_playlist, load_playlist);
+  ui_->tab_bar->SetActions(actions.new_playlist, actions.load_playlist);
 
-  QObject::connect(new_playlist, &QAction::triggered, this, &PlaylistContainer::NewPlaylist);
-  QObject::connect(save_playlist, &QAction::triggered, this, &PlaylistContainer::SaveCurrentPlaylist);
-  QObject::connect(load_playlist, &QAction::triggered, this, &PlaylistContainer::LoadPlaylist);
-  QObject::connect(clear_playlist, &QAction::triggered, this, &PlaylistContainer::ClearPlaylist);
-  QObject::connect(next_playlist, &QAction::triggered, this, &PlaylistContainer::GoToNextPlaylistTab);
-  QObject::connect(previous_playlist, &QAction::triggered, this, &PlaylistContainer::GoToPreviousPlaylistTab);
-  QObject::connect(save_all_playlists, &QAction::triggered, &*manager_, &PlaylistManager::SaveAllPlaylists);
+  QObject::connect(actions.new_playlist, &QAction::triggered, this, &PlaylistContainer::NewPlaylist);
+  QObject::connect(actions.load_playlist, &QAction::triggered, this, &PlaylistContainer::LoadPlaylist);
+  QObject::connect(actions.save_playlist, &QAction::triggered, this, &PlaylistContainer::SaveCurrentPlaylist);
+  QObject::connect(actions.clear_playlist, &QAction::triggered, this, &PlaylistContainer::ClearPlaylist);
+  QObject::connect(actions.next_playlist, &QAction::triggered, this, &PlaylistContainer::GoToNextPlaylistTab);
+  QObject::connect(actions.previous_playlist, &QAction::triggered, this, &PlaylistContainer::GoToPreviousPlaylistTab);
+  QObject::connect(actions.last_playlist, &QAction::triggered, this, &PlaylistContainer::GoToLastPlaylistTab);
+  QObject::connect(actions.active_playlist, &QAction::triggered, this, &PlaylistContainer::GoToActivePlaylistTab);
+  QObject::connect(actions.close_playlist, &QAction::triggered, &*ui_->tab_bar, &PlaylistTabBar::CloseCurrentTab);
+  QObject::connect(&*ui_->tab_bar, &PlaylistTabBar::LastTabCloseRequested, this, &PlaylistContainer::LastTabCloseRequested);
+  QObject::connect(actions.save_all_playlists, &QAction::triggered, &*manager_, &PlaylistManager::SaveAllPlaylists);
 
 }
 
@@ -394,6 +398,26 @@ void PlaylistContainer::GoToPreviousPlaylistTab() {
   int id_previous = ui_->tab_bar->id_of((ui_->tab_bar->currentIndex() + ui_->tab_bar->count() - 1) % ui_->tab_bar->count());
   // Switch to next tab
   manager_->SetCurrentPlaylist(id_previous);
+
+}
+
+void PlaylistContainer::GoToLastPlaylistTab() {
+
+  if (ui_->tab_bar->count() == 0) return;
+  const int id_last = ui_->tab_bar->id_of(ui_->tab_bar->count() - 1);
+  if (id_last == manager_->current_id()) return;
+  manager_->SetCurrentPlaylist(id_last);
+
+}
+
+void PlaylistContainer::GoToActivePlaylistTab() {
+
+  const int active_id = manager_->active_id();
+
+  // Do nothing if no playlist is currently playing: jumping to an arbitrary tab (e.g. the first one) would be surprising when the user asked to go to "the playing tab" and none exists.
+  if (active_id == -1 || active_id == manager_->current_id()) return;
+
+  manager_->SetCurrentPlaylist(active_id);
 
 }
 

--- a/src/playlist/playlistcontainer.h
+++ b/src/playlist/playlistcontainer.h
@@ -52,7 +52,20 @@ class PlaylistContainer : public QWidget {
   explicit PlaylistContainer(QWidget *parent = nullptr);
   ~PlaylistContainer() override;
 
-  void SetActions(QAction *new_playlist, QAction *load_playlist, QAction *save_playlist, QAction *clear_playlist, QAction *next_playlist, QAction *previous_playlist, QAction *save_all_playlists);
+  struct Actions {
+    QAction *new_playlist = nullptr;
+    QAction *load_playlist = nullptr;
+    QAction *save_playlist = nullptr;
+    QAction *clear_playlist = nullptr;
+    QAction *next_playlist = nullptr;
+    QAction *previous_playlist = nullptr;
+    QAction *last_playlist = nullptr;
+    QAction *active_playlist = nullptr;
+    QAction *close_playlist = nullptr;
+    QAction *save_all_playlists = nullptr;
+  };
+
+  void SetActions(const Actions &actions);
   void SetManager(SharedPtr<PlaylistManager> manager);
   void ReloadSettings();
 
@@ -66,6 +79,7 @@ class PlaylistContainer : public QWidget {
  Q_SIGNALS:
   void UndoRedoActionsChanged(QAction *undo, QAction *redo);
   void ViewSelectionModelChanged();
+  void LastTabCloseRequested();
 
  protected:
   // QWidget
@@ -79,6 +93,8 @@ class PlaylistContainer : public QWidget {
   void ClearPlaylist();
   void GoToNextPlaylistTab();
   void GoToPreviousPlaylistTab();
+  void GoToLastPlaylistTab();
+  void GoToActivePlaylistTab();
 
   void SetViewModel(Playlist *playlist, const int scroll_position);
   void PlaylistAdded(const int id, const QString &name, bool favorite);

--- a/src/playlist/playlisttabbar.cpp
+++ b/src/playlist/playlisttabbar.cpp
@@ -289,6 +289,23 @@ void PlaylistTabBar::CloseFromTabIndex(int index) {
 
 }
 
+void PlaylistTabBar::CloseCurrentTab() {
+
+  // We need to finish the renaming action before closing a tab, otherwise RenameInline() would later act on a stale menu_index_ once tab indices have shifted.
+  if (rename_editor_->isVisible()) {
+    // Discard any change
+    HideEditor();
+  }
+
+  if (count() <= 1) {
+    Q_EMIT LastTabCloseRequested();
+    return;
+  }
+
+  CloseFromTabIndex(currentIndex());
+
+}
+
 void PlaylistTabBar::SaveSlot() {
 
   if (menu_index_ == -1) return;

--- a/src/playlist/playlisttabbar.h
+++ b/src/playlist/playlisttabbar.h
@@ -70,6 +70,8 @@ class PlaylistTabBar : public QTabBar {
   void RemoveTab(const int id);
   void InsertTab(const int id, const int index, const QString &text, const bool favorite);
 
+  void CloseCurrentTab();
+
  Q_SIGNALS:
   void CurrentIdChanged(const int id);
   void Rename(const int id, const QString &name);
@@ -77,6 +79,7 @@ class PlaylistTabBar : public QTabBar {
   void Save(const int id);
   void PlaylistOrderChanged(const QList<int> &ids);
   void PlaylistFavorited(const int id, const bool favorite);
+  void LastTabCloseRequested();
 
  protected:
   void contextMenuEvent(QContextMenuEvent *e) override;


### PR DESCRIPTION
- Ctrl+End to go to last tab
- Ctrl+Home to go to currently active tab (playing/paused)
- Ctrl+C to close current tab

Notes:
- I used Ctrl-C instead of Ctrl-W because Ctrl-W is already taken by  [src/core/mainwindow.cpp:1065](https://github.com/strawberrymusicplayer/strawberry/blob/master/src/core/mainwindow.cpp#L1065). However, that does not seem to be doing anything for me (on Arch Linux / i3). I think this deserves investigation. If this is broken/old code, I think that shortcut could be reclaimed for closing tabs.
- Proposed implementation makes Ctrl+Home return to active tab, or to first tab if none is active. This may be confusing for users and could be restricted to not doing anything if no tab is active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shortcuts/commands to jump to the last or active playlist tab.
  * Added a command to close the current playlist tab (the last remaining tab triggers hide instead of closing).
  * Enabled last/active/close playlist navigation from the main window.
* **UI / Shortcut Changes**
  * Updated the shuffle shortcut from **Ctrl+H** to **Ctrl+Shift+H**.
  * Changed the close-window shortcut from **Ctrl+W** to **Ctrl+Shift+W**.
* **Behavior Update**
  * Closing the last playlist tab now hides the window instead of closing it.
  * Closing a playlist tab now ends any in-tab rename editing first.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->