### PR TITLE
Add support to play webm media files

### DIFF
--- a/src/constants/filefilterconstants.h
+++ b/src/constants/filefilterconstants.h
@@ -27,7 +27,7 @@ constexpr char kAllFilesFilterSpec[] = QT_TRANSLATE_NOOP("FileFilter", "All File
 constexpr char kFileFilter[] =
     "*.wav *.flac *.wv *.ogg *.oga *.opus *.spx *.ape *.mpc "
     "*.mp2 *.mp3 *.m4a *.mp4 *.aac *.asf *.asx *.wma "
-    "*.aif *.aiff *.mka *.tta *.dsf *.dsd "
+    "*.aif *.aiff *.mka *.tta *.dsf *.dsd *.webm "
     "*.cue *.m3u *.m3u8 *.pls *.xspf *.asxini "
     "*.ac3 *.dts "
     "*.mod *.s3m *.xm *.it "

--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -243,6 +243,7 @@ const QStringList Song::kAcceptedExtensions = QStringList() << u"wav"_s
                                                             << u"tta"_s
                                                             << u"dsf"_s
                                                             << u"dsd"_s
+                                                            << u"webm"_s
                                                             << u"ac3"_s
                                                             << u"dts"_s
                                                             << u"spc"_s


### PR DESCRIPTION
Allow play files with`.webm` extension. The WebM can comprise both audio and video. It use used more and more widely as an alternative to MPEG to stream audio. The Strawberry should fully support it, since it is based on Matroska container, which is already in the list of allowed extensions/formats (`*.mka`).

The request to play those files was briefly discussed here https://forum.strawberrymusicplayer.org/topic/1236/add-support-for-webm-files-containing-an-opus-audio-stream

https://en.wikipedia.org/wiki/WebM