### PR TITLE
feat: create compile_commands.json for clangd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.13)
 
 project(strawberry C CXX)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 if(APPLE)
   enable_language(OBJC OBJCXX)
 endif()


### PR DESCRIPTION
    
cmake has the option to automatically create `compile_commands.json` for
use by clangd in order to enable code navigation, context sensitive help
and so on which is really nice when trying to navigate an unfamiliar
codebase.
    
This feature depends on cmake 3.5 but as we already require 3.13 that
shouldn't be an issue.