### PR TITLE
macOS/TagFetcher: improve Opus matching reliability (AcoustID POST + MusicBrainz fallback + safer fingerprinting)

### DIFF
--- a/dist/macos/macgstcopy.sh
+++ b/dist/macos/macgstcopy.sh
@@ -45,6 +45,7 @@ fi
 
 mkdir -p "${bundledir}/Contents/PlugIns/gio-modules" || exit 1
 mkdir -p "${bundledir}/Contents/PlugIns/gstreamer" || exit 1
+mkdir -p "${bundledir}/Contents/Frameworks" || exit 1
 
 if [ -e "${GIO_EXTRA_MODULES}/libgiognutls.so" ]; then
   cp -v -f "${GIO_EXTRA_MODULES}/libgiognutls.so" "${bundledir}/Contents/PlugIns/gio-modules/" || exit 1
@@ -91,6 +92,8 @@ libgstid3demux
 libgstid3tag
 libgstisomp4
 libgstlame
+# Needed for WebM/Matroska containers that often wrap Opus streams.
+libgstmatroska
 libgstmpegpsdemux
 libgstmpegpsmux
 libgstmpegtsdemux
@@ -139,12 +142,20 @@ for gst_plugin in $gst_plugins; do
   fi
 done
 
+# libgstmatroska depends on libgstriff, which is not always pulled automatically.
+gst_library_path=$(dirname "${GST_PLUGIN_PATH}")
+if [ -e "${gst_library_path}/libgstriff-1.0.0.dylib" ]; then
+  cp -v -f "${gst_library_path}/libgstriff-1.0.0.dylib" "${bundledir}/Contents/Frameworks/" || exit 1
+  install_name_tool -id "@rpath/libgstriff-1.0.0.dylib" "${bundledir}/Contents/Frameworks/libgstriff-1.0.0.dylib"
+else
+  echo "Warning: Missing ${gst_library_path}/libgstriff-1.0.0.dylib."
+fi
+
 # libsoup is dynamically loaded by gstreamer, so it needs to be copied.
 if [ "${LIBSOUP_LIBRARY_PATH}" = "" ]; then
   echo "Warning: Set the LIBSOUP_LIBRARY_PATH environment variable for copying libsoup."
 else
   if [ -e "${LIBSOUP_LIBRARY_PATH}" ]; then
-    mkdir -p "${bundledir}/Contents/Frameworks" || exit 1
     cp -v -f "${LIBSOUP_LIBRARY_PATH}" "${bundledir}/Contents/Frameworks/" || exit 1
     install_name_tool -id "@rpath/$(basename ${LIBSOUP_LIBRARY_PATH})" "${bundledir}/Contents/Frameworks/$(basename ${LIBSOUP_LIBRARY_PATH})"
   else

--- a/src/dialogs/trackselectiondialog.h
+++ b/src/dialogs/trackselectiondialog.h
@@ -51,7 +51,7 @@ class TrackSelectionDialog : public QDialog {
 
  public Q_SLOTS:
   void FetchTagProgress(const Song &original_song, const QString &progress);
-  void FetchTagFinished(const Song &original_song, const SongList &songs_guessed);
+  void FetchTagFinished(const Song &original_song, const SongList &songs_guessed, const QString &error = QString());
 
   // QDialog
   void accept() override;
@@ -78,6 +78,8 @@ class TrackSelectionDialog : public QDialog {
     Song original_song_;
     bool pending_;
     QString progress_string_;
+    // Carries technical diagnostics returned by TagFetcher for the error page.
+    QString error_string_;
     SongList results_;
     int selected_result_;
   };

--- a/src/dialogs/trackselectiondialog.ui
+++ b/src/dialogs/trackselectiondialog.ui
@@ -143,6 +143,41 @@
          </widget>
         </item>
         <item>
+         <widget class="QLabel" name="error_details_title">
+          <property name="text">
+           <string>Technical details</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="visible">
+           <bool>false</bool>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">QLabel { font-weight: bold; }</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="error_details">
+          <property name="text">
+           <string></string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::TextSelectableByMouse</set>
+          </property>
+          <property name="visible">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
          <spacer name="verticalSpacer_4">
           <property name="orientation">
            <enum>Qt::Vertical</enum>

--- a/src/engine/chromaprinter.cpp
+++ b/src/engine/chromaprinter.cpp
@@ -34,6 +34,7 @@
 #include <QIODevice>
 #include <QByteArray>
 #include <QString>
+#include <QUrl>
 #include <QElapsedTimer>
 
 #include "chromaprinter.h"
@@ -47,14 +48,26 @@ using u_int32_t = unsigned int;
 #endif
 
 namespace {
-constexpr int kDecodeRate = 11025;
-constexpr int kDecodeChannels = 1;
-constexpr int kPlayLengthSecs = 30;
-constexpr int kTimeoutSecs = 10;
+constexpr int kTimeoutSecs = 30;
+constexpr int kMinimumEncodedFingerprintLength = 16;
+// Bound the amount of decoded PCM we keep in memory while fingerprinting.
+constexpr int kMaxPcmSeconds = 120;
+
+QByteArray ToGstUrl(const QUrl &url) {
+  if (url.isLocalFile() && !url.host().isEmpty()) {
+    const QString str = "file:////"_L1 + url.host() + url.path();
+    return str.toUtf8();
+  }
+  return url.toEncoded();
+}
 }  // namespace
 
 Chromaprinter::Chromaprinter(const QString &filename)
     : filename_(filename),
+      sample_rate_(0),
+      channels_(0),
+      max_pcm_bytes_(0),
+      pcm_limit_reached_(false),
       convert_element_(nullptr) {}
 
 GstElement *Chromaprinter::CreateElement(const QString &factory_name, GstElement *bin) {
@@ -75,50 +88,55 @@ QString Chromaprinter::CreateFingerprint() {
 
   Q_ASSERT(qobject_cast<QApplication*>(QCoreApplication::instance()) == nullptr || QThread::currentThread() != qApp->thread());
 
-  if (!buffer_.open(QIODevice::WriteOnly)) return QString();
+  last_error_.clear();
+  sample_rate_ = 0;
+  channels_ = 0;
+  max_pcm_bytes_ = 0;
+  pcm_limit_reached_ = false;
+  auto set_error = [this](const QString &error) {
+    last_error_ = error;
+    qLog(Warning) << "Chromaprinter:" << error << "File:" << filename_;
+  };
+
+  if (!buffer_.open(QIODevice::WriteOnly)) {
+    set_error(QStringLiteral("Could not open temporary fingerprint buffer."));
+    return QString();
+  }
 
   GstElement *pipeline = gst_pipeline_new("pipeline");
   if (!pipeline) {
     buffer_.close();
+    set_error(QStringLiteral("Could not create GStreamer pipeline."));
     return QString();
   }
 
-  GstElement *src = CreateElement(u"filesrc"_s, pipeline);
-  GstElement *decode = CreateElement(u"decodebin"_s, pipeline);
+  GstElement *decode = CreateElement(u"uridecodebin"_s, pipeline);
   GstElement *convert = CreateElement(u"audioconvert"_s, pipeline);
-  GstElement *resample = CreateElement(u"audioresample"_s, pipeline);
+  GstElement *queue = CreateElement(u"queue2"_s, pipeline);
   GstElement *sink = CreateElement(u"appsink"_s, pipeline);
 
-  if (!src || !decode || !convert || !resample || !sink) {
+  if (!decode || !convert || !queue || !sink) {
     gst_object_unref(pipeline);
     buffer_.close();
+    set_error(QStringLiteral("Could not create one or more GStreamer elements (uridecodebin/audioconvert/queue2/appsink)."));
     return QString();
   }
 
   convert_element_ = convert;
 
   // Connect the elements
-  if (!gst_element_link_many(src, decode, nullptr)) {
-    qLog(Error) << "Failed to link filesrc to decodebin.";
-    gst_object_unref(pipeline);
-    buffer_.close();
-    return QString();
-  }
-  if (!gst_element_link_many(convert, resample, nullptr)) {
-    qLog(Error) << "Failed to link audioconvert to audioresample.";
-    gst_object_unref(pipeline);
-    buffer_.close();
-    return QString();
-  }
-
-  // Chromaprint expects mono 16-bit ints at a sample rate of 11025Hz.
-  GstCaps *caps = gst_caps_new_simple("audio/x-raw", "format", G_TYPE_STRING, "S16LE", "channels", G_TYPE_INT, kDecodeChannels, "rate", G_TYPE_INT, kDecodeRate, nullptr);
-  const bool resample_to_sink_linked = gst_element_link_filtered(resample, sink, caps);
+  // Request 16-bit PCM and let GStreamer keep a supported sample rate.
+  GstCaps *caps = gst_caps_new_simple("audio/x-raw",
+                                      "format", G_TYPE_STRING, "S16LE",
+                                      "layout", G_TYPE_STRING, "interleaved",
+                                      "channels", GST_TYPE_INT_RANGE, 1, 2,
+                                      nullptr);
+  const gboolean sink_link_ok = gst_element_link_filtered(convert, queue, caps);
   gst_caps_unref(caps);
-  if (!resample_to_sink_linked) {
-    qLog(Error) << "Failed to link audioresample to appsink with filter.";
+  if (!sink_link_ok || !gst_element_link_many(queue, sink, nullptr)) {
     gst_object_unref(pipeline);
     buffer_.close();
+    set_error(QStringLiteral("Failed to link audioconvert/queue2/appsink with required audio caps."));
     return QString();
   }
 
@@ -129,18 +147,19 @@ QString Chromaprinter::CreateFingerprint() {
   g_object_set(G_OBJECT(sink), "sync", FALSE, nullptr);
   g_object_set(G_OBJECT(sink), "emit-signals", TRUE, nullptr);
 
-  // Set the filename
-  g_object_set(src, "location", filename_.toUtf8().constData(), nullptr);
+  // Use URI-based decodebin for more robust demux/decoder selection.
+  const QByteArray gst_url = ToGstUrl(QUrl::fromLocalFile(filename_));
+  g_object_set(G_OBJECT(decode), "uri", gst_url.constData(), nullptr);
+
+  // Allow queueing of decoded audio to avoid starving appsink callback.
+  // Keep the in-pipeline queue bounded as an additional memory guard.
+  g_object_set(G_OBJECT(queue), "max-size-time", 10 * GST_SECOND, nullptr);
+  g_object_set(G_OBJECT(queue), "max-size-buffers", 0, nullptr);
+  g_object_set(G_OBJECT(queue), "max-size-bytes", 8 * 1024 * 1024, nullptr);
 
   // Connect signals
   GstBus *bus = gst_pipeline_get_bus(GST_PIPELINE(pipeline));
   CHECKED_GCONNECT(decode, "pad-added", &NewPadCallback, this);
-
-  // Play only first x seconds
-  gst_element_set_state(pipeline, GST_STATE_PAUSED);
-  // wait for state change before seeking
-  gst_element_get_state(pipeline, nullptr, nullptr, kTimeoutSecs * GST_SECOND);
-  gst_element_seek(pipeline, 1.0, GST_FORMAT_TIME, GST_SEEK_FLAG_FLUSH, GST_SEEK_TYPE_SET, 0 * GST_SECOND, GST_SEEK_TYPE_SET, kPlayLengthSecs * GST_SECOND);
 
   QElapsedTimer time;
   time.start();
@@ -148,22 +167,52 @@ QString Chromaprinter::CreateFingerprint() {
   // Start playing
   gst_element_set_state(pipeline, GST_STATE_PLAYING);
 
-  // Wait until EOS or error
-  GstMessage *msg = gst_bus_timed_pop_filtered(bus, kTimeoutSecs * GST_SECOND, static_cast<GstMessageType>(GST_MESSAGE_EOS | GST_MESSAGE_ERROR));
-  if (msg) {
+  bool finished = false;
+  QElapsedTimer bus_timer;
+  bus_timer.start();
+
+  while (!finished && bus_timer.elapsed() < kTimeoutSecs * 1000) {
+    GstMessage *msg = gst_bus_timed_pop_filtered(
+        bus, 200 * GST_MSECOND,
+        static_cast<GstMessageType>(GST_MESSAGE_EOS | GST_MESSAGE_ERROR | GST_MESSAGE_WARNING));
+    if (!msg) continue;
+
     if (msg->type == GST_MESSAGE_ERROR) {
-      // Report error
       GError *error = nullptr;
       gchar *debugs = nullptr;
       gst_message_parse_error(msg, &error, &debugs);
       if (error) {
-        QString message = QString::fromLocal8Bit(error->message);
+        const QString message = QString::fromLocal8Bit(error->message);
         g_error_free(error);
         qLog(Debug) << "Error processing" << filename_ << ":" << message;
+        set_error(QStringLiteral("GStreamer decode error: %1").arg(message));
+      }
+      if (debugs) free(debugs);
+      finished = true;
+    }
+    else if (msg->type == GST_MESSAGE_WARNING) {
+      GError *warning = nullptr;
+      gchar *debugs = nullptr;
+      gst_message_parse_warning(msg, &warning, &debugs);
+      if (warning) {
+        const QString message = QString::fromLocal8Bit(warning->message);
+        g_error_free(warning);
+        qLog(Warning) << "Chromaprinter warning for" << filename_ << ":" << message;
+        if (last_error_.isEmpty()) {
+          last_error_ = QStringLiteral("GStreamer warning: %1").arg(message);
+        }
       }
       g_free(debugs);
     }
+    else if (msg->type == GST_MESSAGE_EOS) {
+      finished = true;
+    }
+
     gst_message_unref(msg);
+  }
+
+  if (!finished) {
+    qLog(Warning) << "Chromaprinter: Timed out waiting for EOS/error after" << kTimeoutSecs << "seconds for" << filename_;
   }
 
   const qint64 decode_time = time.restart();
@@ -172,11 +221,69 @@ QString Chromaprinter::CreateFingerprint() {
 
   // Generate fingerprint from recorded buffer data
   QByteArray data = buffer_.data();
+  if (data.isEmpty()) {
+    // Usually means decodebin never produced a usable raw audio pad.
+    gst_object_unref(bus);
+    gst_element_set_state(pipeline, GST_STATE_NULL);
+    gst_object_unref(pipeline);
+    QString error_message = QStringLiteral("No decoded audio samples were produced by GStreamer.");
+    const QString callback_error = last_error_.trimmed();
+    if (!callback_error.isEmpty() && !error_message.contains(callback_error, Qt::CaseInsensitive)) {
+      error_message += QStringLiteral(" %1").arg(callback_error);
+    }
+    set_error(error_message);
+    return QString();
+  }
+  if (pcm_limit_reached_) {
+    qLog(Debug) << "Chromaprinter: Reached in-memory PCM cap for" << filename_ << "bytes stored" << data.size();
+  }
+
+  if (sample_rate_ <= 0 || channels_ <= 0) {
+    gst_object_unref(bus);
+    gst_element_set_state(pipeline, GST_STATE_NULL);
+    gst_object_unref(pipeline);
+    QString error_message = QStringLiteral("No valid PCM format metadata was received from GStreamer.");
+    const QString callback_error = last_error_.trimmed();
+    if (!callback_error.isEmpty() && !error_message.contains(callback_error, Qt::CaseInsensitive)) {
+      error_message += QStringLiteral(" %1").arg(callback_error);
+    }
+    set_error(error_message);
+    return QString();
+  }
 
   ChromaprintContext *chromaprint = chromaprint_new(CHROMAPRINT_ALGORITHM_DEFAULT);
-  chromaprint_start(chromaprint, kDecodeRate, kDecodeChannels);
-  chromaprint_feed(chromaprint, reinterpret_cast<int16_t*>(data.data()), static_cast<int>(data.size() / 2));
-  chromaprint_finish(chromaprint);
+  if (!chromaprint) {
+    gst_object_unref(bus);
+    gst_element_set_state(pipeline, GST_STATE_NULL);
+    gst_object_unref(pipeline);
+    set_error(QStringLiteral("Failed to create Chromaprint context."));
+    return QString();
+  }
+
+  if (chromaprint_start(chromaprint, sample_rate_, channels_) != 1) {
+    chromaprint_free(chromaprint);
+    gst_object_unref(bus);
+    gst_element_set_state(pipeline, GST_STATE_NULL);
+    gst_object_unref(pipeline);
+    set_error(QStringLiteral("Chromaprint could not start (sample rate %1, channels %2).").arg(sample_rate_).arg(channels_));
+    return QString();
+  }
+  if (chromaprint_feed(chromaprint, reinterpret_cast<int16_t*>(data.data()), static_cast<int>(data.size() / 2)) != 1) {
+    chromaprint_free(chromaprint);
+    gst_object_unref(bus);
+    gst_element_set_state(pipeline, GST_STATE_NULL);
+    gst_object_unref(pipeline);
+    set_error(QStringLiteral("Chromaprint failed while processing decoded samples."));
+    return QString();
+  }
+  if (chromaprint_finish(chromaprint) != 1) {
+    chromaprint_free(chromaprint);
+    gst_object_unref(bus);
+    gst_element_set_state(pipeline, GST_STATE_NULL);
+    gst_object_unref(pipeline);
+    set_error(QStringLiteral("Chromaprint could not finalize fingerprint."));
+    return QString();
+  }
 
   u_int32_t *fprint = nullptr;
   int size = 0;
@@ -190,7 +297,13 @@ QString Chromaprinter::CreateFingerprint() {
       fingerprint.append(encoded, encoded_size);
       chromaprint_dealloc(encoded);
     }
+    else {
+      set_error(QStringLiteral("Chromaprint failed to encode generated fingerprint."));
+    }
     chromaprint_dealloc(fprint);
+  }
+  else {
+    set_error(QStringLiteral("Chromaprint did not return a raw fingerprint."));
   }
   chromaprint_free(chromaprint);
 
@@ -204,7 +317,15 @@ QString Chromaprinter::CreateFingerprint() {
   gst_element_set_state(pipeline, GST_STATE_NULL);
   gst_object_unref(pipeline);
 
-  return QString::fromUtf8(fingerprint);
+  const QString fingerprint_string = QString::fromUtf8(fingerprint);
+  if (fingerprint_string.size() < kMinimumEncodedFingerprintLength) {
+    set_error(QStringLiteral("Generated fingerprint is too short (%1 bytes).").arg(fingerprint_string.size()));
+    return QString();
+  }
+
+  qLog(Debug) << "Chromaprinter: Generated fingerprint for" << filename_ << "length" << fingerprint_string.size();
+
+  return fingerprint_string;
 
 }
 
@@ -213,14 +334,52 @@ void Chromaprinter::NewPadCallback(GstElement *element, GstPad *pad, gpointer da
   Q_UNUSED(element)
 
   Chromaprinter *instance = reinterpret_cast<Chromaprinter*>(data);
+  if (!instance || !instance->convert_element_) {
+    return;
+  }
   GstPad *const audiopad = gst_element_get_static_pad(instance->convert_element_, "sink");
-
-  if (GST_PAD_IS_LINKED(audiopad)) {
-    qLog(Warning) << "audiopad is already linked, unlinking old pad";
-    gst_pad_unlink(audiopad, GST_PAD_PEER(audiopad));
+  if (!audiopad) {
+    if (instance->last_error_.isEmpty()) {
+      instance->last_error_ = QStringLiteral("Could not obtain audioconvert sink pad.");
+    }
+    return;
   }
 
-  gst_pad_link(pad, audiopad);
+  GstCaps *caps = gst_pad_get_current_caps(pad);
+  if (!caps) {
+    caps = gst_pad_query_caps(pad, nullptr);
+  }
+  QString caps_name;
+  if (caps) {
+    const GstStructure *structure = gst_caps_get_structure(caps, 0);
+    if (structure) {
+      const gchar *name = gst_structure_get_name(structure);
+      if (name) {
+        caps_name = QString::fromLatin1(name);
+      }
+    }
+    gst_caps_unref(caps);
+  }
+
+  if (GST_PAD_IS_LINKED(audiopad)) {
+    gst_object_unref(audiopad);
+    return;
+  }
+
+  const GstPadLinkReturn ret = gst_pad_link(pad, audiopad);
+  if (ret != GST_PAD_LINK_OK) {
+    QString reason;
+    if (!caps_name.isEmpty()) {
+      reason = QStringLiteral("Failed to link decodebin pad '%1' to audioconvert (code %2).").arg(caps_name).arg(static_cast<int>(ret));
+    }
+    else {
+      reason = QStringLiteral("Failed to link decodebin pad to audioconvert (code %1).").arg(static_cast<int>(ret));
+    }
+    if (instance->last_error_.isEmpty()) {
+      instance->last_error_ = reason;
+    }
+    qLog(Warning) << "Chromaprinter:" << reason << "File:" << instance->filename_;
+  }
   gst_object_unref(audiopad);
 
 }
@@ -231,17 +390,56 @@ GstFlowReturn Chromaprinter::NewBufferCallback(GstAppSink *app_sink, gpointer se
 
   GstSample *sample = gst_app_sink_pull_sample(app_sink);
   if (!sample) return GST_FLOW_ERROR;
+
+  GstCaps *caps = gst_sample_get_caps(sample);
+  if (caps) {
+    const GstStructure *structure = gst_caps_get_structure(caps, 0);
+    if (structure) {
+      int sample_rate = 0;
+      int channels = 0;
+      const bool has_sample_rate = gst_structure_get_int(structure, "rate", &sample_rate);
+      const bool has_channels = gst_structure_get_int(structure, "channels", &channels);
+      if (has_sample_rate && has_channels && sample_rate > 0 && channels > 0) {
+        if (me->sample_rate_ == 0 && me->channels_ == 0) {
+          me->sample_rate_ = sample_rate;
+          me->channels_ = channels;
+          // Bound retained PCM bytes based on the actual decoded stream format.
+          me->max_pcm_bytes_ = static_cast<qint64>(sample_rate) * static_cast<qint64>(channels) * sizeof(int16_t) * kMaxPcmSeconds;
+        }
+      }
+    }
+  }
+
   GstBuffer *buffer = gst_sample_get_buffer(sample);
   if (buffer) {
     GstMapInfo map;
     if (gst_buffer_map(buffer, &map, GST_MAP_READ)) {
-      me->buffer_.write(reinterpret_cast<const char*>(map.data), static_cast<qint64>(map.size));
+      qint64 bytes_to_write = static_cast<qint64>(map.size);
+      if (me->max_pcm_bytes_ > 0) {
+        const qint64 remaining_bytes = me->max_pcm_bytes_ - me->buffer_.size();
+        if (remaining_bytes <= 0) {
+          me->pcm_limit_reached_ = true;
+          bytes_to_write = 0;
+        }
+        else if (bytes_to_write > remaining_bytes) {
+          me->pcm_limit_reached_ = true;
+          bytes_to_write = remaining_bytes;
+        }
+      }
+
+      if (bytes_to_write > 0) {
+        me->buffer_.write(reinterpret_cast<const char*>(map.data), bytes_to_write);
+      }
       gst_buffer_unmap(buffer, &map);
     }
   }
   gst_sample_unref(sample);
 
+  if (me->pcm_limit_reached_) {
+    // Ask upstream to finish once we have enough decoded material.
+    return GST_FLOW_EOS;
+  }
+
   return GST_FLOW_OK;
 
 }
-

--- a/src/engine/chromaprinter.h
+++ b/src/engine/chromaprinter.h
@@ -28,6 +28,7 @@
 #include <gst/gst.h>
 #include <gst/app/gstappsink.h>
 
+#include <QtGlobal>
 #include <QBuffer>
 #include <QString>
 
@@ -45,6 +46,7 @@ class Chromaprinter {
   // This method is blocking, so you want to call it in another thread.
   // Returns an empty string if no fingerprint could be created.
   QString CreateFingerprint();
+  QString LastError() const { return last_error_; }
 
  private:
   static GstElement *CreateElement(const QString &factory_name, GstElement *bin = nullptr);
@@ -54,6 +56,12 @@ class Chromaprinter {
 
  private:
   QString filename_;
+  QString last_error_;
+  int sample_rate_;
+  int channels_;
+  // Hard cap for decoded PCM retained in memory to avoid unbounded growth.
+  qint64 max_pcm_bytes_;
+  bool pcm_limit_reached_;
 
   GstElement *convert_element_;
 

--- a/src/engine/gststartup.cpp
+++ b/src/engine/gststartup.cpp
@@ -29,6 +29,7 @@
 #include <QString>
 #include <QDir>
 #include <QFile>
+#include <QFileInfo>
 
 #include "core/logging.h"
 #include "core/standardpaths.h"
@@ -44,12 +45,59 @@ using namespace Qt::Literals::StringLiterals;
 
 namespace GstStartup {
 
+namespace {
+
+#ifdef USE_BUNDLE
+QString BundledPluginRootPath() {
+
+  const QString app_path = QCoreApplication::applicationDirPath();
+
+#  if defined(Q_OS_MACOS)
+  return QDir::cleanPath(app_path + "/../PlugIns"_L1);
+#  elif defined(Q_OS_UNIX)
+  return QDir::cleanPath(app_path + "/../plugins"_L1);
+#  elif defined(Q_OS_WIN32)
+  return app_path;
+#  else
+  return QString();
+#  endif
+
+}
+
+QString BundledGstPluginPath() {
+
+  const QString plugin_root_path = BundledPluginRootPath();
+  if (plugin_root_path.isEmpty()) {
+    return QString();
+  }
+
+#  if defined(Q_OS_WIN32)
+  return plugin_root_path + "/gstreamer-plugins"_L1;
+#  else
+  return plugin_root_path + "/gstreamer"_L1;
+#  endif
+
+}
+#endif  // USE_BUNDLE
+
+}  // namespace
+
 void Initialize() {
 
   SetEnvironment();
 
   gst_init(nullptr, nullptr);
   gst_pb_utils_init();
+
+#ifdef USE_BUNDLE
+  const QString gst_plugin_path = BundledGstPluginPath();
+  if (!gst_plugin_path.isEmpty() && QDir(gst_plugin_path).exists()) {
+    if (GstRegistry *registry = gst_registry_get()) {
+      qLog(Debug) << "Scanning bundled GStreamer plugins in" << gst_plugin_path;
+      gst_registry_scan_path(registry, gst_plugin_path.toUtf8().constData());
+    }
+  }
+#endif
 
 #ifdef HAVE_GSTFASTSPECTRUM
   gst_strawberry_fastspectrum_register_static();
@@ -81,17 +129,8 @@ void SetEnvironment() {
 
 #ifdef USE_BUNDLE
 
-  const QString app_path = QCoreApplication::applicationDirPath();
-
   // Set plugin root path
-  QString plugin_root_path;
-#  if defined(Q_OS_MACOS)
-  plugin_root_path = QDir::cleanPath(app_path + "/../PlugIns"_L1);
-#  elif defined(Q_OS_UNIX)
-  plugin_root_path = QDir::cleanPath(app_path + "/../plugins"_L1);
-#  elif defined(Q_OS_WIN32)
-  plugin_root_path = app_path;
-#  endif
+  const QString plugin_root_path = BundledPluginRootPath();
 
   // Set GIO module path
   const QString gio_module_path = plugin_root_path + "/gio-modules"_L1;
@@ -145,7 +184,10 @@ void SetEnvironment() {
 #endif  // USE_BUNDLE
 
 #if defined(Q_OS_WIN32) || defined(Q_OS_MACOS)
-  QString gst_registry_filename = StandardPaths::WritableLocation(StandardPaths::StandardLocation::AppLocalDataLocation) + QStringLiteral("/gst-registry-%1-bin").arg(QCoreApplication::applicationVersion());
+  const QFileInfo executable_info(QCoreApplication::applicationFilePath());
+  const qint64 executable_stamp = executable_info.exists() ? executable_info.lastModified().toSecsSinceEpoch() : 0;
+  // Include executable timestamp to avoid reusing stale GStreamer registries across rebuilds.
+  QString gst_registry_filename = StandardPaths::WritableLocation(StandardPaths::StandardLocation::AppLocalDataLocation) + QStringLiteral("/gst-registry-%1-%2-bin").arg(QCoreApplication::applicationVersion()).arg(executable_stamp);
   qLog(Debug) << "Setting GStreamer registry file to" << gst_registry_filename;
   Utilities::SetEnv("GST_REGISTRY", gst_registry_filename);
 #endif

--- a/src/musicbrainz/acoustidclient.cpp
+++ b/src/musicbrainz/acoustidclient.cpp
@@ -54,6 +54,15 @@ namespace {
 constexpr char kClientId[] = "0qjUoxbowg";
 constexpr char kUrl[] = "https://api.acoustid.org/v2/lookup";
 constexpr int kDefaultTimeout = 5000;  // msec
+
+QString FingerprintPreview(const QString &fingerprint) {
+  constexpr int kPreviewLength = 24;
+  const QString normalized = fingerprint.trimmed();
+  if (normalized.size() <= kPreviewLength) {
+    return normalized;
+  }
+  return normalized.left(kPreviewLength) + QStringLiteral("...");
+}
 }  // namespace
 
 AcoustidClient::AcoustidClient(SharedPtr<NetworkAccessManager> network, QObject *parent)
@@ -74,11 +83,15 @@ void AcoustidClient::Start(const int id, const QString &fingerprint, int duratio
   using Param = QPair<QString, QString>;
   using ParamList = QList<Param>;
 
+  const qint64 duration_secs = qMax(static_cast<qint64>(1), duration_msec / kMsecPerSec);
+  const QString normalized_fingerprint = fingerprint.trimmed();
+
+  // Send AcoustID lookup parameters as form data to avoid oversized query URLs.
   const ParamList params = ParamList() << Param(u"format"_s, u"json"_s)
                                        << Param(u"client"_s, QLatin1String(kClientId))
-                                       << Param(u"duration"_s, QString::number(std::max(1LL, duration_msec / kMsecPerSec)))
+                                       << Param(u"duration"_s, QString::number(duration_secs))
                                        << Param(u"meta"_s, u"recordingids+sources"_s)
-                                       << Param(u"fingerprint"_s, fingerprint);
+                                       << Param(u"fingerprint"_s, normalized_fingerprint);
 
   QUrlQuery url_query;
   url_query.setQueryItems(params);
@@ -86,6 +99,7 @@ void AcoustidClient::Start(const int id, const QString &fingerprint, int duratio
   QNetworkRequest network_request(QUrl(QString::fromLatin1(kUrl)));
   network_request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
   network_request.setHeader(QNetworkRequest::ContentTypeHeader, u"application/x-www-form-urlencoded"_s);
+  qLog(Debug) << "AcoustID request id" << id << "duration(s)" << duration_secs << "fingerprint length" << normalized_fingerprint.size() << "preview" << FingerprintPreview(normalized_fingerprint);
   QNetworkReply *reply = network_->post(network_request, data);
   QObject::connect(reply, &QNetworkReply::finished, this, [this, reply, id]() { RequestFinished(reply, id); });
   requests_[id] = reply;
@@ -139,30 +153,73 @@ void AcoustidClient::RequestFinished(QNetworkReply *reply, const int request_id)
   reply->deleteLater();
   requests_.remove(request_id);
 
-  if (reply->error() != QNetworkReply::NoError || reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() != 200) {
-    if (reply->error() != QNetworkReply::NoError) {
-      qLog(Error) << QStringLiteral("Acoustid: %1 (%2)").arg(reply->errorString()).arg(reply->error());
+  const int http_status_code = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+  const QByteArray data = reply->readAll();
+
+  QString api_error_message;
+  QJsonObject json_object;
+  // Keep only a short snippet for diagnostics to avoid dumping full responses in logs.
+  const QString response_preview = QString::fromUtf8(data.left(512)).trimmed();
+  if (!data.isEmpty()) {
+    QJsonParseError parse_error;
+    const QJsonDocument json_document = QJsonDocument::fromJson(data, &parse_error);
+    if (parse_error.error == QJsonParseError::NoError) {
+      json_object = json_document.object();
+      const QString status = json_object["status"_L1].toString();
+      if (status != "ok"_L1) {
+        if (json_object["error"_L1].isObject()) {
+          const QJsonObject error_object = json_object["error"_L1].toObject();
+          const int api_error_code = error_object["code"_L1].toInt();
+          const QString api_error_text = error_object["message"_L1].toString();
+          if (!api_error_text.isEmpty()) {
+            api_error_message = QStringLiteral("%1 (%2)").arg(api_error_text).arg(api_error_code);
+          }
+        }
+        else if (json_object["error"_L1].isString()) {
+          api_error_message = json_object["error"_L1].toString();
+        }
+        if (api_error_message.isEmpty()) {
+          api_error_message = status;
+        }
+      }
     }
-    else {
-      qLog(Error) << QStringLiteral("Acoustid: Received HTTP code %1").arg(reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt());
+    else if (reply->error() == QNetworkReply::NoError && http_status_code == 200) {
+      Q_EMIT Finished(request_id, QStringList(), parse_error.errorString());
+      return;
     }
-    Q_EMIT Finished(request_id, QStringList());
+  }
+
+  if (reply->error() != QNetworkReply::NoError || http_status_code != 200) {
+    QString error_message = api_error_message;
+    if (error_message.isEmpty()) {
+      if (reply->error() != QNetworkReply::NoError) {
+        error_message = QStringLiteral("%1 (%2)").arg(reply->errorString()).arg(reply->error());
+      }
+      else {
+        error_message = QStringLiteral("Received HTTP code %1").arg(http_status_code);
+      }
+    }
+    qLog(Error) << QStringLiteral("Acoustid: %1").arg(error_message);
+    if (!response_preview.isEmpty()) {
+      qLog(Debug) << "AcoustID non-200 response body preview:" << response_preview;
+    }
+    Q_EMIT Finished(request_id, QStringList(), error_message);
     return;
   }
 
-  QJsonParseError error;
-  const QJsonDocument json_document = QJsonDocument::fromJson(reply->readAll(), &error);
-
-  if (error.error != QJsonParseError::NoError) {
-    Q_EMIT Finished(request_id, QStringList(), error.errorString());
+  if (json_object.isEmpty()) {
+    Q_EMIT Finished(request_id, QStringList(), QStringLiteral("Empty response from AcoustID."));
     return;
   }
-
-  const QJsonObject json_object = json_document.object();
 
   const QString status = json_object["status"_L1].toString();
   if (status != "ok"_L1) {
-    Q_EMIT Finished(request_id, QStringList(), status);
+    const QString status_error = api_error_message.isEmpty() ? status : api_error_message;
+    qLog(Warning) << "AcoustID request id" << request_id << "status not ok:" << status_error;
+    if (!response_preview.isEmpty()) {
+      qLog(Debug) << "AcoustID status!=ok body preview:" << response_preview;
+    }
+    Q_EMIT Finished(request_id, QStringList(), status_error);
     return;
   }
 
@@ -196,6 +253,8 @@ void AcoustidClient::RequestFinished(QNetworkReply *reply, const int request_id)
   for (const IdSource &is : std::as_const(id_source_list)) {
     id_list << is.id_;
   }
+
+  qLog(Debug) << "AcoustID request id" << request_id << "returned" << id_list.count() << "recording id(s)";
 
   Q_EMIT Finished(request_id, id_list);
 

--- a/src/musicbrainz/musicbrainzclient.cpp
+++ b/src/musicbrainz/musicbrainzclient.cpp
@@ -20,6 +20,7 @@
 #include "config.h"
 
 #include <algorithm>
+#include <cmath>
 #include <utility>
 
 #include <QSet>
@@ -55,6 +56,165 @@ constexpr char kDateRegex[] = "^[12]\\d{3}";
 constexpr int kRequestsDelay = 1200;
 constexpr int kDefaultTimeout = 8000;
 constexpr int kMaxRequestPerTrack = 3;
+constexpr int kSearchResultsLimit = 12;
+
+QString NormalizeSearchTerm(const QString &text) {
+  QString normalized = text.simplified().trimmed().toLower();
+  normalized.replace(u'_', u' ');
+  return normalized;
+}
+
+QString EscapeSearchTerm(const QString &text) {
+  QString escaped = text.simplified().trimmed();
+  escaped.replace(u'"', u' ');
+  escaped.replace(u'\\', u' ');
+  return escaped.simplified();
+}
+
+QString NormalizeTitleForSearch(const QString &title) {
+  QString normalized = title.simplified().trimmed();
+  static const QList<QRegularExpression> suffix_patterns = {
+      QRegularExpression(QStringLiteral("\\s*\\((official|lyrics?|lyric\\s+video|music\\s+video|audio|hd|4k)[^\\)]*\\)\\s*$"), QRegularExpression::CaseInsensitiveOption),
+      QRegularExpression(QStringLiteral("\\s*\\[(official|lyrics?|lyric\\s+video|music\\s+video|audio|hd|4k)[^\\]]*\\]\\s*$"), QRegularExpression::CaseInsensitiveOption),
+      QRegularExpression(QStringLiteral("\\s*[-–—:]\\s*(official|lyrics?|lyric\\s+video|music\\s+video|audio|hd|4k)\\b.*$"), QRegularExpression::CaseInsensitiveOption)};
+
+  for (const QRegularExpression &pattern : suffix_patterns) {
+    normalized.replace(pattern, QString());
+  }
+  return normalized.simplified();
+}
+
+QStringList TitleSearchTerms(const QString &title) {
+
+  static const QSet<QString> kStopWords = {
+      u"the"_s, u"and"_s, u"of"_s, u"a"_s, u"an"_s, u"to"_s, u"in"_s, u"on"_s,
+      u"le"_s, u"la"_s, u"les"_s, u"de"_s, u"du"_s, u"des"_s, u"et"_s, u"un"_s, u"une"_s,
+      u"el"_s, u"los"_s, u"las"_s, u"y"_s, u"en"_s, u"del"_s, u"da"_s, u"do"_s, u"das"_s, u"dos"_s};
+  static const QRegularExpression kLeadingTrackNumberRegex(QStringLiteral("^\\d+\\s*[-–—.:]\\s*"));
+  static const QRegularExpression kBracketRegex(QStringLiteral("[\\[\\]\\(\\){}]"));
+  static const QRegularExpression kWhitespaceRegex(QStringLiteral("\\s+"));
+  static const QRegularExpression kTrimNonWordPrefixRegex(QStringLiteral("^[^\\p{L}\\p{N}]+"));
+  static const QRegularExpression kTrimNonWordSuffixRegex(QStringLiteral("[^\\p{L}\\p{N}]+$"));
+
+  QString normalized = NormalizeTitleForSearch(title);
+  if (normalized.isEmpty()) {
+    normalized = title.simplified().trimmed();
+  }
+
+  normalized.replace(kLeadingTrackNumberRegex, QString());
+  normalized.replace(u'_', u' ');
+  normalized.replace(kBracketRegex, QStringLiteral(" "));
+  normalized = EscapeSearchTerm(normalized);
+
+  const QStringList tokens = normalized.split(kWhitespaceRegex, Qt::SkipEmptyParts);
+  QStringList terms;
+  terms.reserve(tokens.count());
+  for (const QString &token : tokens) {
+    QString word = token.trimmed().toLower();
+    word.remove(kTrimNonWordPrefixRegex);
+    word.remove(kTrimNonWordSuffixRegex);
+    if (word.isEmpty()) continue;
+    if (word.size() <= 1) continue;
+    if (word.toInt() > 0 && word.size() <= 2) continue;
+    if (kStopWords.contains(word)) continue;
+    if (!terms.contains(word)) {
+      terms << word;
+    }
+  }
+
+  // Keep search usable even if aggressive filtering removed everything.
+  if (terms.isEmpty()) {
+    for (const QString &token : tokens) {
+      const QString word = token.trimmed().toLower();
+      if (word.size() < 2) continue;
+      if (!terms.contains(word)) {
+        terms << word;
+      }
+      if (terms.size() >= 6) break;
+    }
+  }
+
+  return terms;
+}
+
+QString BuildSearchQuery(const QString &title, const QString &artist, const QString &album) {
+  // Build a tolerant query for noisy file names while still preferring exact phrases.
+  QStringList query_parts;
+  const QStringList title_terms = TitleSearchTerms(title);
+  QString normalized_title = NormalizeTitleForSearch(title);
+  if (normalized_title.isEmpty()) {
+    normalized_title = title;
+  }
+  normalized_title = EscapeSearchTerm(normalized_title);
+  const QString normalized_artist = EscapeSearchTerm(artist);
+  const QString normalized_album = EscapeSearchTerm(album);
+
+  if (!title_terms.isEmpty()) {
+    QStringList recording_terms;
+    for (const QString &term : title_terms.mid(0, 8)) {
+      recording_terms << QStringLiteral("recording:\"%1\"").arg(term);
+    }
+    const QString recording_or_terms = recording_terms.join(u" OR "_s);
+    if (!normalized_title.isEmpty() && normalized_title.contains(u' ')) {
+      query_parts << QStringLiteral("(recording:\"%1\" OR (%2))").arg(normalized_title, recording_or_terms);
+    }
+    else {
+      query_parts << QStringLiteral("(%1)").arg(recording_or_terms);
+    }
+  }
+  if (!normalized_artist.isEmpty()) {
+    query_parts << QStringLiteral("artist:\"%1\"").arg(normalized_artist);
+  }
+  // Keep album as a fallback discriminator only when title/artist is incomplete.
+  if (!normalized_album.isEmpty() && (title_terms.isEmpty() || normalized_artist.isEmpty())) {
+    query_parts << QStringLiteral("release:\"%1\"").arg(normalized_album);
+  }
+
+  return query_parts.join(u" AND "_s);
+}
+
+int ComputeSearchScore(const MusicBrainzClient::Result &result, const QString &title, const QString &artist, const QString &album, const int duration_msec, const int musicbrainz_score) {
+
+  QString normalized_title = NormalizeSearchTerm(NormalizeTitleForSearch(title));
+  if (normalized_title.isEmpty()) {
+    normalized_title = NormalizeSearchTerm(title);
+  }
+  const QString normalized_artist = NormalizeSearchTerm(artist);
+  const QString normalized_album = NormalizeSearchTerm(album);
+
+  const QString result_title = NormalizeSearchTerm(result.title_);
+  const QString result_artist = NormalizeSearchTerm(result.artist_);
+  const QString result_album = NormalizeSearchTerm(result.album_);
+
+  int score = qBound(0, musicbrainz_score, 100) * 100;
+
+  if (!normalized_title.isEmpty() && !result_title.isEmpty()) {
+    if (normalized_title == result_title) score += 150;
+    else if (result_title.contains(normalized_title) || normalized_title.contains(result_title)) score += 75;
+  }
+
+  if (!normalized_artist.isEmpty() && !result_artist.isEmpty()) {
+    if (normalized_artist == result_artist) score += 120;
+    else if (result_artist.contains(normalized_artist) || normalized_artist.contains(result_artist)) score += 60;
+  }
+
+  if (!normalized_album.isEmpty() && !result_album.isEmpty()) {
+    if (normalized_album == result_album) score += 80;
+    else if (result_album.contains(normalized_album) || normalized_album.contains(result_album)) score += 40;
+  }
+
+  if (duration_msec > 0 && result.duration_msec_ > 0) {
+    const int diff = std::abs(result.duration_msec_ - duration_msec);
+    if (diff <= 1000) score += 80;
+    else if (diff <= 2500) score += 50;
+    else if (diff <= 5000) score += 25;
+    else if (diff <= 10000) score += 10;
+    else score -= 20;
+  }
+
+  return score;
+
+}
 }  // namespace
 
 MusicBrainzClient::MusicBrainzClient(SharedPtr<NetworkAccessManager> network, QObject *parent)
@@ -78,9 +238,13 @@ MusicBrainzClient::~MusicBrainzClient() {
 void MusicBrainzClient::FlushRequests() {
 
   FlushMbIdRequests();
+  FlushSearchRequests();
   FlushDiscIdRequests();
 
-  if (pending_mbid_requests_.isEmpty() && pending_discid_requests_.isEmpty() && timer_flush_requests_->isActive()) {
+  if (pending_mbid_requests_.isEmpty() &&
+      pending_search_requests_.isEmpty() &&
+      pending_discid_requests_.isEmpty() &&
+      timer_flush_requests_->isActive()) {
     timer_flush_requests_->stop();
   }
 
@@ -93,8 +257,20 @@ void MusicBrainzClient::CancelAll() {
   qDeleteAll(mbid_requests_);
   mbid_requests_.clear();
 
+  qDeleteAll(search_requests_);
+  search_requests_.clear();
+
   qDeleteAll(discid_requests_);
   discid_requests_.clear();
+
+  pending_mbid_requests_.clear();
+  pending_search_requests_.clear();
+  pending_discid_requests_.clear();
+  pending_results_.clear();
+
+  if (timer_flush_requests_->isActive()) {
+    timer_flush_requests_->stop();
+  }
 
 }
 
@@ -162,6 +338,24 @@ void MusicBrainzClient::StartMbIdRequest(const int id, const QStringList &mbid_l
 
 }
 
+void MusicBrainzClient::StartSearchRequest(const int id, const QString &title, const QString &artist, const QString &album, const int duration_msec) {
+
+  // Fallback entry point used when AcoustID could not resolve a recording id.
+  const QString query = BuildSearchQuery(title, artist, album);
+  if (query.isEmpty()) {
+    Q_EMIT MbIdFinished(id, ResultList(), QStringLiteral("MusicBrainz search requires at least a title, artist or album tag."));
+    return;
+  }
+
+  qLog(Debug) << "Starting MusicBrainz search request for track id" << id << "query" << query;
+  pending_search_requests_ << SearchRequest(id, query, title.trimmed(), artist.trimmed(), album.trimmed(), duration_msec);
+
+  if (!timer_flush_requests_->isActive()) {
+    timer_flush_requests_->start();
+  }
+
+}
+
 void MusicBrainzClient::CancelMbIdRequest(const int id) {
 
   while (!mbid_requests_.isEmpty() && mbid_requests_.contains(id)) {
@@ -170,6 +364,25 @@ void MusicBrainzClient::CancelMbIdRequest(const int id) {
     QObject::disconnect(reply, nullptr, this, nullptr);
     if (reply->isRunning()) reply->abort();
     reply->deleteLater();
+  }
+
+  while (!search_requests_.isEmpty() && search_requests_.contains(id)) {
+    QNetworkReply *reply = search_requests_.take(id);
+    replies_.removeAll(reply);
+    QObject::disconnect(reply, nullptr, this, nullptr);
+    if (reply->isRunning()) reply->abort();
+    reply->deleteLater();
+  }
+
+  pending_mbid_requests_.remove(id);
+  pending_results_.remove(id);
+  for (auto it = pending_search_requests_.begin(); it != pending_search_requests_.end();) {
+    if (it->id == id) {
+      it = pending_search_requests_.erase(it);
+    }
+    else {
+      ++it;
+    }
   }
 
 }
@@ -240,6 +453,167 @@ void MusicBrainzClient::MbIdRequestFinished(QNetworkReply *reply, const int id, 
     }
     Q_EMIT MbIdFinished(id, UniqueResults(results, UniqueResultsSortOption::KeepOriginalOrder));
   }
+
+}
+
+void MusicBrainzClient::FlushSearchRequests() {
+
+  if (!search_requests_.isEmpty() || pending_search_requests_.isEmpty()) return;
+
+  SendSearchRequest(pending_search_requests_.takeFirst());
+
+}
+
+void MusicBrainzClient::SendSearchRequest(const SearchRequest &request) {
+
+  QUrlQuery url_query;
+  url_query.addQueryItem(u"query"_s, request.query);
+  url_query.addQueryItem(u"limit"_s, QString::number(kSearchResultsLimit));
+  url_query.addQueryItem(u"fmt"_s, u"json"_s);
+  url_query.addQueryItem(u"inc"_s, u"releases+artists"_s);
+
+  QNetworkReply *reply = CreateGetRequest(QUrl(QString::fromLatin1(kTrackUrl)), url_query);
+  QObject::connect(reply, &QNetworkReply::finished, this, [this, reply, request]() {
+    SearchRequestFinished(reply, request.id, request.query, request.title, request.artist, request.album, request.duration_msec);
+  });
+  search_requests_.insert(request.id, reply);
+
+  timeouts_->AddReply(reply);
+
+}
+
+void MusicBrainzClient::SearchRequestFinished(QNetworkReply *reply, const int id, const QString &query, const QString &title, const QString &artist, const QString &album, const int duration_msec) {
+
+  if (replies_.contains(reply)) {
+    replies_.removeAll(reply);
+  }
+  QObject::disconnect(reply, nullptr, this, nullptr);
+  reply->deleteLater();
+
+  if (search_requests_.contains(id, reply)) {
+    search_requests_.remove(id, reply);
+  }
+
+  if (!timer_flush_requests_->isActive() &&
+      search_requests_.isEmpty() &&
+      !pending_search_requests_.isEmpty()) {
+    timer_flush_requests_->start();
+  }
+
+  const JsonObjectResult json_object_result = ParseJsonObject(reply);
+  if (!json_object_result.success()) {
+    Q_EMIT MbIdFinished(id, ResultList(), json_object_result.error_message);
+    return;
+  }
+
+  // Keep a score so we can surface the best metadata first in the Tag Fetcher.
+  struct ScoredResult {
+    Result result_;
+    int score_;
+  };
+
+  QList<ScoredResult> scored_results;
+  const QJsonObject object_root = json_object_result.json_object;
+  if (object_root.contains("recordings"_L1) && object_root.value("recordings"_L1).isArray()) {
+    const QJsonArray array_recordings = object_root.value("recordings"_L1).toArray();
+    for (const QJsonValue &value_recording : array_recordings) {
+      if (!value_recording.isObject()) continue;
+      const QJsonObject object_recording = value_recording.toObject();
+
+      QString recording_title;
+      if (object_recording.contains("title"_L1) && object_recording.value("title"_L1).isString()) {
+        recording_title = object_recording.value("title"_L1).toString();
+      }
+
+      int recording_duration_msec = 0;
+      if (object_recording.contains("length"_L1) && object_recording.value("length"_L1).isDouble()) {
+        recording_duration_msec = object_recording.value("length"_L1).toInt();
+      }
+
+      Artist recording_artist;
+      if (object_recording.contains("artist-credit"_L1) && object_recording.value("artist-credit"_L1).isArray()) {
+        recording_artist = ParseArtistCredit(object_recording.value("artist-credit"_L1).toArray());
+      }
+
+      int musicbrainz_score = 0;
+      if (object_recording.contains("score"_L1)) {
+        const QJsonValue value_score = object_recording.value("score"_L1);
+        if (value_score.isDouble()) {
+          musicbrainz_score = value_score.toInt();
+        }
+        else if (value_score.isString()) {
+          musicbrainz_score = value_score.toString().toInt();
+        }
+      }
+
+      auto append_result = [&](const QString &result_album, const Artist &result_album_artist, const int result_year) {
+        Result result;
+        result.title_ = recording_title;
+        result.artist_ = recording_artist.name_;
+        result.sort_artist_ = recording_artist.sort_name_;
+        result.album_ = result_album;
+        result.album_artist_ = result_album_artist.name_;
+        result.sort_album_artist_ = result_album_artist.sort_name_;
+        result.duration_msec_ = recording_duration_msec;
+        result.year_ = result_year;
+        result.track_ = 0;
+        const int score = ComputeSearchScore(result, title, artist, album, duration_msec, musicbrainz_score);
+        scored_results << ScoredResult{result, score};
+      };
+
+      bool have_release_results = false;
+      if (object_recording.contains("releases"_L1) && object_recording.value("releases"_L1).isArray()) {
+        const QJsonArray array_releases = object_recording.value("releases"_L1).toArray();
+        for (const QJsonValue &value_release : array_releases) {
+          if (!value_release.isObject()) continue;
+          const QJsonObject object_release = value_release.toObject();
+
+          QString release_title;
+          if (object_release.contains("title"_L1) && object_release.value("title"_L1).isString()) {
+            release_title = object_release.value("title"_L1).toString();
+          }
+
+          Artist release_artist = recording_artist;
+          if (object_release.contains("artist-credit"_L1) && object_release.value("artist-credit"_L1).isArray()) {
+            release_artist = ParseArtistCredit(object_release.value("artist-credit"_L1).toArray());
+          }
+
+          int release_year = -1;
+          if (object_release.contains("date"_L1) && object_release.value("date"_L1).isString()) {
+            const QString release_year_str = ParseDate(object_release.value("date"_L1).toString());
+            if (!release_year_str.isEmpty()) {
+              release_year = release_year_str.toInt();
+            }
+          }
+
+          append_result(release_title, release_artist, release_year);
+          have_release_results = true;
+        }
+      }
+
+      if (!have_release_results) {
+        append_result(QString(), recording_artist, -1);
+      }
+    }
+  }
+
+  if (scored_results.isEmpty()) {
+    Q_EMIT MbIdFinished(id, ResultList(), QStringLiteral("No MusicBrainz results matched this track metadata."));
+    return;
+  }
+
+  std::stable_sort(scored_results.begin(), scored_results.end(), [](const ScoredResult &a, const ScoredResult &b) {
+    return a.score_ > b.score_;
+  });
+
+  ResultList results;
+  results.reserve(scored_results.count());
+  for (const ScoredResult &scored_result : std::as_const(scored_results)) {
+    results << scored_result.result_;
+  }
+
+  qLog(Debug) << "MusicBrainz search for track id" << id << "query" << query << "returned" << results.count() << "candidate(s)";
+  Q_EMIT MbIdFinished(id, UniqueResults(results, UniqueResultsSortOption::KeepOriginalOrder));
 
 }
 

--- a/src/musicbrainz/musicbrainzclient.h
+++ b/src/musicbrainz/musicbrainzclient.h
@@ -92,6 +92,8 @@ class MusicBrainzClient : public JsonBaseRequest {
   using ResultList = QList<Result>;
 
   void StartMbIdRequest(const int id, const QStringList &mbid);
+  // Metadata search fallback used when no MBID was resolved from AcoustID.
+  void StartSearchRequest(const int id, const QString &title, const QString &artist, const QString &album, const int duration_msec);
   void CancelMbIdRequest(const int id);
 
   void StartDiscIdRequest(const QString &disc_id);
@@ -107,6 +109,7 @@ class MusicBrainzClient : public JsonBaseRequest {
   void FlushRequests();
   // ID identifies the track, and request_number means it's the 'request_number'th request for this track
   void MbIdRequestFinished(QNetworkReply *reply, const int id, const int request_number, const QString &mbid);
+  void SearchRequestFinished(QNetworkReply *reply, const int id, const QString &query, const QString &title, const QString &artist, const QString &album, const int duration_msec);
   void DiscIdRequestFinished(const QString &disc_id, QNetworkReply *reply);
 
  private:
@@ -117,6 +120,21 @@ class MusicBrainzClient : public JsonBaseRequest {
     int id;
     QString mbid;
     int number;
+  };
+
+  class SearchRequest {
+   public:
+    SearchRequest() : id(0), duration_msec(0) {}
+    SearchRequest(const int _id, const QString &_query, const QString &_title, const QString &_artist, const QString &_album, const int _duration_msec)
+        : id(_id), query(_query), title(_title), artist(_artist), album(_album), duration_msec(_duration_msec) {}
+    // Track id in TagFetcher request context.
+    int id;
+    // Pre-normalized MusicBrainz Lucene query.
+    QString query;
+    QString title;
+    QString artist;
+    QString album;
+    int duration_msec;
   };
 
   enum class UniqueResultsSortOption {
@@ -172,8 +190,10 @@ class MusicBrainzClient : public JsonBaseRequest {
 
   JsonObjectResult ParseJsonObject(QNetworkReply *reply);
   void FlushMbIdRequests();
+  void FlushSearchRequests();
   void FlushDiscIdRequests();
   void SendMbIdRequest(const MbIdRequest &request);
+  void SendSearchRequest(const SearchRequest &request);
   void SendDiscIdRequest(const QString &disc_id);
 
   static ReleaseList ParseReleases(const QJsonArray &array_releases);
@@ -193,9 +213,11 @@ class MusicBrainzClient : public JsonBaseRequest {
   NetworkTimeouts *timeouts_;
 
   QMultiMap<int, MbIdRequest> pending_mbid_requests_;
+  QList<SearchRequest> pending_search_requests_;
   QList<QString> pending_discid_requests_;
 
   QMultiMap<int, QNetworkReply*> mbid_requests_;
+  QMultiMap<int, QNetworkReply*> search_requests_;
   QMultiMap<QString, QNetworkReply*> discid_requests_;
 
   QMap<int, QList<PendingResults>> pending_results_;

--- a/src/musicbrainz/tagfetcher.cpp
+++ b/src/musicbrainz/tagfetcher.cpp
@@ -28,15 +28,83 @@
 #include <QtConcurrentMap>
 #include <QFuture>
 #include <QFutureWatcher>
+#include <QPair>
 #include <QString>
+#include <QStringList>
+#include <QFileInfo>
+#include <QRegularExpression>
 
 #include "includes/shared_ptr.h"
+#include "core/logging.h"
 #include "core/networkaccessmanager.h"
 #include "constants/timeconstants.h"
 #include "engine/chromaprinter.h"
 #include "acoustidclient.h"
 #include "musicbrainzclient.h"
 #include "tagfetcher.h"
+
+namespace {
+constexpr int kMinimumAcoustidFingerprintLength = 16;
+using FingerprintResult = QPair<QString, QString>;
+
+bool HasUsableFingerprint(const QString &fingerprint) {
+  const QString normalized = fingerprint.trimmed();
+  return !normalized.isEmpty() && normalized.compare(QStringLiteral("NONE"), Qt::CaseInsensitive) != 0 && normalized.size() >= kMinimumAcoustidFingerprintLength;
+}
+
+QString BuildUiErrorDetails(const QString &stage, const QString &reason, const QStringList &extra = QStringList()) {
+  QStringList lines;
+  lines << QStringLiteral("Stage: %1").arg(stage.trimmed());
+  lines << QStringLiteral("Reason: %1").arg(reason.trimmed());
+  for (const QString &line : extra) {
+    const QString trimmed = line.trimmed();
+    if (!trimmed.isEmpty()) {
+      lines << trimmed;
+    }
+  }
+  return lines.join(QLatin1Char('\n'));
+}
+
+void FillMissingSearchMetadataFromFilename(const Song &song, QString *title, QString *artist) {
+
+  static const QRegularExpression kLeadingTrackNumberRegex(QStringLiteral("^\\d+\\s*[-–—.:]\\s*"));
+  static const QRegularExpression kFilenameSeparatorRegex(QStringLiteral("\\s+-\\s+"));
+
+  if (!title || !artist) return;
+  if (!title->trimmed().isEmpty() && !artist->trimmed().isEmpty()) return;
+
+  // When embedded tags are empty (common for yt-dlp files), derive search metadata from filename.
+  QString base_name = QFileInfo(song.url().toLocalFile()).completeBaseName().trimmed();
+  if (base_name.isEmpty()) {
+    const QString fallback_name = song.basefilename().trimmed();
+    base_name = QFileInfo(fallback_name).completeBaseName().trimmed();
+    if (base_name.isEmpty()) {
+      base_name = fallback_name;
+    }
+  }
+  if (base_name.isEmpty()) return;
+
+  base_name.replace(u'_', u' ');
+  base_name = base_name.simplified();
+  base_name.remove(kLeadingTrackNumberRegex);
+  base_name = base_name.simplified();
+  if (base_name.isEmpty()) return;
+
+  const QStringList parts = base_name.split(kFilenameSeparatorRegex, Qt::SkipEmptyParts);
+  if (parts.size() >= 2) {
+    if (artist->trimmed().isEmpty()) {
+      *artist = parts.first().trimmed();
+    }
+    if (title->trimmed().isEmpty()) {
+      *title = parts.mid(1).join(QStringLiteral(" - ")).trimmed();
+    }
+  }
+  else if (title->trimmed().isEmpty()) {
+    *title = base_name.trimmed();
+  }
+
+}
+}  // namespace
 
 TagFetcher::TagFetcher(SharedPtr<NetworkAccessManager> network, QObject *parent)
     : QObject(parent),
@@ -49,8 +117,17 @@ TagFetcher::TagFetcher(SharedPtr<NetworkAccessManager> network, QObject *parent)
 
 }
 
-QString TagFetcher::GetFingerprint(const Song &song) {
-  return Chromaprinter(song.url().toLocalFile()).CreateFingerprint();
+QPair<QString, QString> TagFetcher::GetFingerprint(const Song &song) {
+  Chromaprinter chromaprinter(song.url().toLocalFile());
+  const QString fingerprint = chromaprinter.CreateFingerprint();
+  const QString fingerprint_error = chromaprinter.LastError().trimmed();
+  if (fingerprint.isEmpty()) {
+    qLog(Warning) << "Tag fetch fingerprint generation failed for" << song.url().toLocalFile() << ":" << fingerprint_error;
+  }
+  else {
+    qLog(Debug) << "Tag fetch fingerprint generated for" << song.url().toLocalFile() << "length" << fingerprint.size();
+  }
+  return FingerprintResult(fingerprint, fingerprint_error);
 }
 
 void TagFetcher::StartFetch(const SongList &songs) {
@@ -60,7 +137,7 @@ void TagFetcher::StartFetch(const SongList &songs) {
   songs_ = songs;
 
   bool have_fingerprints = true;
-  if (std::any_of(songs.begin(), songs.end(), [](const Song &song) { return song.fingerprint().isEmpty(); })) {
+  if (std::any_of(songs.begin(), songs.end(), [](const Song &song) { return !HasUsableFingerprint(song.fingerprint()); })) {
     have_fingerprints = false;
   }
 
@@ -68,13 +145,15 @@ void TagFetcher::StartFetch(const SongList &songs) {
     for (int i = 0; i < songs_.count(); ++i) {
       const Song song = songs_.value(i);
       Q_EMIT Progress(song, tr("Identifying song"));
-      acoustid_client_->Start(i, song.fingerprint(), static_cast<int>(song.length_nanosec() / kNsecPerMsec));
+      const QString fingerprint = song.fingerprint().trimmed();
+      qLog(Debug) << "Tag fetch using cached fingerprint for" << song.url().toLocalFile() << "length" << fingerprint.size();
+      acoustid_client_->Start(i, fingerprint, static_cast<int>(song.length_nanosec() / kNsecPerMsec));
     }
   }
   else {
-    QFuture<QString> future = QtConcurrent::mapped(songs_, GetFingerprint);
-    fingerprint_watcher_ = new QFutureWatcher<QString>(this);
-    QObject::connect(fingerprint_watcher_, &QFutureWatcher<QString>::resultReadyAt, this, &TagFetcher::FingerprintFound);
+    QFuture<FingerprintResult> future = QtConcurrent::mapped(songs_, GetFingerprint);
+    fingerprint_watcher_ = new QFutureWatcher<FingerprintResult>(this);
+    QObject::connect(fingerprint_watcher_, &QFutureWatcher<FingerprintResult>::resultReadyAt, this, &TagFetcher::FingerprintFound);
     fingerprint_watcher_->setFuture(future);
     for (const Song &song : std::as_const(songs_)) {
       Q_EMIT Progress(song, tr("Fingerprinting song"));
@@ -100,18 +179,32 @@ void TagFetcher::Cancel() {
 
 void TagFetcher::FingerprintFound(const int index) {
 
-  QFutureWatcher<QString> *watcher = static_cast<QFutureWatcher<QString>*>(sender());
+  QFutureWatcher<FingerprintResult> *watcher = static_cast<QFutureWatcher<FingerprintResult>*>(sender());
   if (!watcher || index >= songs_.count()) return;
 
-  const QString fingerprint = watcher->resultAt(index);
+  const FingerprintResult fingerprint_result = watcher->resultAt(index);
+  const QString fingerprint = fingerprint_result.first.trimmed();
+  const QString fingerprint_error = fingerprint_result.second.trimmed();
   const Song song = songs_.value(index);
 
-  if (fingerprint.isEmpty()) {
-    Q_EMIT ResultAvailable(song, SongList());
+  if (!HasUsableFingerprint(fingerprint)) {
+    QString reason = fingerprint_error;
+    if (reason.isEmpty()) {
+      reason = tr("Generated fingerprint is empty or invalid.");
+    }
+    const QString result_error = BuildUiErrorDetails(
+        tr("Fingerprinting"),
+        reason,
+        QStringList()
+            << QStringLiteral("Fingerprint length: %1").arg(fingerprint.size())
+            << QStringLiteral("Minimum required length: %1").arg(kMinimumAcoustidFingerprintLength));
+    qLog(Error) << "Tag fetch fingerprint invalid for" << song.url().toLocalFile() << ":" << result_error;
+    Q_EMIT ResultAvailable(song, SongList(), result_error);
     return;
   }
 
   Q_EMIT Progress(song, tr("Identifying song"));
+  qLog(Debug) << "Tag fetch sending generated fingerprint for" << song.url().toLocalFile() << "length" << fingerprint.size();
   acoustid_client_->Start(index, fingerprint, static_cast<int>(song.length_nanosec() / kNsecPerMsec));
 
 }
@@ -125,7 +218,24 @@ void TagFetcher::PuidsFound(const int index, const QStringList &puid_list, const
   const Song song = songs_.value(index);
 
   if (puid_list.isEmpty()) {
-    Q_EMIT ResultAvailable(song, SongList(), error);
+    // Fall back to MusicBrainz textual search when AcoustID has no usable match.
+    if (error.isEmpty()) {
+      qLog(Warning) << "Tag fetch AcoustID returned no matches for" << song.url().toLocalFile() << "- falling back to MusicBrainz metadata search";
+    }
+    else {
+      qLog(Warning) << "Tag fetch AcoustID lookup failed for" << song.url().toLocalFile() << ":" << error << "- falling back to MusicBrainz metadata search";
+    }
+    Q_EMIT Progress(song, tr("Searching MusicBrainz"));
+    QString search_title = song.title().trimmed();
+    QString search_artist = song.artist().trimmed();
+    FillMissingSearchMetadataFromFilename(song, &search_title, &search_artist);
+    qLog(Debug) << "Tag fetch MusicBrainz fallback search metadata for" << song.url().toLocalFile() << "title:" << search_title << "artist:" << search_artist << "album:" << song.album().trimmed();
+    musicbrainz_client_->StartSearchRequest(
+        index,
+        search_title,
+        search_artist,
+        song.album().trimmed(),
+        static_cast<int>(song.length_nanosec() / kNsecPerMsec));
     return;
   }
 
@@ -159,6 +269,23 @@ void TagFetcher::TagsFetched(const int index, const MusicBrainzClient::ResultLis
     songs_guessed << song;
   }
 
-  Q_EMIT ResultAvailable(original_song, songs_guessed, error);
+  QString result_error = error;
+  if (songs_guessed.isEmpty()) {
+    QString reason = result_error;
+    if (reason.isEmpty()) {
+      reason = tr("No MusicBrainz metadata was found for this track.");
+    }
+    result_error = BuildUiErrorDetails(
+        tr("MusicBrainz metadata"),
+        reason,
+        QStringList() << QStringLiteral("Candidate metadata rows: 0"));
+  }
+  if (!songs_guessed.isEmpty()) {
+    qLog(Debug) << "Tag fetch resolved" << songs_guessed.count() << "candidate(s) for" << original_song.url().toLocalFile();
+  }
+  else {
+    qLog(Warning) << "Tag fetch no MusicBrainz candidates for" << original_song.url().toLocalFile() << ":" << result_error;
+  }
+  Q_EMIT ResultAvailable(original_song, songs_guessed, result_error);
 
 }

--- a/src/musicbrainz/tagfetcher.h
+++ b/src/musicbrainz/tagfetcher.h
@@ -26,6 +26,7 @@
 
 #include <QObject>
 #include <QFutureWatcher>
+#include <QPair>
 #include <QString>
 #include <QStringList>
 
@@ -51,6 +52,7 @@ class TagFetcher : public QObject {
 
  Q_SIGNALS:
   void Progress(const Song &original_song, const QString &stage);
+  // The optional error string contains user-facing technical diagnostics.
   void ResultAvailable(const Song &original_song, const SongList &songs_guessed, const QString &error = QString());
 
  private Q_SLOTS:
@@ -59,9 +61,9 @@ class TagFetcher : public QObject {
   void TagsFetched(const int index, const MusicBrainzClient::ResultList &results, const QString &error = QString());
 
  private:
-  static QString GetFingerprint(const Song &song);
+  static QPair<QString, QString> GetFingerprint(const Song &song);
 
-  QFutureWatcher<QString> *fingerprint_watcher_;
+  QFutureWatcher<QPair<QString, QString>> *fingerprint_watcher_;
   AcoustidClient *acoustid_client_;
   MusicBrainzClient *musicbrainz_client_;
 


### PR DESCRIPTION
## Summary

This PR improves Tag Fetcher reliability for `.opus` files (notably files downloaded via yt-dlp) on macOS, while keeping the app self-contained (no external CLI dependency at runtime).

## Problem

Some files failed in Tag Fetcher with errors like:
- AcoustID HTTP 400 / invalid fingerprint
- "No decoded audio samples were produced by GStreamer"
- No useful fallback when AcoustID returned no recording IDs, especially when embedded tags were missing

## What changed

### 1) AcoustID request robustness
- Switched lookup request from query-style GET to form POST (`application/x-www-form-urlencoded`)
- Improved API/network error parsing and diagnostics
- Kept request semantics identical (`format`, `client`, `duration`, `meta`, `fingerprint`)

### 2) MusicBrainz fallback when AcoustID fails
- Added metadata search fallback path in `TagFetcher`:
  - If AcoustID returns no MBIDs, perform a MusicBrainz recording search
- Added `MusicBrainzClient::StartSearchRequest(...)`
- Added query normalization/tokenization and result scoring (title/artist/album/duration heuristics)
- Preserved existing MBID path behavior

### 3) Better handling of missing tags
- If title/artist tags are missing, derive search metadata from filename
- Supports common filename patterns like track-number + artist + title

### 4) Better user diagnostics
- Track selection error page now shows technical details from backend failures
- Keeps details readable as plain text

### 5) Fingerprinting hardening + memory safety
- Hardened GStreamer decode path in `Chromaprinter`
- Added explicit in-memory PCM cap to avoid unbounded growth
- Added safer pad checks and clearer failure reasons

### 6) macOS bundle/runtime fixes
- Improved bundled GStreamer plugin discovery on startup
- Added plugin/runtime packaging adjustments needed for matroska/webm/opus flow
- Added `libgstriff` bundling when required by `libgstmatroska`
- Registry filename now includes executable timestamp to avoid stale cache reuse across rebuilds

## Validation

- Build: `cmake --build build-m1-full -j8` (passes)
- Manual tests on macOS Sonoma 14.6.1 (Apple Silicon):
  - Tag Fetcher with `.opus` files with and without embedded tags
  - AcoustID success path
  - MusicBrainz fallback path
  - Error diagnostics visibility in UI

## Commit breakdown

1. `musicbrainz: add metadata-search fallback when AcoustID fails`
2. `ui: show technical diagnostics in tag fetcher error page`
3. `chromaprinter: harden decoding and cap in-memory PCM usage`
4. `macos: bundle and discover GStreamer runtime dependencies reliably`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MusicBrainz search fallback when fingerprint-based identification cannot find a match.
  * Improved track matching using title, artist, album, and duration details.
  * Added technical error details to tag-fetching dialogs.

* **Bug Fixes**
  * Improved fingerprint generation reliability and validation.
  * Preserved clearer backend error messages for failed tag lookups.
  * Improved bundled GStreamer plugin detection and registry refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->