### PR TITLE
Fix length filter not converting to nanoseconds

### DIFF
--- a/src/filterparser/filterparser.cpp
+++ b/src/filterparser/filterparser.cpp
@@ -22,6 +22,7 @@
 
 #include <QString>
 
+#include "constants/timeconstants.h"
 #include "filterparser.h"
 #include "filtertreenop.h"
 #include "filtertreeand.h"
@@ -322,7 +323,7 @@ FilterTree *FilterParser::createSearchTermTreeNode(const QString &column, const 
     else if (Song::kInt64SearchColumns.contains(column, Qt::CaseInsensitive)) {
       qint64 number = 0;
       if (column == "length"_L1) {
-        number = ParseTime(value);
+        number = ParseTime(value) * kNsecPerSec;
       }
       else {
         number = value.toLongLong();


### PR DESCRIPTION
I noticed that if I typed `length:<60` the filter would always say there were no results, until today when I kept adding 0s and noticed that `length:<60000000000` did what I wanted it to