### PR TITLE
Translation of the playlist search text tooltip corrections

### DIFF
--- a/src/translations/strawberry_ca_ES.ts
+++ b/src/translations/strawberry_ca_ES.ts
@@ -36,8 +36,8 @@
       <translation>Si t'agrada Strawberry i pots fer-ne ús, considera patrocinar o donar.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>Podeu patrocinar l'autor a %1. També podeu fer un pagament únic a través de %2.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">Podeu patrocinar l'autor a %1 o %2. També podeu fer un pagament únic a través de %3.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5067,20 +5067,24 @@ Esteu segur que voleu continuar?</translation>
       <translation>artista</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation type="unfinished">searches for all artists containing the word %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation type="unfinished">searches for all artists containing the word %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation type="unfinished">Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation type="unfinished">rating</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</translation>
     </message>
     <message>
       <source>Available fields</source>

--- a/src/translations/strawberry_cs_CZ.ts
+++ b/src/translations/strawberry_cs_CZ.ts
@@ -36,8 +36,8 @@
       <translation>Líbí se a vyhovuje vám-li Strawberry, zvažte příspěvek.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>Můžete podpořit autora na %1. Také můžete jednorázově přispět pomocí %2.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">Můžete podpořit autora na %1 nebo %2. Také můžete jednorázově přispět pomocí %3.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5069,20 +5069,24 @@ Opravdu chcete pokračovat?</translation>
       <translation>umělec</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation type="unfinished">searches for all artists containing the word %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation type="unfinished">searches for all artists containing the word %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation type="unfinished">Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation type="unfinished">rating</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</translation>
     </message>
     <message>
       <source>Available fields</source>

--- a/src/translations/strawberry_de_DE.ts
+++ b/src/translations/strawberry_de_DE.ts
@@ -36,8 +36,8 @@
       <translation>Wenn Ihnen Strawberry gefällt und Sie es nutzen können, sollten Sie sponsern oder spenden.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>Sie können den Autor auf %1 sponsern. Sie können auch eine einmalige Zahlung über %2 vornehmen.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">Sie können den Autor auf %1 oder %2 sponsern. Sie können auch eine einmalige Zahlung über %3 vornehmen.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5067,19 +5067,23 @@ Möchten Sie wirklich fortfahren?</translation>
       <translation>Künstler</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation type="unfinished">searches for all artists containing the word %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation type="unfinished">searches for all artists containing the word %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation>Suchbegriffe für numerische Felder können mit %1 oder %2 vorangestellt werden, um die Suche expliziter zu machen, z.B:</translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation>Bewertung</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
       <translation>Mehrere Suchbegriffe können auch mit &quot;%1&quot; (und, standard) und &quot;%2&quot; (oder) kombiniert, sowie mit Klammern gruppiert werden.</translation>
     </message>
     <message>

--- a/src/translations/strawberry_el_CY.ts
+++ b/src/translations/strawberry_el_CY.ts
@@ -36,8 +36,8 @@
       <translation type="unfinished">If you like Strawberry and can make use of it, consider sponsoring or donating.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>Μπορείτε να επιχορηγήσετε τον συγγραφέα στο %1. Μπορείτε επίσης να κάνετε μια εφάπαξ πληρωμή μέσω του %2.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">Μπορείτε να επιχορηγήσετε τον συγγραφέα στο %1 ή %2. Μπορείτε επίσης να κάνετε μια εφάπαξ πληρωμή μέσω του %3.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5067,20 +5067,24 @@ Are you sure you want to continue?</translation>
       <translation type="unfinished">artist</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation type="unfinished">searches for all artists containing the word %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation type="unfinished">searches for all artists containing the word %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation type="unfinished">Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation type="unfinished">rating</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</translation>
     </message>
     <message>
       <source>Available fields</source>

--- a/src/translations/strawberry_el_GR.ts
+++ b/src/translations/strawberry_el_GR.ts
@@ -36,8 +36,8 @@
       <translation>'Αν σας είναι χρήσιμο το Strawberry εξετάστε το ενδεχόμενο επιχορήγησης ή δωρεά.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>Μπορείτε να επιχορηγήσετε τον συγγραφέα στο %1. Μπορείτε επίσης να κάνετε μια εφάπαξ πληρωμή μέσω του %2.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">Μπορείτε να επιχορηγήσετε τον συγγραφέα στο %1 ή %2. Μπορείτε επίσης να κάνετε μια εφάπαξ πληρωμή μέσω του %3.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5067,20 +5067,24 @@ Are you sure you want to continue?</source>
       <translation>καλλιτέχνης</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation>αναζητήσεις για όλους τους καλλιτέχνες που περιέχουν τη λέξη %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation>αναζητήσεις για όλους τους καλλιτέχνες που περιέχουν τη λέξη %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation type="unfinished">Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation>αξιολόγηση</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</translation>
     </message>
     <message>
       <source>Available fields</source>

--- a/src/translations/strawberry_en_US.ts
+++ b/src/translations/strawberry_en_US.ts
@@ -36,7 +36,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
+        <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5063,7 +5063,7 @@ Are you sure you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>searches for all artists containing the word %1. </source>
+        <source>searches for all artists containing the word %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5071,11 +5071,15 @@ Are you sure you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
+        <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/translations/strawberry_es_AR.ts
+++ b/src/translations/strawberry_es_AR.ts
@@ -36,8 +36,8 @@
       <translation>Si le gusta Strawberry y le da uso, plantéese patrocinarlo o realizar una donación.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>Puede patrocinar al autor en %1. También puede realizar una aportación económica a través de %2.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">Puede patrocinar al autor en %1 o %2. También puede realizar una aportación económica a través de %3.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5066,20 +5066,24 @@ Are you sure you want to continue?</source>
       <translation>artista</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation type="unfinished">searches for all artists containing the word %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation type="unfinished">searches for all artists containing the word %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation type="unfinished">Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation type="unfinished">rating</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</translation>
     </message>
     <message>
       <source>Available fields</source>

--- a/src/translations/strawberry_es_ES.ts
+++ b/src/translations/strawberry_es_ES.ts
@@ -36,8 +36,8 @@
       <translation>Si le gusta Strawberry y le da uso, plantéese patrocinarlo o realizar una donación.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>Puede patrocinar al autor en %1. También puede realizar una aportación económica a través de %2.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">Puede patrocinar al autor en %1 o %2. También puede realizar una aportación económica a través de %3.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5066,20 +5066,24 @@ Are you sure you want to continue?</source>
       <translation>artista</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation>busca todos los artistas que contienen la palabra %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation>busca todos los artistas que contienen la palabra %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation>Los términos de búsqueda para campos numéricos pueden llevar %1 o %2 como prefijos para refinar la búsqueda, p. ej.: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation>valoración</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation>También pueden combinarse múltiples términos de búsqueda con &quot;%1&quot; (por defecto) y &quot;%2&quot;, así como agrupados con paréntesis. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation>También pueden combinarse múltiples términos de búsqueda con &quot;%1&quot; (por defecto) y &quot;%2&quot;, así como agrupados con paréntesis.</translation>
     </message>
     <message>
       <source>Available fields</source>

--- a/src/translations/strawberry_es_MX.ts
+++ b/src/translations/strawberry_es_MX.ts
@@ -36,8 +36,8 @@
       <translation>Si le gusta Strawberry y le da uso, plantéese patrocinarlo o realizar una donación.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>Puede patrocinar al autor en %1. También puede realizar una aportación económica a través de %2.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">Puede patrocinar al autor en %1 o %2. También puede realizar una aportación económica a través de %3.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5066,20 +5066,24 @@ Are you sure you want to continue?</source>
       <translation>artista</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation>busca todos los artistas que contienen la palabra %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation>busca todos los artistas que contienen la palabra %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation>Los términos de búsqueda para campos numéricos pueden llevar %1 o %2 como prefijos para refinar la búsqueda. Por ejemplo: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation>valoración</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation>También se pueden combinar múltiples términos de búsqueda con &quot;%1&quot; (por defecto) y &quot;%2&quot;, así como agruparlos con paréntesis. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation>También se pueden combinar múltiples términos de búsqueda con &quot;%1&quot; (por defecto) y &quot;%2&quot;, así como agruparlos con paréntesis.</translation>
     </message>
     <message>
       <source>Available fields</source>

--- a/src/translations/strawberry_et_EE.ts
+++ b/src/translations/strawberry_et_EE.ts
@@ -36,8 +36,8 @@
       <translation>Kui Strawberry sulle meeldib ja leiad ta olevat kasulik, kaalu rahalist toetust või annetamist.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>Võid toetada autorit saidis %1. Samuti on võimalik ühekordne makse %2 kaudu.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">Võid toetada autorit saidis %1 või %2. Samuti on võimalik ühekordne makse %3 kaudu.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5067,20 +5067,24 @@ Kas soovid jätkata?</translation>
       <translation>esitaja</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation>kõikide esitajate otsing, kus leidub %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation>kõikide esitajate otsing, kus leidub %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation>Otsingu täpsustamiseks võib numbriväljade otsisõnade eesliiteks lisada %1 või %2, nt: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation>hinnang</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation>Mitut otsinguterminit saab kombineerida ka sõnadega &quot;%1&quot; (vaikimisi) ja &quot;%2&quot; ning rühmitada need sulgudega. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation>Mitut otsinguterminit saab kombineerida ka sõnadega &quot;%1&quot; (vaikimisi) ja &quot;%2&quot; ning rühmitada need sulgudega.</translation>
     </message>
     <message>
       <source>Available fields</source>

--- a/src/translations/strawberry_fi_FI.ts
+++ b/src/translations/strawberry_fi_FI.ts
@@ -36,8 +36,8 @@
       <translation>Jos pidät Strawberrystä ja sinulla on sille käyttöä, harkitse sponsorointia tai lahjoitusta.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>Voit sponsoroida tekijää %1:ssa. Voit myös tehdä kertalahjoituksen osoiteessa %2.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">Voit sponsoroida tekijää %1 tai %2:ssa. Voit myös tehdä kertalahjoituksen osoiteessa %3.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5067,20 +5067,24 @@ Haluatko varmasti jatkaa?</translation>
       <translation>esittäjä</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation type="unfinished">searches for all artists containing the word %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation type="unfinished">searches for all artists containing the word %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation type="unfinished">Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation type="unfinished">rating</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</translation>
     </message>
     <message>
       <source>Available fields</source>

--- a/src/translations/strawberry_fr_BE.ts
+++ b/src/translations/strawberry_fr_BE.ts
@@ -36,8 +36,8 @@
       <translation>Si vous aimez ce logiciel Strawberry et que vous pouvez en faire usage, envisagez de sponsoriser ou de faire un don.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>Vous pouvez sponsoriser l&apos;auteur sur %1. Vous pouvez également effectuer un paiement unique via %2.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation>Vous pouvez sponsoriser l&apos;auteur sur %1 ou sur %2. Vous pouvez également effectuer un paiement unique via %3.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5067,19 +5067,23 @@ Are you sure you want to continue?</source>
       <translation>artiste</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation>recherche tous les artistes contenant le mot %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation>recherche tous les artistes contenant le mot %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation>Les termes de recherche pour les champs numériques peuvent être préfixés par %1 ou %2 pour affiner la recherche, par exemple :</translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation>Un mot peut être utilisé pour exclure les titres correspondants en le précédant de &quot;%1&quot;, en cas de besoin de recherche utilisant un mot contenant &quot;%1&quot;, encadrez le mot par des guillemets.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation>notation</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
       <translation>Plusieurs termes de recherche peuvent également être combinés avec &quot;%1&quot; (par défaut) et &quot;%2&quot;, ainsi que regroupés entre parenthèses.</translation>
     </message>
     <message>

--- a/src/translations/strawberry_fr_FR.ts
+++ b/src/translations/strawberry_fr_FR.ts
@@ -36,8 +36,8 @@
       <translation>Si vous aimez ce logiciel Strawberry et que vous pouvez en faire usage, envisagez de sponsoriser ou de faire un don.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>Vous pouvez sponsoriser l&apos;auteur sur %1. Vous pouvez également effectuer un paiement unique via %2.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation>Vous pouvez sponsoriser l&apos;auteur sur %1 ou sur %2. Vous pouvez également effectuer un paiement unique via %3.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5067,20 +5067,24 @@ Are you sure you want to continue?</source>
       <translation>artiste</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation>recherche tous les artistes contenant le mot %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation>recherche tous les artistes contenant le mot %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation>Les termes de recherche pour les champs numériques peuvent être préfixés par %1 ou %2 pour affiner la recherche, par exemple : </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation>Un mot peut être utilisé pour exclure les titres correspondants en le précédant de &quot;%1&quot;, en cas de besoin de recherche utilisant un mot contenant &quot;%1&quot;, encadrez le mot par des guillemets.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation>notation</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation>Plusieurs termes de recherche peuvent également être combinés avec &quot;%1&quot; (par défaut) et &quot;%2&quot;, ainsi que regroupés entre parenthèses. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation>Plusieurs termes de recherche peuvent également être combinés avec &quot;%1&quot; (par défaut) et &quot;%2&quot;, ainsi que regroupés entre parenthèses.</translation>
     </message>
     <message>
       <source>Available fields</source>

--- a/src/translations/strawberry_hu_HU.ts
+++ b/src/translations/strawberry_hu_HU.ts
@@ -36,8 +36,8 @@
       <translation>Ha tetszik a Strawberry, és ki tudja használni, fontolja meg a szponzorálást vagy az adományozást.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>A szerzőt itt szponzorálhatja: %1. Egyszeri összeggel ezen az oldalon támogathat: %2.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation>A szerzőt itt szponzorálhatja: %1 vagy %2. Egyszeri összeggel ezen az oldalon támogathat: %3.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5067,20 +5067,24 @@ Biztos, hogy folytatja?</translation>
       <translation>előadó</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation type="unfinished">searches for all artists containing the word %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation type="unfinished">searches for all artists containing the word %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation type="unfinished">Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation type="unfinished">rating</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</translation>
     </message>
     <message>
       <source>Available fields</source>

--- a/src/translations/strawberry_id_ID.ts
+++ b/src/translations/strawberry_id_ID.ts
@@ -36,8 +36,8 @@
       <translation type="unfinished">If you like Strawberry and can make use of it, consider sponsoring or donating.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation type="unfinished">You can sponsor the author on %1. You can also make a one-time payment through %2.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5066,20 +5066,24 @@ Apakah Anda yakin ingin melanjutkan?</translation>
       <translation type="unfinished">artist</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation type="unfinished">searches for all artists containing the word %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation type="unfinished">searches for all artists containing the word %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation type="unfinished">Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation type="unfinished">rating</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</translation>
     </message>
     <message>
       <source>Available fields</source>

--- a/src/translations/strawberry_is_IS.ts
+++ b/src/translations/strawberry_is_IS.ts
@@ -36,8 +36,8 @@
       <translation>Ef þú kannt við Strawberry og það nýtist þér vel, ættirðu að íhuga að styrkja verkefnið.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>Þú getur styrkt höfundinn á %1. Þú getur líka lagt fram eins-skiptis greiðslu í gegnum %2.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">Þú getur styrkt höfundinn á %1 eða %2. Þú getur líka lagt fram eins-skiptis greiðslu í gegnum %3.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5067,20 +5067,24 @@ Ertu viss um að þú viljir halda áfram?</translation>
       <translation>flytjandi</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation>leitar að öllum flytjendum sem innihalda orðið %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation>leitar að öllum flytjendum sem innihalda orðið %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation>Hægt er að setja forskeytin %1 eða %2 á leitarorð fyrir tölureiti til að fínstilla leitina, t.d.: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation>einkunn</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation>Mörg leitarorð er hægt að setja saman með with &quot;%1&quot; (sjálfgefið) og &quot;%2&quot; og einnig hópuð með svigum. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation>Mörg leitarorð er hægt að setja saman með with &quot;%1&quot; (sjálfgefið) og &quot;%2&quot; og einnig hópuð með svigum.</translation>
     </message>
     <message>
       <source>Available fields</source>

--- a/src/translations/strawberry_it_IT.ts
+++ b/src/translations/strawberry_it_IT.ts
@@ -37,9 +37,9 @@ Il codice sorgente è disponibile su &apos;%1&apos;</translation>
       <translation>Se ti piace Strawberry e puoi farne uso, prendi in considerazione la sponsorizzazione o la donazione.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>Puoi sponsorizzare l&apos;autore su &apos;%1&apos;. 
-Puoi anche effettuare un pagamento una tantum tramite &apos;%2&apos;.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">Puoi sponsorizzare l&apos;autore su &apos;%1&apos; o &apos;%2&apos;. 
+Puoi anche effettuare un pagamento una tantum tramite &apos;%3&apos;.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5074,20 +5074,24 @@ Sei sicuro di voler continuare?</translation>
       <translation>artista</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation type="unfinished">searches for all artists containing the word %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation type="unfinished">searches for all artists containing the word %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation type="unfinished">Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation type="unfinished">rating</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</translation>
     </message>
     <message>
       <source>Available fields</source>

--- a/src/translations/strawberry_ja_JP.ts
+++ b/src/translations/strawberry_ja_JP.ts
@@ -36,8 +36,8 @@
       <translation>もし Strawberry が気に入って利用する場合は、後援または寄付を検討してください</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>%1 の著者をスポンサーにすることができます。 %2 を通じて 1回限りの支払いを行うこともできます。</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">%1, %2 の著者をスポンサーにすることができます。 %3 を通じて 1回限りの支払いを行うこともできます。</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5066,19 +5066,23 @@ Are you sure you want to continue?</source>
       <translation>アーティスト</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation>%1 という単語を含むすべてのアーティストを検索します。 </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation>%1 という単語を含むすべてのアーティストを検索します。</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation>数値フィールドの検索語には、先頭に %1 または %2 を付けると、検索を絞り込むことができます。例: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation>評価</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
       <translation>複数の検索語を「%1」(デフォルト) および「%2」と組み合わせたり、括弧でグループ化したりすることもできます。</translation>
     </message>
     <message>

--- a/src/translations/strawberry_ko_KR.ts
+++ b/src/translations/strawberry_ko_KR.ts
@@ -36,8 +36,8 @@
       <translation>Strawberry가 마음에 들었다면 스폰서쉽과 기부를 할 수 있습니다.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation type="unfinished">You can sponsor the author on %1. You can also make a one-time payment through %2.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5066,20 +5066,24 @@ Are you sure you want to continue?</source>
       <translation>아티스트</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation type="unfinished">searches for all artists containing the word %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation type="unfinished">searches for all artists containing the word %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation type="unfinished">Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation type="unfinished">rating</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</translation>
     </message>
     <message>
       <source>Available fields</source>

--- a/src/translations/strawberry_nb_NO.ts
+++ b/src/translations/strawberry_nb_NO.ts
@@ -36,8 +36,8 @@
       <translation>Hvis du liker Strawberry og kan bruke det, vurder om du kan donere eller bli sponsor.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>Du kan sponse Strawberry på %1. Du kan også gi en engangsbetaling gjennom %2.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">Du kan sponse Strawberry på %1 eller %2. Du kan også gi en engangsbetaling gjennom %3.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5067,20 +5067,24 @@ Er du sikker?</translation>
       <translation type="unfinished">artist</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation type="unfinished">searches for all artists containing the word %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation type="unfinished">searches for all artists containing the word %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation type="unfinished">Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation type="unfinished">rating</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</translation>
     </message>
     <message>
       <source>Available fields</source>

--- a/src/translations/strawberry_nl_NL.ts
+++ b/src/translations/strawberry_nl_NL.ts
@@ -36,8 +36,8 @@
       <translation type="unfinished">If you like Strawberry and can make use of it, consider sponsoring or donating.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>Je kan de schrijvers hier sponseren %1 U kunt ook een eenmalige betaling doen via %2</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">Je kan de schrijvers hier sponseren %1 of %2. U kunt ook een eenmalige betaling doen via %3</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5067,20 +5067,24 @@ Weet je zeker dat je verder wilt gaan?</translation>
       <translation>artiest</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation type="unfinished">searches for all artists containing the word %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation type="unfinished">searches for all artists containing the word %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation type="unfinished">Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation type="unfinished">rating</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</translation>
     </message>
     <message>
       <source>Available fields</source>

--- a/src/translations/strawberry_pl_PL.ts
+++ b/src/translations/strawberry_pl_PL.ts
@@ -36,8 +36,8 @@
       <translation>Jeśli lubisz ten program i uważasz go za użyteczny, możesz rozważyć sponsoring lub donację.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>Możesz sponsorować autora na %1. Możesz także dokonać jednorazowej wpłaty poprzez %2.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">Możesz sponsorować autora na %1 lub %2. Możesz także dokonać jednorazowej wpłaty poprzez %3.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5071,20 +5071,24 @@ Na pewno chcesz usunąć?</translation>
       <translation>artysta</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation type="unfinished">searches for all artists containing the word %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation type="unfinished">searches for all artists containing the word %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation type="unfinished">Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation type="unfinished">rating</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</translation>
     </message>
     <message>
       <source>Available fields</source>

--- a/src/translations/strawberry_pt_BR.ts
+++ b/src/translations/strawberry_pt_BR.ts
@@ -36,8 +36,8 @@
       <translation>Se você gosta do Strawberry e o acha útil, considere patrocinar o projeto ou fazer uma doação.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>Você pode patrocinar o autor em %1. Você também pode fazer um pagamento único em %2.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">Você pode patrocinar o autor em %1 ou %2. Você também pode fazer um pagamento único em %3.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5067,20 +5067,24 @@ Deseja continuar?</translation>
       <translation type="unfinished">artist</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation type="unfinished">searches for all artists containing the word %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation type="unfinished">searches for all artists containing the word %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation type="unfinished">Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation type="unfinished">rating</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</translation>
     </message>
     <message>
       <source>Available fields</source>

--- a/src/translations/strawberry_ru_RU.ts
+++ b/src/translations/strawberry_ru_RU.ts
@@ -36,8 +36,8 @@
       <translation>Если вам приглянулся Strawberry, пожалуйста, рассмотрите возможность спонсорства или пожертвования.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>Вы можете материально поддержать автора на %1. Также можно произвести единовременный платёж на %2.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">Вы можете материально поддержать автора на %1 или %2. Также можно произвести единовременный платёж на %3.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5069,19 +5069,23 @@ Are you sure you want to continue?</source>
       <translation>артист</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation>выполняет поиск всех артистов со словом %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation>выполняет поиск всех артистов со словом %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation>Для уточнения поиска в числовых полях можно использовать приставки %1 или %2, например:</translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation>оценка</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
       <translation>Несколько поисковых терминов можно объединить с помощью символов «%1» (по умолчанию) и «%2», а сгруппировать с помощью круглых скобок.</translation>
     </message>
     <message>

--- a/src/translations/strawberry_sv_SE.ts
+++ b/src/translations/strawberry_sv_SE.ts
@@ -36,8 +36,8 @@
       <translation>Om du gillar Strawberry och har nytta av det, överväg att sponsra eller donera.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>Du kan sponsra upphovsmannen på %1. Du kan också göra en engångsbetalning genom %2.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">Du kan sponsra upphovsmannen på %1 eller %2. Du kan också göra en engångsbetalning genom %3.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5067,19 +5067,23 @@ Are you sure you want to continue?</source>
       <translation>artist</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation>söker efter alla artister som innehåller ordet %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation>söker efter alla artister som innehåller ordet %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation>Söktermer för numeriska fält kan prefixas med %1 eller %2 för att förfina sökningen, t.ex.:</translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation>betyg</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
       <translation>Flera söktermer kan också kombineras med &quot;%1&quot; (standard) och &quot;%2&quot;, samt grupperas med parenteser.</translation>
     </message>
     <message>

--- a/src/translations/strawberry_tr_CY.ts
+++ b/src/translations/strawberry_tr_CY.ts
@@ -36,8 +36,8 @@
       <translation type="unfinished">If you like Strawberry and can make use of it, consider sponsoring or donating.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation type="unfinished">You can sponsor the author on %1. You can also make a one-time payment through %2.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5067,20 +5067,24 @@ Are you sure you want to continue?</translation>
       <translation type="unfinished">artist</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation type="unfinished">searches for all artists containing the word %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation type="unfinished">searches for all artists containing the word %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation type="unfinished">Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation type="unfinished">rating</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</translation>
     </message>
     <message>
       <source>Available fields</source>

--- a/src/translations/strawberry_tr_TR.ts
+++ b/src/translations/strawberry_tr_TR.ts
@@ -36,8 +36,8 @@
       <translation>Eğer Strawberry&apos;yi beğendiyseniz ve işinize yarıyorsa sponsor olmayı düşünebilir veya bağışta bulunabilirsiniz.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>Geliştiriciye %1 üzerinden sponsor olabilirsiniz. Ayrıca %2 üzerinden tek seferlik ödeme yapabilirsiniz.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">Geliştiriciye %1 veya %2 üzerinden sponsor olabilirsiniz. Ayrıca %3 üzerinden tek seferlik ödeme yapabilirsiniz.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5067,20 +5067,24 @@ Devam etmek istediğinizden emin misiniz?</translation>
       <translation>sanatçı</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation type="unfinished">searches for all artists containing the word %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation type="unfinished">searches for all artists containing the word %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation type="unfinished">Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation>derecelendirme</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</translation>
     </message>
     <message>
       <source>Available fields</source>

--- a/src/translations/strawberry_uk_UA.ts
+++ b/src/translations/strawberry_uk_UA.ts
@@ -36,8 +36,8 @@
       <translation>Якщо вам подобається Strawberry і ви часто ним користуєтесь, подумайте про спонсорство або пожертвування.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>Ви можете підтримати автора на %1. Ви також можете зробити одноразовий платіж через %2.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">Ви можете підтримати автора на %1 або %2. Ви також можете зробити одноразовий платіж через %3.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5069,20 +5069,24 @@ Are you sure you want to continue?</source>
       <translation>виконавець</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation>шукати всіх виконавців, що містять слово %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation>шукати всіх виконавців, що містять слово %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation>Для уточнення пошуку перед пошуковими термінами для числових полів можна додати %1 або %2, наприклад: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation>рейтинг</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation>Кілька пошукових термінів також можна об'єднати за допомогою &quot;%1&quot; (за замовчуванням) та &quot;%2&quot;, а також згрупувати за допомогою дужок. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation>Кілька пошукових термінів також можна об'єднати за допомогою &quot;%1&quot; (за замовчуванням) та &quot;%2&quot;, а також згрупувати за допомогою дужок.</translation>
     </message>
     <message>
       <source>Available fields</source>

--- a/src/translations/strawberry_vi_VN.ts
+++ b/src/translations/strawberry_vi_VN.ts
@@ -36,8 +36,8 @@
       <translation>Nếu bạn thích Strawberry và có thể sử dụng được thì hãy cân nhắc tài trợ hoặc quyên góp.</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>Bạn có thể tài trợ cho tác giả trên %1. Bạn cũng có thể thực hiện thanh toán một lần thông qua %2.</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">Bạn có thể tài trợ cho tác giả trên %1 hoặc %2. Bạn cũng có thể thực hiện thanh toán một lần thông qua %3.</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5066,20 +5066,24 @@ Bạn có chắc chắn muốn tiếp tục không?</translation>
       <translation>nghệ sĩ</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation>tìm tất cả nghệ sĩ chứa từ %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation>tìm tất cả nghệ sĩ chứa từ %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation>Các từ khóa cho trường số có thể thêm tiền tố %1 hoặc %2 để lọc tìm kiếm, ví dụ: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation>đánh giá</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation>Nhiều từ khóa cũng có thể kết hợp với &quot;%1&quot; (mặc định) và &quot;%2&quot;, cũng như nhóm bằng dấu ngoặc. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation>Nhiều từ khóa cũng có thể kết hợp với &quot;%1&quot; (mặc định) và &quot;%2&quot;, cũng như nhóm bằng dấu ngoặc.</translation>
     </message>
     <message>
       <source>Available fields</source>

--- a/src/translations/strawberry_zh_CN.ts
+++ b/src/translations/strawberry_zh_CN.ts
@@ -36,8 +36,8 @@
       <translation>如果您喜欢 Strawberry 并能用得上它，请考虑赞助或捐赠。</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>您可以在 %1 赞助作者。您也可以通过 %2 进行一次性付款。</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">您可以在 %1 或 %2 赞助作者。您也可以通过 %3 进行一次性付款。</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5066,7 +5066,7 @@ Are you sure you want to continue?</source>
       <translation>艺术家</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
+      <source>searches for all artists containing the word %1.</source>
       <translation>搜索所有包含单词 %1 的艺术家。</translation>
     </message>
     <message>
@@ -5074,11 +5074,15 @@ Are you sure you want to continue?</source>
       <translation>数字字段的搜索词可以用 %1 或 %2 前缀来细化搜索，例如：</translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation>评分</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
       <translation>多个搜索词也可以与 &quot;%1&quot;（默认）和 &quot;%2&quot; 组合，以及用括号分组。</translation>
     </message>
     <message>

--- a/src/translations/strawberry_zh_TW.ts
+++ b/src/translations/strawberry_zh_TW.ts
@@ -37,8 +37,8 @@
       <translation>如果您喜歡 Strawberry 並覺得它對您有幫助，歡迎考慮贊助或捐款支持。</translation>
     </message>
     <message>
-      <source>You can sponsor the author on %1. You can also make a one-time payment through %2.</source>
-      <translation>您可以在 %1 贊助作者，也可以透過 %2 進行一次性付款。</translation>
+      <source>You can sponsor the author on %1 or %2. You can also make a one-time payment through %3.</source>
+      <translation type="unfinished">您可以在 %1 %2 贊助作者，也可以透過 %3 進行一次性付款。</translation>
     </message>
     <message>
       <source>Author and maintainer</source>
@@ -5067,20 +5067,24 @@ Are you sure you want to continue?</translation>
       <translation type="unfinished">artist</translation>
     </message>
     <message>
-      <source>searches for all artists containing the word %1. </source>
-      <translation type="unfinished">searches for all artists containing the word %1. </translation>
+      <source>searches for all artists containing the word %1.</source>
+      <translation type="unfinished">searches for all artists containing the word %1.</translation>
     </message>
     <message>
       <source>Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </source>
       <translation type="unfinished">Search terms for numerical fields can be prefixed with %1 or %2 to refine the search, e.g.: </translation>
     </message>
     <message>
+      <source>A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</source>
+      <translation type="unfinished">A word can be excluded with a preceding &quot;%1&quot;, if you need to search for a word including &quot;%1&quot;, place quotes around the word.</translation>
+    </message>
+    <message>
       <source>rating</source>
       <translation type="unfinished">rating</translation>
     </message>
     <message>
-      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </source>
-      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses. </translation>
+      <source>Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</source>
+      <translation type="unfinished">Multiple search terms can also be combined with &quot;%1&quot; (default) and &quot;%2&quot;, as well as grouped with parentheses.</translation>
     </message>
     <message>
       <source>Available fields</source>


### PR DESCRIPTION
An update in the About text was not reported in the translation module, now corrected.
Some white space make failure in translation.
A sentence was forgotten, I add it and create the translation for french countries.