### PR TITLE
Fix "Show in file browser" opens the file instead of directory

### DIFF
--- a/src/utilities/filemanagerutils.cpp
+++ b/src/utilities/filemanagerutils.cpp
@@ -85,7 +85,7 @@ void OpenInFileManager(const QString &path, const QUrl &url) {
            command.startsWith("dolphin"_L1) ||
            command.startsWith("konqueror"_L1) ||
            command.startsWith("kfmclient"_L1)) {
-    proc.startDetached(command, QStringList() << command_params << u"--select"_s << url.toLocalFile());
+    proc.startDetached(command, QStringList() << command_params << u"--select"_s << path);
   }
   else if (command.startsWith("caja"_L1)) {
     proc.startDetached(command, QStringList() << command_params << u"--no-desktop"_s << path);


### PR DESCRIPTION
(KDE), clicking "Show in file browser" makes dolphin open the *file*
rather than the directory in which it resides.
    
This has the unfortunate side effect and then starting playback of the
file in question in the default media player.
    
This patch just opens the directory rather than the file (as it should).

On a completely separate note - is there any particular reason that
`OpenInFileManager` tries to be so clever rather than just invoking
`xdg-open` and let that figure out what to do?