### PR TITLE
Add a sub-menu to the shuffle playlist menu to decide how to shuffle.

### DIFF
--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -382,6 +382,7 @@ MainWindow::MainWindow(Application *app,
       collection_show_duplicates_(nullptr),
       collection_show_untagged_(nullptr),
       playlist_menu_(new QMenu(this)),
+      shuffle_playlist_menu_(new QMenu(this)),
       playlist_play_pause_(nullptr),
       playlist_stop_after_(nullptr),
       playlist_undoredo_(nullptr),
@@ -612,7 +613,6 @@ MainWindow::MainWindow(Application *app,
   QObject::connect(ui_->action_toggle_show_sidebar, &QAction::toggled, this, &MainWindow::ToggleSidebar);
   QObject::connect(ui_->action_about_strawberry, &QAction::triggered, this, &MainWindow::ShowAboutDialog);
   QObject::connect(ui_->action_about_qt, &QAction::triggered, qApp, &QApplication::aboutQt);
-  QObject::connect(ui_->action_shuffle, &QAction::triggered, &*app_->playlist_manager(), &PlaylistManager::ShuffleCurrent);
   QObject::connect(ui_->action_open_file, &QAction::triggered, this, &MainWindow::AddFile);
   QObject::connect(ui_->action_open_cd, &QAction::triggered, this, &MainWindow::AddCDTracks);
   QObject::connect(ui_->action_add_file, &QAction::triggered, this, &MainWindow::AddFile);
@@ -654,6 +654,15 @@ MainWindow::MainWindow(Application *app,
   ui_->button_scrobble->setDefaultAction(ui_->action_toggle_scrobbling);
   ui_->button_love->setDefaultAction(ui_->action_love);
 
+  // Shuffle playlist sub-menu
+  QActionGroup *shuffle_playlist_group = new QActionGroup(this);
+  shuffle_playlist_group->addAction(ui_->action_shuffle_playlist_all);
+  shuffle_playlist_group->addAction(ui_->action_shuffle_playlist_albums);
+  shuffle_playlist_group->addAction(ui_->action_shuffle_playlist_grouping);
+  shuffle_playlist_menu_->addActions(shuffle_playlist_group->actions());
+
+  QObject::connect(shuffle_playlist_group, &QActionGroup::triggered, this, &MainWindow::ShufflePlaylistActionTriggered);
+
   PlaylistContainer::Actions playlist_actions;
   playlist_actions.new_playlist = ui_->action_new_playlist;
   playlist_actions.load_playlist = ui_->action_load_playlist;
@@ -670,6 +679,7 @@ MainWindow::MainWindow(Application *app,
   // Add the shuffle and repeat action groups to the menu
   ui_->action_shuffle_mode->setMenu(ui_->playlist_sequence->shuffle_menu());
   ui_->action_repeat_mode->setMenu(ui_->playlist_sequence->repeat_menu());
+  ui_->action_shuffle->setMenu(shuffle_playlist_menu_);
 
   // Stop actions
   QMenu *stop_menu = new QMenu(this);
@@ -3695,5 +3705,15 @@ void MainWindow::ProcessMetadataQueue() {
   if (!metadata_queue_.isEmpty()) {
     metadata_queue_timer_->start();
   }
+
+}
+
+void MainWindow::ShufflePlaylistActionTriggered(QAction *action) {
+
+  PlaylistSequence::ShuffleMode mode = PlaylistSequence::ShuffleMode::All;
+  if (action == ui_->action_shuffle_playlist_albums) mode = PlaylistSequence::ShuffleMode::Albums;
+  if (action == ui_->action_shuffle_playlist_grouping) mode = PlaylistSequence::ShuffleMode::Grouping;
+
+  app_->playlist_manager()->ShuffleCurrent(mode);
 
 }

--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -385,6 +385,7 @@ MainWindow::MainWindow(Application *app,
       collection_show_duplicates_(nullptr),
       collection_show_untagged_(nullptr),
       playlist_menu_(new QMenu(this)),
+      shuffle_playlist_menu_(new QMenu(this)),
       playlist_play_pause_(nullptr),
       playlist_stop_after_(nullptr),
       playlist_undoredo_(nullptr),
@@ -616,7 +617,6 @@ MainWindow::MainWindow(Application *app,
   QObject::connect(ui_->action_toggle_show_sidebar, &QAction::toggled, this, &MainWindow::ToggleSidebar);
   QObject::connect(ui_->action_about_strawberry, &QAction::triggered, this, &MainWindow::ShowAboutDialog);
   QObject::connect(ui_->action_about_qt, &QAction::triggered, qApp, &QApplication::aboutQt);
-  QObject::connect(ui_->action_shuffle, &QAction::triggered, &*app_->playlist_manager(), &PlaylistManager::ShuffleCurrent);
   QObject::connect(ui_->action_open_file, &QAction::triggered, this, &MainWindow::AddFile);
   QObject::connect(ui_->action_open_cd, &QAction::triggered, this, &MainWindow::AddCDTracks);
   QObject::connect(ui_->action_add_file, &QAction::triggered, this, &MainWindow::AddFile);
@@ -658,6 +658,15 @@ MainWindow::MainWindow(Application *app,
   ui_->button_scrobble->setDefaultAction(ui_->action_toggle_scrobbling);
   ui_->button_love->setDefaultAction(ui_->action_love);
 
+  // Shuffle playlist sub-menu
+  QActionGroup *shuffle_playlist_group = new QActionGroup(this);
+  shuffle_playlist_group->addAction(ui_->action_shuffle_playlist_all);
+  shuffle_playlist_group->addAction(ui_->action_shuffle_playlist_albums);
+  shuffle_playlist_group->addAction(ui_->action_shuffle_playlist_grouping);
+  shuffle_playlist_menu_->addActions(shuffle_playlist_group->actions());
+
+  QObject::connect(shuffle_playlist_group, &QActionGroup::triggered, this, &MainWindow::ShufflePlaylistActionTriggered);
+
   PlaylistContainer::Actions playlist_actions;
   playlist_actions.new_playlist = ui_->action_new_playlist;
   playlist_actions.load_playlist = ui_->action_load_playlist;
@@ -674,6 +683,7 @@ MainWindow::MainWindow(Application *app,
   // Add the shuffle and repeat action groups to the menu
   ui_->action_shuffle_mode->setMenu(ui_->playlist_sequence->shuffle_menu());
   ui_->action_repeat_mode->setMenu(ui_->playlist_sequence->repeat_menu());
+  ui_->action_shuffle->setMenu(shuffle_playlist_menu_);
 
   // Stop actions
   QMenu *stop_menu = new QMenu(this);
@@ -3711,5 +3721,15 @@ void MainWindow::ProcessMetadataQueue() {
   if (!metadata_queue_.isEmpty()) {
     metadata_queue_timer_->start();
   }
+
+}
+
+void MainWindow::ShufflePlaylistActionTriggered(QAction *action) {
+
+  PlaylistSequence::ShuffleMode mode = PlaylistSequence::ShuffleMode::All;
+  if (action == ui_->action_shuffle_playlist_albums) mode = PlaylistSequence::ShuffleMode::Albums;
+  if (action == ui_->action_shuffle_playlist_grouping) mode = PlaylistSequence::ShuffleMode::Grouping;
+
+  app_->playlist_manager()->ShuffleCurrent(mode);
 
 }

--- a/src/core/mainwindow.h
+++ b/src/core/mainwindow.h
@@ -284,6 +284,8 @@ class MainWindow : public QMainWindow, public PlatformInterface {
   void FetchStreamingMetadata();
   void ProcessMetadataQueue();
 
+  void ShufflePlaylistActionTriggered(QAction *action);
+
  public Q_SLOTS:
   void CommandlineOptionsReceived(const QByteArray &string_options);
   void Raise();
@@ -374,6 +376,7 @@ class MainWindow : public QMainWindow, public PlatformInterface {
   QAction *collection_show_untagged_;
 
   QMenu *playlist_menu_;
+  QMenu *shuffle_playlist_menu_;
   QAction *playlist_play_pause_;
   QAction *playlist_stop_after_;
   QAction *playlist_undoredo_;

--- a/src/core/mainwindow.ui
+++ b/src/core/mainwindow.ui
@@ -661,9 +661,6 @@
    <property name="text">
     <string>S&amp;huffle playlist</string>
    </property>
-   <property name="shortcut">
-    <string>Ctrl+Shift+H</string>
-   </property>
   </action>
   <action name="action_add_file">
    <property name="text">
@@ -870,6 +867,33 @@
    </property>
    <property name="text">
     <string>Show sidebar</string>
+   </property>
+  </action>
+  <action name="action_shuffle_playlist_all">
+   <property name="checkable">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Single track as random element</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+H</string>
+   </property>
+  </action>
+  <action name="action_shuffle_playlist_albums">
+   <property name="checkable">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Album as random element</string>
+   </property>
+  </action>
+  <action name="action_shuffle_playlist_grouping">
+   <property name="checkable">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Grouped tracks as random element</string>
    </property>
   </action>
  </widget>

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -2123,29 +2123,47 @@ void Playlist::ReloadItems(const QList<int> &rows) {
 
 }
 
-void Playlist::Shuffle() {
+void Playlist::Shuffle(const PlaylistSequence::ShuffleMode shuffle_mode) {
 
-  PlaylistItemPtrList new_items(items_);
-
+  QList<int> index_items;
   int begin = 0;
+  int exclude_index = -1;
+
   if (current_item_index_.isValid()) {
     if (dynamic_playlist_) {
-      // Keep the history and the current track fixed; only shuffle the future region (mirrors sort()).
-      begin = current_item_index_.row() + 1;
+      begin += current_item_index_.row() + 1;
     }
-    else {
-      if (new_items[0] != new_items[current_item_index_.row()]) {
-        std::swap(new_items[0], new_items[current_item_index_.row()]);
-      }
-      begin = 1;
+    else if (shuffle_mode == PlaylistSequence::ShuffleMode::All) {
+      // I keep the current track on the first place only when I shuffle all the tracks
+      exclude_index = current_item_index_.row();
     }
   }
 
   const int count = static_cast<int>(items_.count());
   for (int i = begin; i < count; ++i) {
-    const int new_pos = i + (rand() % (count - i));
+    if (exclude_index == i) {
+      continue;
+    }
+    index_items.push_back(i);
+  }
 
-    std::swap(new_items[i], new_items[new_pos]);
+  ReshuffleIndices(index_items, shuffle_mode, true);
+
+  PlaylistItemPtrList new_items;
+
+  if (exclude_index >= 0) {
+    // Here I want to keep the current track fixed
+    new_items.push_back(items_[exclude_index]);
+  }
+  else if (begin > 0) {
+    // Here I want to keep the history and the current track fixed
+    for (int i = 0; i < begin; ++i) {
+      new_items.push_back(items_[i]);
+    }
+  }
+  // Then, I shuffle the remaining «future» tracks to read
+  for (int idx_shuffle : std::as_const(index_items)) {
+    new_items.push_back(items_[idx_shuffle]);
   }
 
   undo_stack_->push(new PlaylistUndoCommandShuffleItems(this, new_items));
@@ -2159,7 +2177,29 @@ bool AlbumShuffleComparator(const QHash<QString, int> &album_key_positions, cons
   const int left_pos = album_key_positions[album_keys[left]];
   const int right_pos = album_key_positions[album_keys[right]];
 
+  // With this return, I keep the tracks in the order they have in the playlist
   if (left_pos == right_pos) return left < right;
+
+  // Sort the albums by their position in the playlist
+  return left_pos < right_pos;
+
+}
+
+// to the contrary of the function upper, I will keep the tracks in the order of their position in the album
+// not with the position they have in the playlist
+bool AlbumShuffleComparatorTrackOrder(const QHash<QString, int> &album_key_positions, const QHash<int, QString> &album_keys, const PlaylistItemPtrList &items, const int left, const int right) {
+
+  const int left_pos = album_key_positions[album_keys[left]];
+  const int right_pos = album_key_positions[album_keys[right]];
+
+  if (left_pos == right_pos) {
+    auto &&left_song = items[left]->EffectiveMetadata();
+    auto &&right_song = items[right]->EffectiveMetadata();
+
+    if (left_song.disc() == right_song.disc()) return left_song.track() < right_song.track();
+
+    return left_song.disc() < right_song.disc();
+  }
   return left_pos < right_pos;
 
 }
@@ -2168,18 +2208,41 @@ bool AlbumShuffleComparator(const QHash<QString, int> &album_key_positions, cons
 
 void Playlist::ReshuffleIndices() {
 
-  const PlaylistSequence::ShuffleMode shuffle_mode = ShuffleMode();
+  // First, cancel the replay position
+  // TODO : uncomment the code below when the branch «Grouped tracks are considered as single track» will be merged
+  // next_song_after_queued_ = -1;
+
+  current_virtual_index_ = ReshuffleIndices(virtual_items_, ShuffleMode(), false);
+
+}
+
+int Playlist::ReshuffleIndices(QList<int>& virtual_items, const PlaylistSequence::ShuffleMode shuffle_mode, const bool album_keep_track_order) {
+
+  static std::mt19937 rng{std::random_device{}()};
+
   switch (shuffle_mode) {
     case PlaylistSequence::ShuffleMode::Off:{
       // No shuffling - sort the virtual item list normally.
-      std::sort(virtual_items_.begin(), virtual_items_.end());
+      std::sort(virtual_items.begin(), virtual_items.end());
       break;
     }
 
     case PlaylistSequence::ShuffleMode::All:
     case PlaylistSequence::ShuffleMode::InsideAlbum:{
-      std::random_device rd;
-      std::shuffle(virtual_items_.begin(), virtual_items_.end(), std::mt19937(rd()));
+      std::shuffle(virtual_items.begin(), virtual_items.end(), rng);
+
+      if (!virtual_items.isEmpty()) {
+        // If the user is currently playing a song, force its track to be first
+        // Also check last_played_row() for cases where current_row() hasn't been set yet (e.g., on app startup)
+        int reference_row = current_row();
+        if (reference_row == -1 && last_played_row() != -1) {
+          reference_row = last_played_row();
+        }
+        const int reference_pos = virtual_items.indexOf(reference_row);
+        if (reference_pos > 0) {
+          std::swap(virtual_items[0], virtual_items[reference_pos]);
+        }
+      }
       break;
     }
 
@@ -2188,7 +2251,7 @@ void Playlist::ReshuffleIndices() {
       QSet<QString> album_key_set;     // unique keys
 
       // Find all the unique albums in the playlist
-      for (QList<int>::const_iterator it = virtual_items_.constBegin(); it != virtual_items_.constEnd(); ++it) {
+      for (QList<int>::const_iterator it = virtual_items.constBegin(); it != virtual_items.constEnd(); ++it) {
         const int index = *it;
         const QString key = items_[index]->EffectiveMetadata().AlbumKey();
         album_keys[index] = key;
@@ -2196,7 +2259,6 @@ void Playlist::ReshuffleIndices() {
       }
 
       // Shuffle them
-      static std::mt19937 rng{std::random_device{}()};
       QStringList shuffled_album_keys = album_key_set.values();
       std::shuffle(shuffled_album_keys.begin(), shuffled_album_keys.end(), rng);
 
@@ -2209,7 +2271,7 @@ void Playlist::ReshuffleIndices() {
       if (reference_row != -1) {
         const QString key = items_[reference_row]->EffectiveMetadata().AlbumKey();
         const qint64 pos = shuffled_album_keys.indexOf(key);
-        if (pos >= 1) {
+        if (pos > 0) {
           std::swap(shuffled_album_keys[0], shuffled_album_keys[pos]);
         }
       }
@@ -2220,8 +2282,18 @@ void Playlist::ReshuffleIndices() {
         album_key_positions[shuffled_album_keys[i]] = i;
       }
 
+      if (album_keep_track_order) {
+        // Sort the virtual items : use AlbumShuffleComparator with a cheap-to-copy lambda comparator
+        // force the track order to be the album one
+        std::stable_sort(virtual_items.begin(), virtual_items.end(), [&album_key_positions, &album_keys, this](const int lhs, const int rhs) {
+          return AlbumShuffleComparatorTrackOrder(album_key_positions, album_keys, items_, lhs, rhs);
+        });
+
+        break;
+      }
       // Sort the virtual items : use AlbumShuffleComparator with a cheap-to-copy lambda comparator
-      std::stable_sort(virtual_items_.begin(), virtual_items_.end(), [&album_key_positions, &album_keys](const int lhs, const int rhs) {
+      // keep the track order they have in the playlist
+      std::stable_sort(virtual_items.begin(), virtual_items.end(), [&album_key_positions, &album_keys](const int lhs, const int rhs) {
         return AlbumShuffleComparator(album_key_positions, album_keys, lhs, rhs);
       });
 
@@ -2232,7 +2304,7 @@ void Playlist::ReshuffleIndices() {
       QSet<QString> grouping_key_set;    // unique keys
 
       // Find all the unique grouping keys in the playlist
-      for (QList<int>::const_iterator it = virtual_items_.constBegin(); it != virtual_items_.constEnd(); ++it) {
+      for (QList<int>::const_iterator it = virtual_items.constBegin(); it != virtual_items.constEnd(); ++it) {
         const int index = *it;
         const QString key = items_[index]->EffectiveMetadata().GroupingKey();
         grouping_keys[index] = key;
@@ -2240,7 +2312,6 @@ void Playlist::ReshuffleIndices() {
       }
 
       // Shuffle them
-      static std::mt19937 rng{std::random_device{}()};
       QStringList shuffled_grouping_keys = grouping_key_set.values();
       std::shuffle(shuffled_grouping_keys.begin(), shuffled_grouping_keys.end(), rng);
 
@@ -2253,7 +2324,7 @@ void Playlist::ReshuffleIndices() {
       if (reference_row != -1) {
         const QString key = items_[reference_row]->EffectiveMetadata().GroupingKey();
         const qint64 pos = shuffled_grouping_keys.indexOf(key);
-        if (pos >= 1) {
+        if (pos > 0) {
           std::swap(shuffled_grouping_keys[0], shuffled_grouping_keys[pos]);
         }
       }
@@ -2264,21 +2335,22 @@ void Playlist::ReshuffleIndices() {
         grouping_key_positions[shuffled_grouping_keys[i]] = i;
       }
 
-      // Sort the virtual items: use AlbumShuffleComparator as a grouping-key comparator with a cheap-to-copy lambda
-      std::stable_sort(virtual_items_.begin(), virtual_items_.end(), [&grouping_key_positions, &grouping_keys](const int lhs, const int rhs) {
-        return AlbumShuffleComparator(grouping_key_positions, grouping_keys, lhs, rhs);
+      // Sort the virtual items: use AlbumShuffleComparatorTrackOrder as a grouping-key comparator with a cheap-to-copy lambda
+      // This sort method will keep the track number order so important in the grouped read
+      std::stable_sort(virtual_items.begin(), virtual_items.end(), [&grouping_key_positions, &grouping_keys, this](const int lhs, const int rhs) {
+        return AlbumShuffleComparatorTrackOrder(grouping_key_positions, grouping_keys, items_, lhs, rhs);
       });
       break;
     }
   }
 
-  // Update current virtual index
+  // I keep the computation of the virtual index because it is only return, if you want to ignore it, you can
+  // besides, it will be usefull in the cases I want to use the updated method
   if (current_item_index_.isValid()) {
-    current_virtual_index_ = static_cast<int>(virtual_items_.indexOf(current_item_index_.row()));
+    return static_cast<int>(virtual_items.indexOf(current_item_index_.row()));
   }
-  else {
-    current_virtual_index_ = -1;
-  }
+
+  return -1;
 
 }
 

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -2190,29 +2190,47 @@ void Playlist::ReloadItems(const QList<int> &rows) {
 
 }
 
-void Playlist::Shuffle() {
+void Playlist::Shuffle(const PlaylistSequence::ShuffleMode shuffle_mode) {
 
-  PlaylistItemPtrList new_items(items_);
-
+  QList<int> index_items;
   int begin = 0;
+  int exclude_index = -1;
+
   if (current_item_index_.isValid()) {
     if (dynamic_playlist_) {
-      // Keep the history and the current track fixed; only shuffle the future region (mirrors sort()).
-      begin = current_item_index_.row() + 1;
+      begin += current_item_index_.row() + 1;
     }
-    else {
-      if (new_items[0] != new_items[current_item_index_.row()]) {
-        std::swap(new_items[0], new_items[current_item_index_.row()]);
-      }
-      begin = 1;
+    else if (shuffle_mode == PlaylistSequence::ShuffleMode::All) {
+      // I keep the current track on the first place only when I shuffle all the tracks
+      exclude_index = current_item_index_.row();
     }
   }
 
   const int count = static_cast<int>(items_.count());
   for (int i = begin; i < count; ++i) {
-    const int new_pos = i + (rand() % (count - i));
+    if (exclude_index == i) {
+      continue;
+    }
+    index_items.push_back(i);
+  }
 
-    std::swap(new_items[i], new_items[new_pos]);
+  ReshuffleIndices(index_items, shuffle_mode, true);
+
+  PlaylistItemPtrList new_items;
+
+  if (exclude_index >= 0) {
+    // Here I want to keep the current track fixed
+    new_items.push_back(items_[exclude_index]);
+  }
+  else if (begin > 0) {
+    // Here I want to keep the history and the current track fixed
+    for (int i = 0; i < begin; ++i) {
+      new_items.push_back(items_[i]);
+    }
+  }
+  // Then, I shuffle the remaining «future» tracks to read
+  for (int idx_shuffle : std::as_const(index_items)) {
+    new_items.push_back(items_[idx_shuffle]);
   }
 
   undo_stack_->push(new PlaylistUndoCommandShuffleItems(this, new_items));
@@ -2226,7 +2244,29 @@ bool AlbumShuffleComparator(const QHash<QString, int> &album_key_positions, cons
   const int left_pos = album_key_positions[album_keys[left]];
   const int right_pos = album_key_positions[album_keys[right]];
 
+  // With this return, I keep the tracks in the order they have in the playlist
   if (left_pos == right_pos) return left < right;
+
+  // Sort the albums by their position in the playlist
+  return left_pos < right_pos;
+
+}
+
+// to the contrary of the function upper, I will keep the tracks in the order of their position in the album
+// not with the position they have in the playlist
+bool AlbumShuffleComparatorTrackOrder(const QHash<QString, int> &album_key_positions, const QHash<int, QString> &album_keys, const PlaylistItemPtrList &items, const int left, const int right) {
+
+  const int left_pos = album_key_positions[album_keys[left]];
+  const int right_pos = album_key_positions[album_keys[right]];
+
+  if (left_pos == right_pos) {
+    auto &&left_song = items[left]->EffectiveMetadata();
+    auto &&right_song = items[right]->EffectiveMetadata();
+
+    if (left_song.disc() == right_song.disc()) return left_song.track() < right_song.track();
+
+    return left_song.disc() < right_song.disc();
+  }
   return left_pos < right_pos;
 
 }
@@ -2235,18 +2275,41 @@ bool AlbumShuffleComparator(const QHash<QString, int> &album_key_positions, cons
 
 void Playlist::ReshuffleIndices() {
 
-  const PlaylistSequence::ShuffleMode shuffle_mode = ShuffleMode();
+  // First, cancel the replay position
+  // TODO : uncomment the code below when the branch «Grouped tracks are considered as single track» will be merged
+  // next_song_after_queued_ = -1;
+
+  current_virtual_index_ = ReshuffleIndices(virtual_items_, ShuffleMode(), false);
+
+}
+
+int Playlist::ReshuffleIndices(QList<int>& virtual_items, const PlaylistSequence::ShuffleMode shuffle_mode, const bool album_keep_track_order) {
+
+  static std::mt19937 rng{std::random_device{}()};
+
   switch (shuffle_mode) {
     case PlaylistSequence::ShuffleMode::Off:{
       // No shuffling - sort the virtual item list normally.
-      std::sort(virtual_items_.begin(), virtual_items_.end());
+      std::sort(virtual_items.begin(), virtual_items.end());
       break;
     }
 
     case PlaylistSequence::ShuffleMode::All:
     case PlaylistSequence::ShuffleMode::InsideAlbum:{
-      std::random_device rd;
-      std::shuffle(virtual_items_.begin(), virtual_items_.end(), std::mt19937(rd()));
+      std::shuffle(virtual_items.begin(), virtual_items.end(), rng);
+
+      if (!virtual_items.isEmpty()) {
+        // If the user is currently playing a song, force its track to be first
+        // Also check last_played_row() for cases where current_row() hasn't been set yet (e.g., on app startup)
+        int reference_row = current_row();
+        if (reference_row == -1 && last_played_row() != -1) {
+          reference_row = last_played_row();
+        }
+        const int reference_pos = virtual_items.indexOf(reference_row);
+        if (reference_pos > 0) {
+          std::swap(virtual_items[0], virtual_items[reference_pos]);
+        }
+      }
       break;
     }
 
@@ -2255,7 +2318,7 @@ void Playlist::ReshuffleIndices() {
       QSet<QString> album_key_set;     // unique keys
 
       // Find all the unique albums in the playlist
-      for (QList<int>::const_iterator it = virtual_items_.constBegin(); it != virtual_items_.constEnd(); ++it) {
+      for (QList<int>::const_iterator it = virtual_items.constBegin(); it != virtual_items.constEnd(); ++it) {
         const int index = *it;
         const QString key = items_[index]->EffectiveMetadata().AlbumKey();
         album_keys[index] = key;
@@ -2263,7 +2326,6 @@ void Playlist::ReshuffleIndices() {
       }
 
       // Shuffle them
-      static std::mt19937 rng{std::random_device{}()};
       QStringList shuffled_album_keys = album_key_set.values();
       std::shuffle(shuffled_album_keys.begin(), shuffled_album_keys.end(), rng);
 
@@ -2276,7 +2338,7 @@ void Playlist::ReshuffleIndices() {
       if (reference_row != -1) {
         const QString key = items_[reference_row]->EffectiveMetadata().AlbumKey();
         const qint64 pos = shuffled_album_keys.indexOf(key);
-        if (pos >= 1) {
+        if (pos > 0) {
           std::swap(shuffled_album_keys[0], shuffled_album_keys[pos]);
         }
       }
@@ -2287,8 +2349,18 @@ void Playlist::ReshuffleIndices() {
         album_key_positions[shuffled_album_keys[i]] = i;
       }
 
+      if (album_keep_track_order) {
+        // Sort the virtual items : use AlbumShuffleComparator with a cheap-to-copy lambda comparator
+        // force the track order to be the album one
+        std::stable_sort(virtual_items.begin(), virtual_items.end(), [&album_key_positions, &album_keys, this](const int lhs, const int rhs) {
+          return AlbumShuffleComparatorTrackOrder(album_key_positions, album_keys, items_, lhs, rhs);
+        });
+
+        break;
+      }
       // Sort the virtual items : use AlbumShuffleComparator with a cheap-to-copy lambda comparator
-      std::stable_sort(virtual_items_.begin(), virtual_items_.end(), [&album_key_positions, &album_keys](const int lhs, const int rhs) {
+      // keep the track order they have in the playlist
+      std::stable_sort(virtual_items.begin(), virtual_items.end(), [&album_key_positions, &album_keys](const int lhs, const int rhs) {
         return AlbumShuffleComparator(album_key_positions, album_keys, lhs, rhs);
       });
 
@@ -2299,7 +2371,7 @@ void Playlist::ReshuffleIndices() {
       QSet<QString> grouping_key_set;    // unique keys
 
       // Find all the unique grouping keys in the playlist
-      for (QList<int>::const_iterator it = virtual_items_.constBegin(); it != virtual_items_.constEnd(); ++it) {
+      for (QList<int>::const_iterator it = virtual_items.constBegin(); it != virtual_items.constEnd(); ++it) {
         const int index = *it;
         const QString key = items_[index]->EffectiveMetadata().GroupingKey();
         grouping_keys[index] = key;
@@ -2307,7 +2379,6 @@ void Playlist::ReshuffleIndices() {
       }
 
       // Shuffle them
-      static std::mt19937 rng{std::random_device{}()};
       QStringList shuffled_grouping_keys = grouping_key_set.values();
       std::shuffle(shuffled_grouping_keys.begin(), shuffled_grouping_keys.end(), rng);
 
@@ -2320,7 +2391,7 @@ void Playlist::ReshuffleIndices() {
       if (reference_row != -1) {
         const QString key = items_[reference_row]->EffectiveMetadata().GroupingKey();
         const qint64 pos = shuffled_grouping_keys.indexOf(key);
-        if (pos >= 1) {
+        if (pos > 0) {
           std::swap(shuffled_grouping_keys[0], shuffled_grouping_keys[pos]);
         }
       }
@@ -2331,21 +2402,22 @@ void Playlist::ReshuffleIndices() {
         grouping_key_positions[shuffled_grouping_keys[i]] = i;
       }
 
-      // Sort the virtual items: use AlbumShuffleComparator as a grouping-key comparator with a cheap-to-copy lambda
-      std::stable_sort(virtual_items_.begin(), virtual_items_.end(), [&grouping_key_positions, &grouping_keys](const int lhs, const int rhs) {
-        return AlbumShuffleComparator(grouping_key_positions, grouping_keys, lhs, rhs);
+      // Sort the virtual items: use AlbumShuffleComparatorTrackOrder as a grouping-key comparator with a cheap-to-copy lambda
+      // This sort method will keep the track number order so important in the grouped read
+      std::stable_sort(virtual_items.begin(), virtual_items.end(), [&grouping_key_positions, &grouping_keys, this](const int lhs, const int rhs) {
+        return AlbumShuffleComparatorTrackOrder(grouping_key_positions, grouping_keys, items_, lhs, rhs);
       });
       break;
     }
   }
 
-  // Update current virtual index
+  // I keep the computation of the virtual index because it is only return, if you want to ignore it, you can
+  // besides, it will be usefull in the cases I want to use the updated method
   if (current_item_index_.isValid()) {
-    current_virtual_index_ = static_cast<int>(virtual_items_.indexOf(current_item_index_.row()));
+    return static_cast<int>(virtual_items.indexOf(current_item_index_.row()));
   }
-  else {
-    current_virtual_index_ = -1;
-  }
+
+  return -1;
 
 }
 

--- a/src/playlist/playlist.h
+++ b/src/playlist/playlist.h
@@ -299,6 +299,8 @@ class Playlist : public QAbstractListModel {
 
   void ReloadItem(const QPersistentModelIndex &idx, PlaylistItemPtr item, const bool saved = false, const quint64 save_generation = -1, const Song &fallback_metadata = Song());
 
+  void Shuffle(const PlaylistSequence::ShuffleMode shuffle_mode = PlaylistSequence::ShuffleMode::All);
+
  public Q_SLOTS:
   void set_current_row(const int i, const Playlist::AutoScroll autoscroll = Playlist::AutoScroll::Maybe, const bool is_stopping = false, const bool force_inform = false);
   void Paused();
@@ -312,7 +314,6 @@ class Playlist : public QAbstractListModel {
   void Clear();
   void RemoveDuplicateSongs();
   void RemoveUnavailableSongs();
-  void Shuffle();
 
   void ShuffleModeChanged(const PlaylistSequence::ShuffleMode shuffle_mode);
 
@@ -368,6 +369,8 @@ class Playlist : public QAbstractListModel {
   void MoveItemWithoutUndo(const int source, const int dest);
   void MoveItemsWithoutUndo(int start, const QList<int> &dest_rows);
   void ReOrderWithoutUndo(const PlaylistItemPtrList &new_items);
+
+  int ReshuffleIndices(QList<int>& virtual_items, const PlaylistSequence::ShuffleMode shuffle_mode, const bool album_keep_track_order);
 
   void RemoveItemsNotInQueue();
 

--- a/src/playlist/playlist.h
+++ b/src/playlist/playlist.h
@@ -302,6 +302,8 @@ class Playlist : public QAbstractListModel {
 
   void ReloadItem(const QPersistentModelIndex &idx, PlaylistItemPtr item, const bool saved = false, const quint64 save_generation = -1, const Song &fallback_metadata = Song());
 
+  void Shuffle(const PlaylistSequence::ShuffleMode shuffle_mode = PlaylistSequence::ShuffleMode::All);
+
  public Q_SLOTS:
   void set_current_row(const int i, const Playlist::AutoScroll autoscroll = Playlist::AutoScroll::Maybe, const bool is_stopping = false, const bool force_inform = false);
   void Paused();
@@ -315,7 +317,6 @@ class Playlist : public QAbstractListModel {
   void Clear();
   void RemoveDuplicateSongs();
   void RemoveUnavailableSongs();
-  void Shuffle();
 
   void ShuffleModeChanged(const PlaylistSequence::ShuffleMode shuffle_mode);
 
@@ -374,6 +375,8 @@ class Playlist : public QAbstractListModel {
   void MoveItemWithoutUndo(const int source, const int dest);
   void MoveItemsWithoutUndo(int start, const QList<int> &dest_rows);
   void ReOrderWithoutUndo(const PlaylistItemPtrList &new_items);
+
+  int ReshuffleIndices(QList<int>& virtual_items, const PlaylistSequence::ShuffleMode shuffle_mode, const bool album_keep_track_order);
 
   void RemoveItemsNotInQueue();
 

--- a/src/playlist/playlistmanager.cpp
+++ b/src/playlist/playlistmanager.cpp
@@ -413,6 +413,10 @@ void PlaylistManager::ShuffleCurrent() {
   current()->Shuffle();
 }
 
+void PlaylistManager::ShuffleCurrent(const PlaylistSequence::ShuffleMode shuffle_mode) {
+  current()->Shuffle(shuffle_mode);
+}
+
 void PlaylistManager::RemoveDuplicatesCurrent() {
   current()->RemoveDuplicateSongs();
 }

--- a/src/playlist/playlistmanager.h
+++ b/src/playlist/playlistmanager.h
@@ -94,6 +94,8 @@ class PlaylistManager : public PlaylistManagerInterface {
   PlaylistParser *parser() const override { return parser_; }
   PlaylistContainer *playlist_container() const override { return playlist_container_; }
 
+  void ShuffleCurrent(const PlaylistSequence::ShuffleMode shuffle_mode) override;
+
  public Q_SLOTS:
   void New(const QString &name, const SongList &songs = SongList(), const QString &special_type = QString()) override;
   void Load(const QString &filename) override;
@@ -118,6 +120,7 @@ class PlaylistManager : public PlaylistManagerInterface {
 
   // Convenience slots that defer to either current() or active()
   void ClearCurrent() override;
+  // TODO : this method is only used for external unit tests : the version with parameter is the one that is used.
   void ShuffleCurrent() override;
   void RemoveDuplicatesCurrent() override;
   void RemoveUnavailableCurrent() override;

--- a/src/playlist/playlistmanagerinterface.h
+++ b/src/playlist/playlistmanagerinterface.h
@@ -77,6 +77,8 @@ class PlaylistManagerInterface : public QObject {
 
   virtual void PlaySmartPlaylist(PlaylistGeneratorPtr generator, const bool as_new, const bool clear) = 0;
 
+  virtual void ShuffleCurrent(const PlaylistSequence::ShuffleMode shuffle_mode) = 0;
+
  public Q_SLOTS:
   virtual void New(const QString &name, const SongList &songs = SongList(), const QString &special_type = QString()) = 0;
   virtual void Load(const QString &filename) = 0;
@@ -97,6 +99,7 @@ class PlaylistManagerInterface : public QObject {
 
   // Convenience slots that defer to either current() or active()
   virtual void ClearCurrent() = 0;
+  // TODO : this method is only used for external unit tests : the version with parameter is the one that is used.
   virtual void ShuffleCurrent() = 0;
   virtual void RemoveDuplicatesCurrent() = 0;
   virtual void RemoveUnavailableCurrent() = 0;


### PR DESCRIPTION
Change the menu Shuffle playlist (mainwindow ui) to offer three shuffle modes :
- track based shuffle (the actual playlist shuffle mode)
- album based shuffle : shuffle the playlist by album and make the album played in the track number order
- grouped track shuffle : keep the grouped tracks together, other tracks and distinct track group are shuffled.

Correct what I consider as an issue : when playing a playlist with a mode shuffle grouped, the tracks are played in the order they have in the playlist. Grouped tracks must be played following the track number order.

Update mainwindow for updating the menus
Update playlist to make the ReshuffleIndices reusable for both Reshuffling indices when playing in shuffle mode and when shuffling the playlist from the menu. I left some commented code with a TODO mark for some code linked to another PR to remind me what to do when I will merge one branch in the other.
Update the playlistmanager and it's interface to handle the choice we can now make while shuffling a playlist.
Add the translations for the created menu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Shuffle playlist** submenu with three mutually-exclusive modes: **Single track as random element**, **Album as random element**, and **Grouped tracks as random element** (existing **Ctrl+H** preserved for the single-track mode).
* **Behavior Updates**
  * Shuffle is now mode-aware.
  * **Album** and **Grouped** modes keep album/group boundaries and preserve disc/track ordering within the selected album or group while randomizing the chosen units.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->