### PR TITLE
Include .webp in allowed image extensions

### DIFF
--- a/src/constants/filefilterconstants.h
+++ b/src/constants/filefilterconstants.h
@@ -33,7 +33,7 @@ constexpr char kFileFilter[] =
     "*.mod *.s3m *.xm *.it "
     "*.spc *.vgm";
 
-constexpr char kLoadImageFileFilter[] = QT_TRANSLATE_NOOP("FileFilter", "Images (*.png *.jpg *.jpeg *.bmp *.gif *.xpm *.pbm *.pgm *.ppm *.xbm)");
-constexpr char kSaveImageFileFilter[] = QT_TRANSLATE_NOOP("FileFilter", "Images (*.png *.jpg *.jpeg *.bmp *.xpm *.pbm *.ppm *.xbm)");
+constexpr char kLoadImageFileFilter[] = QT_TRANSLATE_NOOP("FileFilter", "Images (*.png *.jpg *.jpeg *.bmp *.gif *.xpm *.pbm *.pgm *.ppm *.xbm *.webp)");
+constexpr char kSaveImageFileFilter[] = QT_TRANSLATE_NOOP("FileFilter", "Images (*.png *.jpg *.jpeg *.bmp *.xpm *.pbm *.ppm *.xbm *.webp)");
 
 #endif  // FILEFILTERCONSTANTS_H


### PR DESCRIPTION
Modern Qt can read and write webp out of the box, no use excluding that.

(so does my cover scanning pipeline, so there's at least one user of this :) )
