### PR TITLE
kglobalaccel: add globalShortcutRepeated signal

### DIFF
--- a/src/globalshortcuts/globalshortcutsbackend-kglobalaccel.cpp
+++ b/src/globalshortcuts/globalshortcutsbackend-kglobalaccel.cpp
@@ -120,6 +120,7 @@ void GlobalShortcutsBackendKGlobalAccel::RegisterFinished(QDBusPendingCallWatche
   }
 
   QObject::connect(component_, &org::kde::kglobalaccel::Component::globalShortcutPressed, this, &GlobalShortcutsBackendKGlobalAccel::GlobalShortcutPressed, Qt::UniqueConnection);
+  QObject::connect(component_, &org::kde::kglobalaccel::Component::globalShortcutRepeated, this, &GlobalShortcutsBackendKGlobalAccel::GlobalShortcutPressed, Qt::UniqueConnection);
 
   qLog(Debug) << "Registered.";
 

--- a/src/globalshortcuts/org.kde.KGlobalAccel.Component.xml
+++ b/src/globalshortcuts/org.kde.KGlobalAccel.Component.xml
@@ -8,6 +8,11 @@
             <arg name="actionUnique" type="s" direction="out"/>
             <arg name="timestamp" type="x" direction="out"/>
         </signal>
+        <signal name="globalShortcutRepeated">
+            <arg name="componentUnique" type="s" direction="out"/>
+            <arg name="actionUnique" type="s" direction="out"/>
+            <arg name="timestamp" type="x" direction="out"/>
+        </signal>
         <method name="cleanUp">
             <arg type="b" direction="out"/>
         </method>


### PR DESCRIPTION
Resolves #1842

This adds the missing `globalShortcutRepeated` signal to Strawberry's `GlobalShortcutsBackendKGlobalAccel` implementation. `globalShortcutRepeated` was added recently in Plasma 6.5.0 and replaced follow-up `globalShortcutPressed` signals while the shortcut button is being pressed.

----

Since #1842 hasn't received a response in over a month, I decided to open a PR and fix it myself, as it's trivial: simply register the new signal and use the same method for handling it. The disconnect call below already disconnects all registered signals, so no change is needed there.

In https://github.com/strawberrymusicplayer/strawberry/issues/1842#issuecomment-3453071025 I've posted the output from `dbus-monitor`, which shows the exact sequence of signals emitted, namely one `globalShortcutPressed` signal followed by multiple `globalShortcutRepeated` signals followed by an eventual `globalShortcutReleased` signal.

```
$ dbus-monitor --session interface=org.kde.kglobalaccel.Component
...
signal time=1761594883.145444 sender=:1.81 -> destination=(null destination) serial=19263 path=/component/Strawberry; interface=org.kde.kglobalaccel.Component; member=globalShortcutPressed
   string "Strawberry"
   string "dec_volume"
   int64 0
signal time=1761594883.765817 sender=:1.81 -> destination=(null destination) serial=19264 path=/component/Strawberry; interface=org.kde.kglobalaccel.Component; member=globalShortcutRepeated
   string "Strawberry"
   string "dec_volume"
   int64 0
signal time=1761594883.807301 sender=:1.81 -> destination=(null destination) serial=19265 path=/component/Strawberry; interface=org.kde.kglobalaccel.Component; member=globalShortcutRepeated
   string "Strawberry"
   string "dec_volume"
   int64 0
...
signal time=1761594884.287596 sender=:1.81 -> destination=(null destination) serial=19277 path=/component/Strawberry; interface=org.kde.kglobalaccel.Component; member=globalShortcutRepeated
   string "Strawberry"
   string "dec_volume"
   int64 0
signal time=1761594884.326952 sender=:1.81 -> destination=(null destination) serial=19278 path=/component/Strawberry; interface=org.kde.kglobalaccel.Component; member=globalShortcutRepeated
   string "Strawberry"
   string "dec_volume"
   int64 0
signal time=1761594884.327360 sender=:1.81 -> destination=(null destination) serial=19279 path=/component/Strawberry; interface=org.kde.kglobalaccel.Component; member=globalShortcutReleased
   string "Strawberry"
   string "dec_volume"
   int64 0
signal time=1761594886.325407 sender=:1.81 -> destination=(null destination) serial=19280 path=/component/Strawberry; interface=org.kde.kglobalaccel.Component; member=globalShortcutPressed
   string "Strawberry"
   string "inc_volume"
   int64 0
signal time=1761594886.955325 sender=:1.81 -> destination=(null destination) serial=19281 path=/component/Strawberry; interface=org.kde.kglobalaccel.Component; member=globalShortcutRepeated
   string "Strawberry"
   string "inc_volume"
   int64 0
signal time=1761594886.995645 sender=:1.81 -> destination=(null destination) serial=19282 path=/component/Strawberry; interface=org.kde.kglobalaccel.Component; member=globalShortcutRepeated
   string "Strawberry"
   string "inc_volume"
   int64 0
...
signal time=1761594887.515705 sender=:1.81 -> destination=(null destination) serial=19295 path=/component/Strawberry; interface=org.kde.kglobalaccel.Component; member=globalShortcutRepeated
   string "Strawberry"
   string "inc_volume"
   int64 0
signal time=1761594887.555295 sender=:1.81 -> destination=(null destination) serial=19296 path=/component/Strawberry; interface=org.kde.kglobalaccel.Component; member=globalShortcutRepeated
   string "Strawberry"
   string "inc_volume"
   int64 0
signal time=1761594887.589364 sender=:1.81 -> destination=(null destination) serial=19297 path=/component/Strawberry; interface=org.kde.kglobalaccel.Component; member=globalShortcutReleased
   string "Strawberry"
   string "inc_volume"
   int64 0
...
```

The PR on the Clementine repo that I had linked in #1842 was made by the same KDE contributor who introduced the DBus interface changes (motivated by my bug report on the KDE bug tracker), so there's no speculation here on whether the changes are needed or not. See https://bugs.kde.org/show_bug.cgi?id=511041#c5 if you have any doubts.

I've verified this fix on a local build. It's broken on `1.2.15`. Using Arch with Plasma 6.5 (Wayland).