### PR TITLE
Add qwebp*.dll to Windows NSIS uninstall script

### DIFF
--- a/dist/windows/strawberry.nsi.in
+++ b/dist/windows/strawberry.nsi.in
@@ -1121,6 +1121,7 @@ Section "Uninstall"
   Delete "$INSTDIR\imageformats\qjpegd.dll"
   Delete "$INSTDIR\imageformats\qtiffd.dll"
   Delete "$INSTDIR\imageformats\qjp2d.dll"
+  Delete "$INSTDIR\imageformats\qwebpd.dll"
 !else
   Delete "$INSTDIR\platforms\qwindows.dll"
   Delete "$INSTDIR\styles\qmodernwindowsstyle.dll"
@@ -1132,6 +1133,7 @@ Section "Uninstall"
   Delete "$INSTDIR\imageformats\qjpeg.dll"
   Delete "$INSTDIR\imageformats\qtiff.dll"
   Delete "$INSTDIR\imageformats\qjp2.dll"
+  Delete "$INSTDIR\imageformats\qwebp.dll"
 !endif
 
   ; MinGW GStreamer plugins


### PR DESCRIPTION
While testing my builds, I noticed that `imageformats\qwebp(d).dll` is left over after uninstall in 1.2.18.

This adds the delete lines for the new dependency to the uninstall section of the NSIS config.