### PR TITLE
Grouped tracks are considered as a single track.

### DIFF
--- a/src/constants/playlistsettings.h
+++ b/src/constants/playlistsettings.h
@@ -45,6 +45,8 @@ constexpr char kShowToolbar[] = "show_toolbar";
 constexpr char kPlaylistClear[] = "playlist_clear";
 constexpr char kAutoSort[] = "auto_sort";
 
+constexpr char kGroupingBeforeQueue[] = "grouping_queue";
+constexpr int kGroupingBeforeQueueDefault = 1;
 constexpr char kPathType[] = "path_type";
 
 constexpr char kEditMetadataInline[] = "editmetadatainline";

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -151,6 +151,7 @@ void Player::ReloadSettings() {
   s.beginGroup(PlaylistSettings::kSettingsGroup);
   continue_on_error_ = s.value(PlaylistSettings::kContinueOnError, PlaylistSettings::kDefaultContinueOnError).toBool();
   greyout_ = s.value(PlaylistSettings::kGreyoutSongsPlay, PlaylistSettings::kDefaultGreyoutSongsPlay).toBool();
+  playlist_manager_->update_grouped_before_queue(s.value(PlaylistSettings::kGroupingBeforeQueue, GROUPED_BEFORE_QUEUE_DEFAULT).toInt());
   s.endGroup();
 
   s.beginGroup(BehaviourSettings::kSettingsGroup);
@@ -435,7 +436,7 @@ void Player::NextItem(const EngineBase::TrackChangeFlags change, const Playlist:
   // Manual track changes override "Repeat track"
   const bool ignore_repeat_track = change & EngineBase::TrackChangeType::Manual;
 
-  int i = active_playlist->next_row(ignore_repeat_track);
+  int i = active_playlist->next_row(ignore_repeat_track, false);
   if (i == -1) {
     playlist_manager_->active()->set_current_row(i);
     playlist_manager_->active()->reset_last_played();
@@ -634,10 +635,12 @@ void Player::PreviousItem(const EngineBase::TrackChangeFlags change) {
   playlist_manager_->active()->set_current_row(i, Playlist::AutoScroll::Always, false);
   if (i == -1) {
     Stop();
+    playlist_manager_->active()->CleanNextSongQueued();
     return;
   }
 
   PlayAt(i, false, 0, change, Playlist::AutoScroll::Always, false);
+  playlist_manager_->active()->CleanNextSongQueued();
 
 }
 

--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -1123,6 +1123,16 @@ bool Song::IsOnSameAlbum(const Song &other) const {
 
 }
 
+bool Song::IsOnSameGrouping(const Song &other) const {
+
+  return (   !grouping().isEmpty()
+          && !other.grouping().isEmpty()
+          && AlbumKey() == other.AlbumKey()
+          && grouping() == other.grouping()
+          && filetype() == other.filetype()   );
+
+}
+
 bool Song::IsSimilar(const Song &other) const {
   return title().compare(other.title(), Qt::CaseInsensitive) == 0 &&
          artist().compare(other.artist(), Qt::CaseInsensitive) == 0 &&

--- a/src/core/song.h
+++ b/src/core/song.h
@@ -488,6 +488,7 @@ class Song {
   bool IsEqual(const Song &other) const;
 
   bool IsOnSameAlbum(const Song &other) const;
+  bool IsOnSameGrouping(const Song &other) const;
   bool IsSimilar(const Song &other) const;
 
   static Source SourceFromURL(const QUrl &url);

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -132,6 +132,7 @@ Playlist::Playlist(const SharedPtr<TaskManager> task_manager,
                    const int id,
                    const QString &special_type,
                    const bool favorite,
+                   const int grouped_before_queue,
                    QObject *parent)
     : QAbstractListModel(parent),
       is_loading_(false),
@@ -156,7 +157,10 @@ Playlist::Playlist(const SharedPtr<TaskManager> task_manager,
       scrobble_point_(-1),
       auto_sort_(false),
       sort_column_(Column::Title),
-      sort_order_(Qt::AscendingOrder) {
+      sort_order_(Qt::AscendingOrder),
+      left_grouped_song_before_queue_(grouped_before_queue),
+      init_grouped_song_before_queue_(grouped_before_queue),
+      next_song_after_queued_(-1) {
 
   undo_stack_->setUndoLimit(kUndoStackSize);
 
@@ -683,14 +687,72 @@ int Playlist::PreviousVirtualIndex(int i, const bool ignore_repeat_track) const 
 
 }
 
-int Playlist::next_row(const bool ignore_repeat_track) {
+int Playlist::next_row(const bool ignore_repeat_track, const bool no_grouping_track_count) {
 
-  // Any queued items take priority
-  if (!queue_->is_empty()) {
+  int next_virtual_index = next_song_after_queued_;
+
+  if (next_virtual_index < 0) {
+    next_virtual_index = NextVirtualIndex(current_virtual_index_, ignore_repeat_track);
+    switch (RepeatMode()) {
+      default:
+
+        // Compare with unsigned int to avoid to check if it is less than the count but positive
+        if (   static_cast<unsigned int>(current_virtual_index_) < static_cast<unsigned int>(virtual_items_.count())
+            && static_cast<unsigned int>(next_virtual_index) < static_cast<unsigned int>(virtual_items_.count())   ) {
+           // The two indexes are in the virtual items array
+           Song this_song = item_at(virtual_items_[current_virtual_index_])->EffectiveMetadata();
+           Song next_song = item_at(virtual_items_[next_virtual_index])->EffectiveMetadata();
+
+           if (   this_song.IsOnSameGrouping(next_song)
+               && (   left_grouped_song_before_queue_ == 0
+                   || no_grouping_track_count
+                   || --left_grouped_song_before_queue_ > 0   )   ) {
+              // We have two choices here :
+              // either resetting left_grouped_song_before_queue_ as soon as there is no queued song,
+              // that is too say, when a song will be queued, you will have to wait the setted number of grouped song before playing it
+              // either resetting left_grouped_song_before_queue_ when it reaches 0,
+              // that is too say, when a song will be queued, you will have to wait every n th grouped song before playing it
+              if (queue_->is_empty())
+              // if (left_grouped_song_before_queue_ == 0)
+              {
+                left_grouped_song_before_queue_ = init_grouped_song_before_queue_;
+              }
+              // The next song is on the same grouping than the current one,
+              // it cannot be interrupt by the queued items
+              break;
+           }
+        }
+
+        [[fallthrough]];
+
+      case PlaylistSequence::RepeatMode::Intro:
+      case PlaylistSequence::RepeatMode::Track:
+
+        // Reset the grouping values
+        left_grouped_song_before_queue_ = init_grouped_song_before_queue_;
+
+        // Any queued items take priority
+        if (!queue_->is_empty()) {
+          // Remember the location in the current playlist to go back right there after the queued play
+          next_song_after_queued_ = next_virtual_index;
+
+          // Play the queued song
+          return queue_->PeekNext();
+        }
+
+        break;
+    }
+  }
+  else if (!queue_->is_empty()) {
+    // We already remember the location where we want to go back after the queued play
+    // we just have to return the next queued song
     return queue_->PeekNext();
   }
+  else if (next_song_after_queued_ >= 0 && !no_grouping_track_count) {
+     // No more queued song, go back to the list to play
+     next_song_after_queued_ = -1;
+  }
 
-  int next_virtual_index = NextVirtualIndex(current_virtual_index_, ignore_repeat_track);
   if (next_virtual_index >= virtual_items_.count()) {
     // We've gone off the end of the playlist.
 
@@ -1054,6 +1116,9 @@ void Playlist::MoveItemsWithoutUndo(const QList<int> &source_rows, int pos) {
   PlaylistItemPtrList moved_items;
   moved_items.reserve(source_rows.count());
 
+  // Reset the item to be played after the queued, it is the safer behavior, if we are not on a dynamic playlist
+  if (!dynamic_playlist_) next_song_after_queued_ = -1;
+
   if (pos < 0) {
     pos = static_cast<int>(items_.count());
   }
@@ -1123,6 +1188,9 @@ void Playlist::MoveItemsWithoutUndo(int start, const QList<int> &dest_rows) {
   PlaylistItemPtrList old_items = items_;
   PlaylistItemPtrList moved_items;
   moved_items.reserve(dest_rows.count());
+
+  // Reset the item to be played after the queued, it is the safer behavior, if we are not on a dynamic playlist
+  if (!dynamic_playlist_) next_song_after_queued_ = -1;
 
   int pos = start;
   for (const int dest_row : dest_rows) {
@@ -1194,6 +1262,9 @@ void Playlist::InsertItems(const PlaylistItemPtrList &itemsIn, const int pos, co
   if (itemsIn.isEmpty()) {
     return;
   }
+
+  // Reset the item to be played after the queued, it is the safer behavior, if we are not on a dynamic playlist
+  if (!dynamic_playlist_) next_song_after_queued_ = -1;
 
   PlaylistItemPtrList items = itemsIn;
 
@@ -1822,6 +1893,9 @@ void Playlist::RemoveItemsWithoutUndo(const QList<int> &indicesIn) {
     removeRows(beginning, end - beginning + 1);
   }
 
+  // Reset the item to be played after the queued, it is the safer behavior, if we are not on a dynamic playlist
+  if (!dynamic_playlist_) next_song_after_queued_ = -1;
+
 }
 
 bool Playlist::removeRows(const int row, const int count, const QModelIndex &parent) {
@@ -1936,6 +2010,9 @@ PlaylistItemPtrList Playlist::RemoveItemsWithoutUndo(const int row, const int co
   if (!signal_track_ids.isEmpty()) {
     Q_EMIT PlaylistItemsRemoved(id_, signal_track_ids);
   }
+
+  // Reset the item to be played after the queued, it is the safer behavior, if we are not on a dynamic playlist
+  if (!dynamic_playlist_) next_song_after_queued_ = -1;
 
   ScheduleSave();
 
@@ -2169,6 +2246,10 @@ bool AlbumShuffleComparator(const QHash<QString, int> &album_key_positions, cons
 void Playlist::ReshuffleIndices() {
 
   const PlaylistSequence::ShuffleMode shuffle_mode = ShuffleMode();
+
+  // First, cancel the replay position
+  next_song_after_queued_ = -1;
+
   switch (shuffle_mode) {
     case PlaylistSequence::ShuffleMode::Off:{
       // No shuffling - sort the virtual item list normally.

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -133,6 +133,7 @@ Playlist::Playlist(const SharedPtr<TaskManager> task_manager,
                    const int id,
                    const QString &special_type,
                    const bool favorite,
+                   const int grouped_before_queue,
                    QObject *parent)
     : QAbstractListModel(parent),
       is_loading_(false),
@@ -160,7 +161,10 @@ Playlist::Playlist(const SharedPtr<TaskManager> task_manager,
       auto_sort_(false),
       is_sorted_(false),
       sort_column_(Column::Title),
-      sort_order_(Qt::AscendingOrder) {
+      sort_order_(Qt::AscendingOrder),
+      left_grouped_song_before_queue_(grouped_before_queue),
+      init_grouped_song_before_queue_(grouped_before_queue),
+      next_song_after_queued_(-1) {
 
   undo_stack_->setUndoLimit(kUndoStackSize);
 
@@ -687,14 +691,72 @@ int Playlist::PreviousVirtualIndex(int i, const bool ignore_repeat_track) const 
 
 }
 
-int Playlist::next_row(const bool ignore_repeat_track) {
+int Playlist::next_row(const bool ignore_repeat_track, const bool no_grouping_track_count) {
 
-  // Any queued items take priority
-  if (!queue_->is_empty()) {
+  int next_virtual_index = next_song_after_queued_;
+
+  if (next_virtual_index < 0) {
+    next_virtual_index = NextVirtualIndex(current_virtual_index_, ignore_repeat_track);
+    switch (RepeatMode()) {
+      default:
+
+        // Compare with unsigned int to avoid to check if it is less than the count but positive
+        if (   static_cast<unsigned int>(current_virtual_index_) < static_cast<unsigned int>(virtual_items_.count())
+            && static_cast<unsigned int>(next_virtual_index) < static_cast<unsigned int>(virtual_items_.count())   ) {
+           // The two indexes are in the virtual items array
+           Song this_song = item_at(virtual_items_[current_virtual_index_])->EffectiveMetadata();
+           Song next_song = item_at(virtual_items_[next_virtual_index])->EffectiveMetadata();
+
+           if (   this_song.IsOnSameGrouping(next_song)
+               && (   left_grouped_song_before_queue_ == 0
+                   || no_grouping_track_count
+                   || --left_grouped_song_before_queue_ > 0   )   ) {
+              // We have two choices here :
+              // either resetting left_grouped_song_before_queue_ as soon as there is no queued song,
+              // that is too say, when a song will be queued, you will have to wait the setted number of grouped song before playing it
+              // either resetting left_grouped_song_before_queue_ when it reaches 0,
+              // that is too say, when a song will be queued, you will have to wait every n th grouped song before playing it
+              if (queue_->is_empty())
+              // if (left_grouped_song_before_queue_ == 0)
+              {
+                left_grouped_song_before_queue_ = init_grouped_song_before_queue_;
+              }
+              // The next song is on the same grouping than the current one,
+              // it cannot be interrupt by the queued items
+              break;
+           }
+        }
+
+        [[fallthrough]];
+
+      case PlaylistSequence::RepeatMode::Intro:
+      case PlaylistSequence::RepeatMode::Track:
+
+        // Reset the grouping values
+        left_grouped_song_before_queue_ = init_grouped_song_before_queue_;
+
+        // Any queued items take priority
+        if (!queue_->is_empty()) {
+          // Remember the location in the current playlist to go back right there after the queued play
+          next_song_after_queued_ = next_virtual_index;
+
+          // Play the queued song
+          return queue_->PeekNext();
+        }
+
+        break;
+    }
+  }
+  else if (!queue_->is_empty()) {
+    // We already remember the location where we want to go back after the queued play
+    // we just have to return the next queued song
     return queue_->PeekNext();
   }
+  else if (next_song_after_queued_ >= 0 && !no_grouping_track_count) {
+     // No more queued song, go back to the list to play
+     next_song_after_queued_ = -1;
+  }
 
-  int next_virtual_index = NextVirtualIndex(current_virtual_index_, ignore_repeat_track);
   if (next_virtual_index >= virtual_items_.count()) {
     // We've gone off the end of the playlist.
 
@@ -1058,6 +1120,9 @@ void Playlist::MoveItemsWithoutUndo(const QList<int> &source_rows, int pos) {
   PlaylistItemPtrList moved_items;
   moved_items.reserve(source_rows.count());
 
+  // Reset the item to be played after the queued, it is the safer behavior, if we are not on a dynamic playlist
+  if (!dynamic_playlist_) next_song_after_queued_ = -1;
+
   if (pos < 0) {
     pos = static_cast<int>(items_.count());
   }
@@ -1127,6 +1192,9 @@ void Playlist::MoveItemsWithoutUndo(int start, const QList<int> &dest_rows) {
   PlaylistItemPtrList old_items = items_;
   PlaylistItemPtrList moved_items;
   moved_items.reserve(dest_rows.count());
+
+  // Reset the item to be played after the queued, it is the safer behavior, if we are not on a dynamic playlist
+  if (!dynamic_playlist_) next_song_after_queued_ = -1;
 
   int pos = start;
   for (const int dest_row : dest_rows) {
@@ -1198,6 +1266,9 @@ void Playlist::InsertItems(const PlaylistItemPtrList &itemsIn, const int pos, co
   if (itemsIn.isEmpty()) {
     return;
   }
+
+  // Reset the item to be played after the queued, it is the safer behavior, if we are not on a dynamic playlist
+  if (!dynamic_playlist_) next_song_after_queued_ = -1;
 
   PlaylistItemPtrList items = itemsIn;
 
@@ -1889,6 +1960,9 @@ void Playlist::RemoveItemsWithoutUndo(const QList<int> &indicesIn) {
     removeRows(beginning, end - beginning + 1);
   }
 
+  // Reset the item to be played after the queued, it is the safer behavior, if we are not on a dynamic playlist
+  if (!dynamic_playlist_) next_song_after_queued_ = -1;
+
 }
 
 bool Playlist::removeRows(const int row, const int count, const QModelIndex &parent) {
@@ -2003,6 +2077,9 @@ PlaylistItemPtrList Playlist::RemoveItemsWithoutUndo(const int row, const int co
   if (!signal_track_ids.isEmpty()) {
     Q_EMIT PlaylistItemsRemoved(id_, signal_track_ids);
   }
+
+  // Reset the item to be played after the queued, it is the safer behavior, if we are not on a dynamic playlist
+  if (!dynamic_playlist_) next_song_after_queued_ = -1;
 
   ScheduleSave();
 
@@ -2236,6 +2313,10 @@ bool AlbumShuffleComparator(const QHash<QString, int> &album_key_positions, cons
 void Playlist::ReshuffleIndices() {
 
   const PlaylistSequence::ShuffleMode shuffle_mode = ShuffleMode();
+
+  // First, cancel the replay position
+  next_song_after_queued_ = -1;
+
   switch (shuffle_mode) {
     case PlaylistSequence::ShuffleMode::Off:{
       // No shuffling - sort the virtual item list normally.

--- a/src/playlist/playlist.h
+++ b/src/playlist/playlist.h
@@ -76,6 +76,9 @@ using ColumnAlignmentMap = QMap<int, Qt::Alignment>;
 Q_DECLARE_METATYPE(Qt::Alignment)
 Q_DECLARE_METATYPE(ColumnAlignmentMap)
 
+// This default value keep the current behavior : the queued item is played at the end of the current track, even a grouped one
+static constexpr int GROUPED_BEFORE_QUEUE_DEFAULT = 1;
+
 class Playlist : public QAbstractListModel {
   Q_OBJECT
 
@@ -94,6 +97,7 @@ class Playlist : public QAbstractListModel {
                     const int id,
                     const QString &special_type = QString(),
                     const bool favorite = false,
+                    const int grouped_before_queue = GROUPED_BEFORE_QUEUE_DEFAULT,
                     QObject *parent = nullptr);
 
   ~Playlist() override;
@@ -194,9 +198,11 @@ class Playlist : public QAbstractListModel {
   int last_played_row() const;
   void reset_last_played() { last_played_item_index_ = QPersistentModelIndex(); }
   void reset_played_indexes() { played_indexes_.clear(); }
-  int next_row(const bool ignore_repeat_track = false);
+  int next_row(const bool ignore_repeat_track = false, const bool no_grouping_track_count = true);
   int previous_row(const bool ignore_repeat_track = false) const;
   int take_previous_row(const bool ignore_repeat_track = false);
+
+  void update_grouped_before_queue(const int grouped_before_queue) { init_grouped_song_before_queue_ = grouped_before_queue; }
 
   QModelIndex current_index() const;
 
@@ -294,6 +300,9 @@ class Playlist : public QAbstractListModel {
   // Changes rating of a song to the given value asynchronously
   void RateSong(const QModelIndex &idx, const float rating);
   void RateSongs(const QModelIndexList &index_list, const float rating);
+
+  // Clean the queued song
+  void CleanNextSongQueued() { next_song_after_queued_ = -1; }
 
   void set_auto_sort(const bool auto_sort) { auto_sort_ = auto_sort; }
 
@@ -455,6 +464,11 @@ class Playlist : public QAbstractListModel {
   bool auto_sort_;
   Column sort_column_;
   Qt::SortOrder sort_order_;
+
+  // Variables to count the number of times the queue list had been ignored due to grouping values
+  int left_grouped_song_before_queue_;
+  int init_grouped_song_before_queue_;
+  int next_song_after_queued_;
 };
 
 #endif  // PLAYLIST_H

--- a/src/playlist/playlist.h
+++ b/src/playlist/playlist.h
@@ -77,6 +77,9 @@ using ColumnAlignmentMap = QMap<int, Qt::Alignment>;
 Q_DECLARE_METATYPE(Qt::Alignment)
 Q_DECLARE_METATYPE(ColumnAlignmentMap)
 
+// This default value keep the current behavior : the queued item is played at the end of the current track, even a grouped one
+static constexpr int GROUPED_BEFORE_QUEUE_DEFAULT = 1;
+
 class Playlist : public QAbstractListModel {
   Q_OBJECT
 
@@ -96,6 +99,7 @@ class Playlist : public QAbstractListModel {
                     const int id,
                     const QString &special_type = QString(),
                     const bool favorite = false,
+                    const int grouped_before_queue = GROUPED_BEFORE_QUEUE_DEFAULT,
                     QObject *parent = nullptr);
 
   ~Playlist() override;
@@ -197,9 +201,11 @@ class Playlist : public QAbstractListModel {
   int last_played_row() const;
   void reset_last_played() { last_played_item_index_ = QPersistentModelIndex(); }
   void reset_played_indexes() { played_indexes_.clear(); }
-  int next_row(const bool ignore_repeat_track = false);
+  int next_row(const bool ignore_repeat_track = false, const bool no_grouping_track_count = true);
   int previous_row(const bool ignore_repeat_track = false) const;
   int take_previous_row(const bool ignore_repeat_track = false);
+
+  void update_grouped_before_queue(const int grouped_before_queue) { init_grouped_song_before_queue_ = grouped_before_queue; }
 
   QModelIndex current_index() const;
 
@@ -297,6 +303,9 @@ class Playlist : public QAbstractListModel {
   // Changes rating of a song to the given value asynchronously
   void RateSong(const QModelIndex &idx, const float rating);
   void RateSongs(const QModelIndexList &index_list, const float rating);
+
+  // Clean the queued song
+  void CleanNextSongQueued() { next_song_after_queued_ = -1; }
 
   void set_auto_sort(const bool auto_sort) { auto_sort_ = auto_sort; }
 
@@ -469,6 +478,11 @@ class Playlist : public QAbstractListModel {
   bool is_sorted_;
   Column sort_column_;
   Qt::SortOrder sort_order_;
+
+  // Variables to count the number of times the queue list had been ignored due to grouping values
+  int left_grouped_song_before_queue_;
+  int init_grouped_song_before_queue_;
+  int next_song_after_queued_;
 };
 
 #endif  // PLAYLIST_H

--- a/src/playlist/playlistmanager.cpp
+++ b/src/playlist/playlistmanager.cpp
@@ -82,7 +82,8 @@ PlaylistManager::PlaylistManager(const SharedPtr<TaskManager> task_manager,
       playlist_container_(nullptr),
       current_(-1),
       active_(-1),
-      playlists_loading_(0) {
+      playlists_loading_(0),
+      grouped_before_queue_(GROUPED_BEFORE_QUEUE_DEFAULT) {
 
   setObjectName(QLatin1String(QObject::metaObject()->className()));
 
@@ -92,6 +93,17 @@ PlaylistManager::~PlaylistManager() {
 
   const QList<Data> datas = playlists_.values();
   for (const Data &data : datas) delete data.p;
+
+}
+
+void PlaylistManager::update_grouped_before_queue(const int grouped_before_queue) {
+
+  grouped_before_queue_ = grouped_before_queue;
+
+  QList<Data> datas = playlists_.values();
+  for (Data &data : datas) {
+    data.p->update_grouped_before_queue(grouped_before_queue);
+  }
 
 }
 
@@ -156,7 +168,7 @@ QItemSelection PlaylistManager::selection(const int id) const {
 
 Playlist *PlaylistManager::AddPlaylist(const int id, const QString &name, const QString &special_type, const QString &ui_path, const bool favorite) {
 
-  Playlist *ret = new Playlist(task_manager_, url_handlers_, playlist_backend_, collection_backend_, tagreader_client_, id, special_type, favorite);
+  Playlist *ret = new Playlist(task_manager_, url_handlers_, playlist_backend_, collection_backend_, tagreader_client_, id, special_type, favorite, grouped_before_queue_);
   ret->set_sequence(sequence_);
   ret->set_ui_path(ui_path);
 

--- a/src/playlist/playlistmanager.h
+++ b/src/playlist/playlistmanager.h
@@ -71,6 +71,10 @@ class PlaylistManager : public PlaylistManagerInterface {
   Playlist *playlist(const int id) const override { return playlists_[id].p; }
   Playlist *current() const override { return playlist(current_id()); }
   Playlist *active() const override { return playlist(active_id()); }
+  int grouped_before_queue() const { return grouped_before_queue_; }
+
+  // Update the grouped before queue value : we have to do more than just update the attribute
+  void update_grouped_before_queue(const int grouped_before_queue);
 
   // Returns the collection of playlists managed by this PlaylistManager.
   QList<Playlist*> GetAllPlaylists() const override;
@@ -179,6 +183,7 @@ class PlaylistManager : public PlaylistManagerInterface {
   int current_;
   int active_;
   int playlists_loading_;
+  int grouped_before_queue_;
 };
 
 #endif  // PLAYLISTMANAGER_H

--- a/src/settings/playlistsettingspage.cpp
+++ b/src/settings/playlistsettingspage.cpp
@@ -45,10 +45,34 @@ PlaylistSettingsPage::PlaylistSettingsPage(SettingsDialog *dialog, QWidget *pare
   ui_->setupUi(this);
   setWindowIcon(IconLoader::Load(u"document-new"_s, true, 0, 32));
 
+  ui_->spinbox_grouping_before_queue->setToolTip(GroupingBeforeQueueToolTip());
+
+
 }
 
 PlaylistSettingsPage::~PlaylistSettingsPage() {
   delete ui_;
+}
+
+QString PlaylistSettingsPage::GroupingBeforeQueueToolTip() {
+
+  return "<html><head/><body><p>"_L1 +
+         QObject::tr("This field is used to tell how many tracks of the same group will be played before the queued track will be played.") +
+         u' ' +
+         "</p><p>"_L1 +
+
+         "<span style=\"font-weight:600;\">0:</span> "_L1 +
+         QObject::tr(" is used to say that the queued track will wait for the end of the current track group before being played.") +
+         "</p><p>"_L1 +
+
+         "<span style=\"font-weight:600;\">1:</span> "_L1 +
+         QObject::tr(" is used to say that the queued track will be played after the end of the current track, whatever it belongs to a group or not.") +
+         "</p><p>"_L1 +
+
+         QObject::tr("Any other value to give the number of grouped tracks played before playing the queued one(s). ") +
+         QObject::tr("Obviously, if there are less grouped tracks to play than the given number, the queued tracks will be played as soon as the last grouped track is played.") +
+         "</p></body></html>"_L1;
+
 }
 
 void PlaylistSettingsPage::Load() {
@@ -87,6 +111,8 @@ void PlaylistSettingsPage::Load() {
     case PathType::Ask_User:
       ui_->radiobutton_askpath->setChecked(true);
   }
+
+  ui_->spinbox_grouping_before_queue->setValue(s.value(kGroupingBeforeQueue, kGroupingBeforeQueueDefault).toInt());
 
   ui_->checkbox_editmetadatainline->setChecked(s.value(kEditMetadataInline, kDefaultEditMetadataInline).toBool());
   ui_->checkbox_writemetadata->setChecked(s.value(kWriteMetadata, kDefaultWriteMetadata).toBool());
@@ -130,6 +156,7 @@ void PlaylistSettingsPage::Save() {
   s.setValue(kShowToolbar, ui_->checkbox_show_toolbar->isChecked());
   s.setValue(kPlaylistClear, ui_->checkbox_playlist_clear->isChecked());
   s.setValue(kPathType, static_cast<int>(path_type));
+  s.setValue(kGroupingBeforeQueue, ui_->spinbox_grouping_before_queue->value());
   s.setValue(kEditMetadataInline, ui_->checkbox_editmetadatainline->isChecked());
   s.setValue(kWriteMetadata, ui_->checkbox_writemetadata->isChecked());
   s.setValue(kDeleteFiles, ui_->checkbox_delete_files->isChecked());

--- a/src/settings/playlistsettingspage.h
+++ b/src/settings/playlistsettingspage.h
@@ -42,6 +42,8 @@ class PlaylistSettingsPage : public SettingsPage {
   void Load() override;
   void Save() override;
 
+  static QString GroupingBeforeQueueToolTip();
+
  private:
   Ui_PlaylistSettingsPage *ui_;
 };

--- a/src/settings/playlistsettingspage.ui
+++ b/src/settings/playlistsettingspage.ui
@@ -99,6 +99,39 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupbox_grouping_play">
+     <property name="title">
+      <string>Grouping Play</string>
+     </property>
+     <layout class="QVBoxLayout" name="layout_grouping_play">
+      <item>
+       <layout class="QHBoxLayout" name="layout_grouping_play_before_queue">
+        <item>
+         <widget class="QLabel" name="label_grouping_play_before_queue_1">
+          <property name="text">
+           <string>Number of grouped tracks played before play queued track</string>
+          </property>
+          <property name="indent">
+           <number>22</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="spinbox_grouping_before_queue">
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="value">
+           <number>1</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupbox_paths">
      <property name="title">
       <string>When saving a playlist, file paths should be</string>

--- a/src/smartplaylists/smartplaylistsearchpreview.cpp
+++ b/src/smartplaylists/smartplaylistsearchpreview.cpp
@@ -72,7 +72,7 @@ void SmartPlaylistSearchPreview::Init(const SharedPtr<Player> player,
 
   collection_backend_ = collection_backend;
 
-  model_ = new Playlist(nullptr, nullptr, nullptr, collection_backend_, nullptr, -1, QString(), false, this);
+  model_ = new Playlist(nullptr, nullptr, nullptr, collection_backend_, nullptr, -1, QString(), false, GROUPED_BEFORE_QUEUE_DEFAULT, this);
   ui_->tree->setModel(model_);
   ui_->tree->SetPlaylist(model_);
 


### PR DESCRIPTION
consider the grouped tracks as one track so the queued tracks cannot interrupt the grouped tracks play :
- add a parameter to the Playlist::next_row method to handle this
- add a method Song::IsOnSameGrouping  
- add the attribute next_song_after_queued_ to remember the position where to go back when the queued rest is finish

add a configuration to define the behavior of the queued tracks in front of the grouped tracks :
- add the GROUPED_BEFORE_QUEUE_DEFAULT constexpr that define the default value for this configuration (default value set to 1 to keep the current behavior and ignore the grouped tracks)
- add the update_grouped_before_queue method to set the playlist objects with the value set in the ui
- use left_grouped_song_before_queue_ & init_grouped_song_before_queue_ to determine what to do next when we have queued tracks while reading grouped tracks
- add the ui in the backendsettingspage,in the background management tab.
- add a tool-tip on the created spinbox to explain how this parameter is used.
- translations had been prepared, but only the french one had been done.  

correct the previous row to navigate in the playlist :
- update the Playlist::previous_row code
- use only the navigation in the playlist to determine the previous row
- if we are on queued track read, use next_song_after_queued_ attribute to determine the position where to go back (that is to say that queued tracks are ignored in this navigation)

Values for the added parameter :
0 : wait for the end of all the grouped tracks on the same group than the current read track before playing the queued track(s)
1 : ignore the grouping attribute and read the queued track after the end of the current played track
n : wait for the end of the read of the n tracks of the current played track (the current one is the first of the n). If there is less than n grouped tracks to read, wait for the end of all the grouped tracks (same group than the current read track) to start the read of the queued track(s). If the read track is not a grouped track, the queued track(s) will be read just after it.
No maximum had been set.
I will use it this 0 : never interrupt grouped tracks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **“Grouping Before Queue”** option to playlist preferences, including a descriptive tooltip and a persisted numeric setting.

* **Improved Playback Behavior**
  * Enhanced grouped-track queue handling so queued playback returns/resumes more consistently within matching album/grouping contexts.
  * Improved “next song” state management when navigating tracks and when reshuffling or mutating playlists, preventing stale queued-next behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->