### PR TITLE
Shuffle grouping

### DIFF
--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -2077,6 +2077,20 @@ QString Song::AlbumKey() const {
   return QStringLiteral("%1|%2|%3").arg(is_compilation() ? u"_compilation"_s : effective_albumartist(), has_cue() ? cue_path() : ""_L1, effective_album());
 }
 
+QString Song::GroupingKey() const {
+  if (d->grouping_.isEmpty()) {
+    // We don't have grouping data, when we want to shuffle individual tracks
+    // The goal with grouping shuffle is to keep the introduction and the song (that may be on two distinct tracks)
+    // as if they were on the same track, and play the shuffle on individual track
+    return QStringLiteral("%1|%2|%3").arg(d->album_.isEmpty() ? d->artist_ : d->album_, d->title_, QString::number(d->id_));
+  }
+  // We have some grouping data, we want to regroup this track with the tracks that belongs :
+  // to the same album (as defined by AlbumKey, including compilation/album-artist and cue identity)
+  // to the same grouping value
+  // to the same file type
+  return QStringLiteral("%1|%2|%3").arg(AlbumKey(), d->grouping_, QString::number(static_cast<int>(d->filetype_)));
+}
+
 size_t qHash(const Song &song) {
   // Should compare the same fields as operator==
   return qHash(song.url().toString()) ^ qHash(song.beginning_nanosec());

--- a/src/core/song.h
+++ b/src/core/song.h
@@ -553,6 +553,7 @@ class Song {
   // Two songs that are on the same album will have the same AlbumKey.
   // It is more efficient to use IsOnSameAlbum, but this function can be used when you need to hash the key to do fast lookups.
   QString AlbumKey() const;
+  QString GroupingKey() const;
 
   static bool ContainsRegexList(const QString &str, const RegularExpressionList &regex_list);
   static QString StripRegexList(QString str, const RegularExpressionList &regex_list);

--- a/src/osd/osdbase.cpp
+++ b/src/osd/osdbase.cpp
@@ -367,6 +367,7 @@ void OSDBase::ShuffleModeChanged(const PlaylistSequence::ShuffleMode mode) {
       case PlaylistSequence::ShuffleMode::All:         current_mode = tr("Shuffle all");     break;
       case PlaylistSequence::ShuffleMode::InsideAlbum: current_mode = tr("Shuffle tracks in this album"); break;
       case PlaylistSequence::ShuffleMode::Albums:      current_mode = tr("Shuffle albums");  break;
+      case PlaylistSequence::ShuffleMode::Grouping:    current_mode = tr("Shuffle grouping"); break;
     }
     ShowMessage(QCoreApplication::applicationName(), current_mode);
   }

--- a/src/playlist/playlistsequence.cpp
+++ b/src/playlist/playlistsequence.cpp
@@ -85,6 +85,7 @@ PlaylistSequence::PlaylistSequence(QWidget *parent, SettingsProvider *settings)
   shuffle_group->addAction(ui_->action_shuffle_all);
   shuffle_group->addAction(ui_->action_shuffle_inside_album);
   shuffle_group->addAction(ui_->action_shuffle_albums);
+  shuffle_group->addAction(ui_->action_shuffle_grouping);
   shuffle_menu_->addActions(shuffle_group->actions());
   ui_->shuffle->setMenu(shuffle_menu_);
 
@@ -165,6 +166,7 @@ void PlaylistSequence::ShuffleActionTriggered(QAction *action) {
   if (action == ui_->action_shuffle_all) mode = ShuffleMode::All;
   if (action == ui_->action_shuffle_inside_album) mode = ShuffleMode::InsideAlbum;
   if (action == ui_->action_shuffle_albums) mode = ShuffleMode::Albums;
+  if (action == ui_->action_shuffle_grouping) mode = ShuffleMode::Grouping;
 
   SetShuffleMode(mode);
 
@@ -202,6 +204,7 @@ void PlaylistSequence::SetShuffleMode(const ShuffleMode mode) {
     case ShuffleMode::All:         ui_->action_shuffle_all->setChecked(true);          break;
     case ShuffleMode::InsideAlbum: ui_->action_shuffle_inside_album->setChecked(true); break;
     case ShuffleMode::Albums:      ui_->action_shuffle_albums->setChecked(true);       break;
+    case ShuffleMode::Grouping:    ui_->action_shuffle_grouping->setChecked(true);     break;
   }
 
   if (mode != shuffle_mode_) {
@@ -230,7 +233,8 @@ void PlaylistSequence::CycleShuffleMode() {
     case ShuffleMode::Off:         mode = ShuffleMode::All;           break;
     case ShuffleMode::All:         mode = ShuffleMode::InsideAlbum;   break;
     case ShuffleMode::InsideAlbum: mode = ShuffleMode::Albums;        break;
-    case ShuffleMode::Albums: break;
+    case ShuffleMode::Albums:      mode = ShuffleMode::Grouping;      break;
+    case ShuffleMode::Grouping: break;
   }
 
   SetShuffleMode(mode);

--- a/src/playlist/playlistsequence.h
+++ b/src/playlist/playlistsequence.h
@@ -57,7 +57,8 @@ class PlaylistSequence : public QWidget {
     Off = 0,
     All = 1,
     InsideAlbum = 2,
-    Albums = 3
+    Albums = 3,
+    Grouping = 4
   };
 
   RepeatMode repeat_mode() const;

--- a/src/playlist/playlistsequence.ui
+++ b/src/playlist/playlistsequence.ui
@@ -158,6 +158,14 @@
     <string>Shuffle albums</string>
    </property>
   </action>
+  <action name="action_shuffle_grouping">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Shuffle grouping</string>
+   </property>
+  </action>
  </widget>
  <resources/>
  <connections/>

--- a/src/translations/strawberry_ca_ES.ts
+++ b/src/translations/strawberry_ca_ES.ts
@@ -3983,6 +3983,10 @@ Si no hi ha resultats, s’usarà la imatge més gran en el directori.</translat
       <translation>Mescla els àlbums</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Mescla els d’agrupació</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>Sense repetició</translation>
     </message>
@@ -4635,6 +4639,10 @@ Si no hi ha resultats, s’usarà la imatge més gran en el directori.</translat
     <message>
       <source>Shuffle albums</source>
       <translation>Mescla els àlbums</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Mescla els d’agrupació</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_cs_CZ.ts
+++ b/src/translations/strawberry_cs_CZ.ts
@@ -3983,6 +3983,10 @@ Pokud nenajde žádné, které by se shodovaly, potom použije největší obrá
       <translation>Zamíchat alba</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Zamíchat seskupování</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>Neopakovat</translation>
     </message>
@@ -4637,6 +4641,10 @@ Pokud nenajde žádné, které by se shodovaly, potom použije největší obrá
     <message>
       <source>Shuffle albums</source>
       <translation>Zamíchat alba</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Zamíchat seskupování</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_de_DE.ts
+++ b/src/translations/strawberry_de_DE.ts
@@ -3983,6 +3983,10 @@ Falls es keine Treffer gibt, wird das größte Bild aus dem Verzeichnis ausgewä
       <translation>Zufällige Albenreihenfolge</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Zufällige Titelsortierung</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>Wiederholung aus</translation>
     </message>
@@ -4635,6 +4639,10 @@ Falls es keine Treffer gibt, wird das größte Bild aus dem Verzeichnis ausgewä
     <message>
       <source>Shuffle albums</source>
       <translation>Zufällige Albenreihenfolge</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Zufällige Titelsortierung</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_el_CY.ts
+++ b/src/translations/strawberry_el_CY.ts
@@ -3983,6 +3983,10 @@ If there are no matches then it will use the largest image in the directory.</tr
       <translation type="unfinished">Shuffle albums</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Shuffle grouping</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation type="unfinished">Don&apos;t repeat</translation>
     </message>
@@ -4635,6 +4639,10 @@ If there are no matches then it will use the largest image in the directory.</tr
     <message>
       <source>Shuffle albums</source>
       <translation type="unfinished">Shuffle albums</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Shuffle grouping</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_el_GR.ts
+++ b/src/translations/strawberry_el_GR.ts
@@ -3983,6 +3983,10 @@ If there are no matches then it will use the largest image in the directory.</so
       <translation>Τυχαίο άλμπουμ</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Τυχαίο ομαδοποίηση</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>Μη επανάληψη</translation>
     </message>
@@ -4635,6 +4639,10 @@ If there are no matches then it will use the largest image in the directory.</so
     <message>
       <source>Shuffle albums</source>
       <translation>Τυχαία αναπαραγωγή άλμπουμ</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Τυχαίο ομαδοποίηση</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_en_US.ts
+++ b/src/translations/strawberry_en_US.ts
@@ -3982,6 +3982,10 @@ If there are no matches then it will use the largest image in the directory.</so
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Shuffle grouping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Don&apos;t repeat</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4631,6 +4635,10 @@ If there are no matches then it will use the largest image in the directory.</so
     </message>
     <message>
         <source>Shuffle albums</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shuffle grouping</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/translations/strawberry_es_AR.ts
+++ b/src/translations/strawberry_es_AR.ts
@@ -3982,6 +3982,10 @@ If there are no matches then it will use the largest image in the directory.</so
       <translation>Mezclar álbumes</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Mezclar agrupamiento</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>No repetir</translation>
     </message>
@@ -4634,6 +4638,10 @@ If there are no matches then it will use the largest image in the directory.</so
     <message>
       <source>Shuffle albums</source>
       <translation>Mezclar álbumes</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Mezclar agrupamiento</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_es_ES.ts
+++ b/src/translations/strawberry_es_ES.ts
@@ -3982,6 +3982,10 @@ If there are no matches then it will use the largest image in the directory.</so
       <translation>Mezclar álbumes</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Mezclar agrupamiento</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>No repetir</translation>
     </message>
@@ -4634,6 +4638,10 @@ If there are no matches then it will use the largest image in the directory.</so
     <message>
       <source>Shuffle albums</source>
       <translation>Mezclar álbumes</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Mezclar agrupamiento</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_es_MX.ts
+++ b/src/translations/strawberry_es_MX.ts
@@ -3982,6 +3982,10 @@ If there are no matches then it will use the largest image in the directory.</so
       <translation>Mezclar álbumes</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Mezclar agrupamiento</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>No repetir</translation>
     </message>
@@ -4634,6 +4638,10 @@ If there are no matches then it will use the largest image in the directory.</so
     <message>
       <source>Shuffle albums</source>
       <translation>Mezclar álbumes</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Mezclar agrupamiento</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_et_EE.ts
+++ b/src/translations/strawberry_et_EE.ts
@@ -3983,6 +3983,10 @@ Kui vasteid pole, kasutab ta kaustas asuvat suurimat pilti.</translation>
       <translation>Albumite juhuesitus</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Rühmitamine juhuesitus</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>Ära korda</translation>
     </message>
@@ -4635,6 +4639,10 @@ Kui vasteid pole, kasutab ta kaustas asuvat suurimat pilti.</translation>
     <message>
       <source>Shuffle albums</source>
       <translation>Albumite juhuesitus</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Rühmitamine juhuesitus</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_fi_FI.ts
+++ b/src/translations/strawberry_fi_FI.ts
@@ -3983,6 +3983,10 @@ Jos vastaavia tiedostoja ei löydy, Strawberry käyttää suurinta kansiossa ole
       <translation>Sekoita albumit</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Sekoita ryhmittely</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>Älä kertaa</translation>
     </message>
@@ -4635,6 +4639,10 @@ Jos vastaavia tiedostoja ei löydy, Strawberry käyttää suurinta kansiossa ole
     <message>
       <source>Shuffle albums</source>
       <translation>Sekoita albumit</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Sekoita ryhmittely</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_fr_BE.ts
+++ b/src/translations/strawberry_fr_BE.ts
@@ -3983,6 +3983,10 @@ S&apos;il n&apos;en existe pas alors Strawberry utilisera la plus grande image d
       <translation>Aléatoire : albums</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation>Aléatoire : groupement</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>Ne pas répéter</translation>
     </message>
@@ -4635,6 +4639,10 @@ S&apos;il n&apos;en existe pas alors Strawberry utilisera la plus grande image d
     <message>
       <source>Shuffle albums</source>
       <translation>Aléatoire : albums</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation>Aléatoire : groupement</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_fr_FR.ts
+++ b/src/translations/strawberry_fr_FR.ts
@@ -3983,6 +3983,10 @@ S&apos;il n&apos;en existe pas alors Strawberry utilisera la plus grande image d
       <translation>Aléatoire : albums</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation>Aléatoire : groupement</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>Ne pas répéter</translation>
     </message>
@@ -4635,6 +4639,10 @@ S&apos;il n&apos;en existe pas alors Strawberry utilisera la plus grande image d
     <message>
       <source>Shuffle albums</source>
       <translation>Aléatoire : albums</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation>Aléatoire : groupement</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_hu_HU.ts
+++ b/src/translations/strawberry_hu_HU.ts
@@ -3983,6 +3983,10 @@ Ha nincs egyezés, akkor a legnagyobb képet veszi a könyvtárból.</translatio
       <translation>Albumok összekeverése</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Gyűjtemény összekeverése</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>Nincs ismétlés</translation>
     </message>
@@ -4635,6 +4639,10 @@ Ha nincs egyezés, akkor a legnagyobb képet veszi a könyvtárból.</translatio
     <message>
       <source>Shuffle albums</source>
       <translation>Albumok összekeverése</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Gyűjtemény összekeverése</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_id_ID.ts
+++ b/src/translations/strawberry_id_ID.ts
@@ -3983,6 +3983,10 @@ Jika tidak ada yang cocok maka akan menggunakan gambar terbesar dalam direktori.
       <translation>Karau album</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Karau grouping</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>Jangan ulang</translation>
     </message>
@@ -4634,6 +4638,10 @@ Jika tidak ada yang cocok maka akan menggunakan gambar terbesar dalam direktori.
     <message>
       <source>Shuffle albums</source>
       <translation>Karau album</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Karau grouping</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_is_IS.ts
+++ b/src/translations/strawberry_is_IS.ts
@@ -3983,6 +3983,10 @@ Ef engar samsvaranir finnast, verður notast víð stærstu myndina í möppunni
       <translation>Stokka hljómplötur</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Shuffle grouping</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>Ekki endurtaka</translation>
     </message>
@@ -4635,6 +4639,10 @@ Ef engar samsvaranir finnast, verður notast víð stærstu myndina í möppunni
     <message>
       <source>Shuffle albums</source>
       <translation>Stokka hljómplötur</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Shuffle grouping</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_it_IT.ts
+++ b/src/translations/strawberry_it_IT.ts
@@ -3988,6 +3988,10 @@ Prima di iniziare ti suggeriamo di eseguire il backup del database.</translation
       <translation>Mescola album</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Mescola raggruppando</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>Non ripetere</translation>
     </message>
@@ -4642,6 +4646,10 @@ Non è stato possibile eliminare i seguenti file:</translation>
     <message>
       <source>Shuffle albums</source>
       <translation>Mescola album</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Mescola raggruppando</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_ja_JP.ts
+++ b/src/translations/strawberry_ja_JP.ts
@@ -3983,6 +3983,10 @@ If there are no matches then it will use the largest image in the directory.</so
       <translation>アルバムをシャッフル</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Shuffle grouping</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>リピートしない</translation>
     </message>
@@ -4634,6 +4638,10 @@ If there are no matches then it will use the largest image in the directory.</so
     <message>
       <source>Shuffle albums</source>
       <translation>アルバムをシャッフル</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Shuffle grouping</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_ko_KR.ts
+++ b/src/translations/strawberry_ko_KR.ts
@@ -3983,6 +3983,10 @@ If there are no matches then it will use the largest image in the directory.</so
       <translation>앨범 셔플</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Shuffle grouping</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>반복하지 않기</translation>
     </message>
@@ -4634,6 +4638,10 @@ If there are no matches then it will use the largest image in the directory.</so
     <message>
       <source>Shuffle albums</source>
       <translation>앨범 셔플</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Shuffle grouping</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_nb_NO.ts
+++ b/src/translations/strawberry_nb_NO.ts
@@ -3983,6 +3983,10 @@ Hvis ingen ord passer, blir det største bildet i mappen brukt.</translation>
       <translation>Stokk om album</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Stokk om gruppering</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>Ikke gjenta</translation>
     </message>
@@ -4635,6 +4639,10 @@ Hvis ingen ord passer, blir det største bildet i mappen brukt.</translation>
     <message>
       <source>Shuffle albums</source>
       <translation>Stokk om album</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Stokk om gruppering</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_nl_NL.ts
+++ b/src/translations/strawberry_nl_NL.ts
@@ -3983,6 +3983,10 @@ Als er geen match is wordt de grootste afbeelding uit de map gebruikt.</translat
       <translation>Albums willekeurig afspelen</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Groeperen willekeurig afspelen</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>Niet herhalen</translation>
     </message>
@@ -4635,6 +4639,10 @@ Als er geen match is wordt de grootste afbeelding uit de map gebruikt.</translat
     <message>
       <source>Shuffle albums</source>
       <translation>Albums willekeurig afspelen</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Groeperen willekeurig afspelen</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_pl_PL.ts
+++ b/src/translations/strawberry_pl_PL.ts
@@ -3983,6 +3983,10 @@ W przypadku braku takich plików użyty zostanie największy obraz z danego kata
       <translation>Losuj albumy</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Losuj grupowanie</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>Nie powtarzaj</translation>
     </message>
@@ -4639,6 +4643,10 @@ tekstu zostanie ukryty.&lt;/p&gt;</translation>
     <message>
       <source>Shuffle albums</source>
       <translation>Losuj albumy</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Losuj grupowanie</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_pt_BR.ts
+++ b/src/translations/strawberry_pt_BR.ts
@@ -3983,6 +3983,10 @@ Se não houver resultados, ele usará a maior imagem no diretório.</translation
       <translation>Embaralhar albuns</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Embaralhar agrupamento</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>Não repetir</translation>
     </message>
@@ -4635,6 +4639,10 @@ Se não houver resultados, ele usará a maior imagem no diretório.</translation
     <message>
       <source>Shuffle albums</source>
       <translation>Embaralhar albuns</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Embaralhar agrupamento</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_ru_RU.ts
+++ b/src/translations/strawberry_ru_RU.ts
@@ -3983,6 +3983,10 @@ If there are no matches then it will use the largest image in the directory.</so
       <translation>Перемешать альбомы</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Перемешать группировка</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>Не повторять</translation>
     </message>
@@ -4637,6 +4641,10 @@ If there are no matches then it will use the largest image in the directory.</so
     <message>
       <source>Shuffle albums</source>
       <translation>Перемешать альбомы</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Перемешать группировка</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_sv_SE.ts
+++ b/src/translations/strawberry_sv_SE.ts
@@ -3983,6 +3983,10 @@ Om det inte finns några matchningar så kommer den största bilden i mappen att
       <translation>Blanda album</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Blanda gruppering</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>Upprepa inte</translation>
     </message>
@@ -4635,6 +4639,10 @@ Om det inte finns några matchningar så kommer den största bilden i mappen att
     <message>
       <source>Shuffle albums</source>
       <translation>Blanda album</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Blanda gruppering</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_tr_CY.ts
+++ b/src/translations/strawberry_tr_CY.ts
@@ -3983,6 +3983,10 @@ If there are no matches then it will use the largest image in the directory.</tr
       <translation type="unfinished">Shuffle albums</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Shuffle grouping</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation type="unfinished">Don&apos;t repeat</translation>
     </message>
@@ -4635,6 +4639,10 @@ If there are no matches then it will use the largest image in the directory.</tr
     <message>
       <source>Shuffle albums</source>
       <translation type="unfinished">Shuffle albums</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Shuffle grouping</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_tr_TR.ts
+++ b/src/translations/strawberry_tr_TR.ts
@@ -3983,6 +3983,10 @@ If there are no matches then it will use the largest image in the directory.</tr
       <translation>Albümleri karıştır</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Gruplama karıştır</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>Tekrarlama</translation>
     </message>
@@ -4635,6 +4639,10 @@ If there are no matches then it will use the largest image in the directory.</tr
     <message>
       <source>Shuffle albums</source>
       <translation>Albümleri karıştır</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Gruplama karıştır</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_uk_UA.ts
+++ b/src/translations/strawberry_uk_UA.ts
@@ -3983,6 +3983,10 @@ If there are no matches then it will use the largest image in the directory.</so
       <translation>Перемішати альбоми</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Перемішати групування</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>Не повторювати</translation>
     </message>
@@ -4637,6 +4641,10 @@ If there are no matches then it will use the largest image in the directory.</so
     <message>
       <source>Shuffle albums</source>
       <translation>Перемішати альбоми</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Перемішати групування</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_vi_VN.ts
+++ b/src/translations/strawberry_vi_VN.ts
@@ -3983,6 +3983,10 @@ Nếu không có kết quả trùng khớp thì nó sẽ sử dụng hình ảnh
       <translation>Trộn ngẫu nhiên album</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Trộn ngẫu nhiên nâng cao</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>Không lặp lại</translation>
     </message>
@@ -4634,6 +4638,10 @@ Nếu không có kết quả trùng khớp thì nó sẽ sử dụng hình ảnh
     <message>
       <source>Shuffle albums</source>
       <translation>Trộn ngẫu nhiên album</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Trộn ngẫu nhiên nâng cao</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_zh_CN.ts
+++ b/src/translations/strawberry_zh_CN.ts
@@ -3983,6 +3983,10 @@ If there are no matches then it will use the largest image in the directory.</so
       <translation>乱序专辑</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Shuffle grouping</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation>不循环播放</translation>
     </message>
@@ -4634,6 +4638,10 @@ If there are no matches then it will use the largest image in the directory.</so
     <message>
       <source>Shuffle albums</source>
       <translation>乱序专辑</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Shuffle grouping</translation>
     </message>
   </context>
   <context>

--- a/src/translations/strawberry_zh_TW.ts
+++ b/src/translations/strawberry_zh_TW.ts
@@ -3984,6 +3984,10 @@ If there are no matches then it will use the largest image in the directory.</tr
       <translation type="unfinished">Shuffle albums</translation>
     </message>
     <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Shuffle grouping</translation>
+    </message>
+    <message>
       <source>Don&apos;t repeat</source>
       <translation type="unfinished">Don&apos;t repeat</translation>
     </message>
@@ -4635,6 +4639,10 @@ If there are no matches then it will use the largest image in the directory.</tr
     <message>
       <source>Shuffle albums</source>
       <translation type="unfinished">Shuffle albums</translation>
+    </message>
+    <message>
+      <source>Shuffle grouping</source>
+      <translation type="unfinished">Shuffle grouping</translation>
     </message>
   </context>
   <context>


### PR DESCRIPTION
Add a shuffle mode based on the grouping metadata value.
As I have flac & mp3 files for the same albums, I add the file type in the grouping key value.

The translations had not been checked that's why I let them in unfinished type.