### PR TITLE
Add an auto remove duplicates for the playlists.

### DIFF
--- a/src/constants/playlistsettings.h
+++ b/src/constants/playlistsettings.h
@@ -55,6 +55,7 @@ constexpr char kStateVersion[] = "state_version";
 constexpr char kState[] = "state";
 constexpr char kColumnAlignments[] = "column_alignments";
 constexpr char kRatingLocked[] = "rating_locked";
+constexpr char kRemoveDuplicates[] = "remove_duplicates";
 
 constexpr char kLastSaveFilter[] = "last_save_filter";
 constexpr char kLastSavePath[] = "last_save_path";
@@ -82,6 +83,7 @@ constexpr PathType kDefaultPathType = PathType::Automatic;
 constexpr bool kDefaultEditMetadataInline = false;
 constexpr bool kDefaultWriteMetadata = true;
 constexpr bool kDefaultDeleteFiles = false;
+constexpr bool kDefaultRemoveDuplicates = false;
 constexpr int kDefaultStateVersion = 0;
 constexpr bool kDefaultRatingLocked = false;
 

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -151,6 +151,7 @@ void Player::ReloadSettings() {
   s.beginGroup(PlaylistSettings::kSettingsGroup);
   continue_on_error_ = s.value(PlaylistSettings::kContinueOnError, PlaylistSettings::kDefaultContinueOnError).toBool();
   greyout_ = s.value(PlaylistSettings::kGreyoutSongsPlay, PlaylistSettings::kDefaultGreyoutSongsPlay).toBool();
+  playlist_manager_->update_setting(s.value(PlaylistSettings::kRemoveDuplicates, REMOVE_DUPLICATES_DEFAULT).toBool());
   s.endGroup();
 
   s.beginGroup(BehaviourSettings::kSettingsGroup);

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -133,6 +133,7 @@ Playlist::Playlist(const SharedPtr<TaskManager> task_manager,
                    const int id,
                    const QString &special_type,
                    const bool favorite,
+                   const bool remove_duplicates,
                    QObject *parent)
     : QAbstractListModel(parent),
       is_loading_(false),
@@ -160,7 +161,8 @@ Playlist::Playlist(const SharedPtr<TaskManager> task_manager,
       auto_sort_(false),
       is_sorted_(false),
       sort_column_(Column::Title),
-      sort_order_(Qt::AscendingOrder) {
+      sort_order_(Qt::AscendingOrder),
+      remove_duplicates_(remove_duplicates) {
 
   undo_stack_->setUndoLimit(kUndoStackSize);
 
@@ -200,6 +202,10 @@ void Playlist::InsertSongItems(const SongList &songs, const int pos, const bool 
   items.reserve(songs.count());
   for (const Song &song : songs) {
     items << make_shared<T>(song, signal);
+  }
+
+  if (remove_duplicates_) {
+    RemoveDuplicateSongs(items);
   }
 
   InsertItems(items, pos, play_now, enqueue, enqueue_next);
@@ -1916,7 +1922,7 @@ bool Playlist::removeRows(const int row, const int count, const QModelIndex &par
 
 }
 
-bool Playlist::removeRows(QList<int> &rows) {
+bool Playlist::removeRows(QList<int> &rows, PlaylistItemPtrList &items) {
 
   if (rows.isEmpty()) {
     return false;
@@ -1934,7 +1940,11 @@ bool Playlist::removeRows(QList<int> &rows) {
     }
 
     // And now we're removing the current sequence
-    if (!removeRows(part.last(), static_cast<int>(part.size()))) {
+    if (std::addressof(items) != std::addressof(items_)) {
+      // I want to clean a list to be added to the current playlist, I call a specific function for that
+      items.remove(part.last(), part.size());
+    }
+    else if (!removeRows(part.last(), static_cast<int>(part.size()))) {
       return false;
     }
 
@@ -2717,13 +2727,13 @@ struct SongSimilarEqual {
 
 }  // namespace
 
-void Playlist::RemoveDuplicateSongs() {
+void Playlist::RemoveDuplicateSongs(PlaylistItemPtrList &items) {
 
   QList<int> rows_to_remove;
   std::unordered_map<Song, int, SongSimilarHash, SongSimilarEqual> unique_songs;
 
-  for (int row = 0; row < items_.count(); ++row) {
-    const PlaylistItemPtr item = items_.value(row);
+  for (int row = 0; row < items.count(); ++row) {
+    const PlaylistItemPtr item = items.value(row);
     const Song &song = item->EffectiveMetadata();
 
     bool found_duplicate = false;
@@ -2748,7 +2758,7 @@ void Playlist::RemoveDuplicateSongs() {
     }
   }
 
-  removeRows(rows_to_remove);
+  removeRows(rows_to_remove, items);
 
 }
 

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -132,6 +132,7 @@ Playlist::Playlist(const SharedPtr<TaskManager> task_manager,
                    const int id,
                    const QString &special_type,
                    const bool favorite,
+                   const bool remove_duplicates,
                    QObject *parent)
     : QAbstractListModel(parent),
       is_loading_(false),
@@ -156,7 +157,8 @@ Playlist::Playlist(const SharedPtr<TaskManager> task_manager,
       scrobble_point_(-1),
       auto_sort_(false),
       sort_column_(Column::Title),
-      sort_order_(Qt::AscendingOrder) {
+      sort_order_(Qt::AscendingOrder),
+      remove_duplicates_(remove_duplicates) {
 
   undo_stack_->setUndoLimit(kUndoStackSize);
 
@@ -196,6 +198,10 @@ void Playlist::InsertSongItems(const SongList &songs, const int pos, const bool 
   items.reserve(songs.count());
   for (const Song &song : songs) {
     items << make_shared<T>(song, signal);
+  }
+
+  if (remove_duplicates_) {
+    RemoveDuplicateSongs(items);
   }
 
   InsertItems(items, pos, play_now, enqueue, enqueue_next);
@@ -1849,7 +1855,7 @@ bool Playlist::removeRows(const int row, const int count, const QModelIndex &par
 
 }
 
-bool Playlist::removeRows(QList<int> &rows) {
+bool Playlist::removeRows(QList<int> &rows, PlaylistItemPtrList &items) {
 
   if (rows.isEmpty()) {
     return false;
@@ -1867,7 +1873,11 @@ bool Playlist::removeRows(QList<int> &rows) {
     }
 
     // And now we're removing the current sequence
-    if (!removeRows(part.last(), static_cast<int>(part.size()))) {
+    if (std::addressof(items) != std::addressof(items_)) {
+      // I want to clean a list to be added to the current playlist, I call a specific function for that
+      items.remove(part.last(), part.size());
+    }
+    else if (!removeRows(part.last(), static_cast<int>(part.size()))) {
       return false;
     }
 
@@ -2650,13 +2660,13 @@ struct SongSimilarEqual {
 
 }  // namespace
 
-void Playlist::RemoveDuplicateSongs() {
+void Playlist::RemoveDuplicateSongs(PlaylistItemPtrList &items) {
 
   QList<int> rows_to_remove;
   std::unordered_map<Song, int, SongSimilarHash, SongSimilarEqual> unique_songs;
 
-  for (int row = 0; row < items_.count(); ++row) {
-    const PlaylistItemPtr item = items_.value(row);
+  for (int row = 0; row < items.count(); ++row) {
+    const PlaylistItemPtr item = items.value(row);
     const Song &song = item->EffectiveMetadata();
 
     bool found_duplicate = false;
@@ -2681,7 +2691,7 @@ void Playlist::RemoveDuplicateSongs() {
     }
   }
 
-  removeRows(rows_to_remove);
+  removeRows(rows_to_remove, items);
 
 }
 

--- a/src/playlist/playlist.h
+++ b/src/playlist/playlist.h
@@ -77,6 +77,9 @@ using ColumnAlignmentMap = QMap<int, Qt::Alignment>;
 Q_DECLARE_METATYPE(Qt::Alignment)
 Q_DECLARE_METATYPE(ColumnAlignmentMap)
 
+// This default value keep the current behavior : the duplicates are ignored
+static constexpr bool REMOVE_DUPLICATES_DEFAULT = false;
+
 class Playlist : public QAbstractListModel {
   Q_OBJECT
 
@@ -96,6 +99,7 @@ class Playlist : public QAbstractListModel {
                     const int id,
                     const QString &special_type = QString(),
                     const bool favorite = false,
+                    const bool remove_duplicates = false,
                     QObject *parent = nullptr);
 
   ~Playlist() override;
@@ -201,6 +205,10 @@ class Playlist : public QAbstractListModel {
   int previous_row(const bool ignore_repeat_track = false) const;
   int take_previous_row(const bool ignore_repeat_track = false);
 
+  void update_setting(const bool remove_duplicates) {
+    remove_duplicates_ = remove_duplicates;
+  }
+
   QModelIndex current_index() const;
 
   bool stop_after_current() const;
@@ -261,6 +269,12 @@ class Playlist : public QAbstractListModel {
   // This returns true if this playlist had current item when the method was invoked.
   bool ApplyValidityOnCurrentSong(const QUrl &url, bool valid);
 
+  // Get the real position for skipping the grouped tracks
+  int get_real_pos(int pos, const int origin);
+
+  // Update the list of the tracks moved
+  void update_list_to_move(QList<int> &list);
+
   // Removes from the playlist all local files that don't exist anymore.
   void RemoveDeletedSongs();
 
@@ -302,6 +316,8 @@ class Playlist : public QAbstractListModel {
 
   void ReloadItem(const QPersistentModelIndex &idx, PlaylistItemPtr item, const bool saved = false, const quint64 save_generation = -1, const Song &fallback_metadata = Song());
 
+  void RemoveDuplicateSongs(PlaylistItemPtrList &items);
+
  public Q_SLOTS:
   void set_current_row(const int i, const Playlist::AutoScroll autoscroll = Playlist::AutoScroll::Maybe, const bool is_stopping = false, const bool force_inform = false);
   void Paused();
@@ -313,7 +329,9 @@ class Playlist : public QAbstractListModel {
   void UpdateItems(SongList songs);
 
   void Clear();
-  void RemoveDuplicateSongs();
+  void RemoveDuplicateSongs() {
+    RemoveDuplicateSongs(items_);
+  }
   void RemoveUnavailableSongs();
   void Shuffle();
 
@@ -378,7 +396,10 @@ class Playlist : public QAbstractListModel {
   void RemoveItemsNotInQueue();
 
   // Removes rows with given indices from this playlist.
-  bool removeRows(QList<int> &rows);
+  bool removeRows(QList<int> &rows, PlaylistItemPtrList &items);
+  bool removeRows(QList<int> &rows) {
+    return removeRows(rows, items_);
+  }
 
   void TurnOnDynamicPlaylist(PlaylistGeneratorPtr gen);
   void InsertDynamicItems(const int count);
@@ -469,6 +490,9 @@ class Playlist : public QAbstractListModel {
   bool is_sorted_;
   Column sort_column_;
   Qt::SortOrder sort_order_;
+
+  // Variables to insert tracks
+  bool remove_duplicates_;
 };
 
 #endif  // PLAYLIST_H

--- a/src/playlist/playlist.h
+++ b/src/playlist/playlist.h
@@ -76,6 +76,9 @@ using ColumnAlignmentMap = QMap<int, Qt::Alignment>;
 Q_DECLARE_METATYPE(Qt::Alignment)
 Q_DECLARE_METATYPE(ColumnAlignmentMap)
 
+// This default value keep the current behavior : the duplicates are ignored
+static constexpr bool REMOVE_DUPLICATES_DEFAULT = false;
+
 class Playlist : public QAbstractListModel {
   Q_OBJECT
 
@@ -94,6 +97,7 @@ class Playlist : public QAbstractListModel {
                     const int id,
                     const QString &special_type = QString(),
                     const bool favorite = false,
+                    const bool remove_duplicates = false,
                     QObject *parent = nullptr);
 
   ~Playlist() override;
@@ -198,6 +202,10 @@ class Playlist : public QAbstractListModel {
   int previous_row(const bool ignore_repeat_track = false) const;
   int take_previous_row(const bool ignore_repeat_track = false);
 
+  void update_setting(const bool remove_duplicates) {
+    remove_duplicates_ = remove_duplicates;
+  }
+
   QModelIndex current_index() const;
 
   bool stop_after_current() const;
@@ -258,6 +266,12 @@ class Playlist : public QAbstractListModel {
   // This returns true if this playlist had current item when the method was invoked.
   bool ApplyValidityOnCurrentSong(const QUrl &url, bool valid);
 
+  // Get the real position for skipping the grouped tracks
+  int get_real_pos(int pos, const int origin);
+
+  // Update the list of the tracks moved
+  void update_list_to_move(QList<int> &list);
+
   // Removes from the playlist all local files that don't exist anymore.
   void RemoveDeletedSongs();
 
@@ -299,6 +313,8 @@ class Playlist : public QAbstractListModel {
 
   void ReloadItem(const QPersistentModelIndex &idx, PlaylistItemPtr item, const bool saved = false, const quint64 save_generation = -1, const Song &fallback_metadata = Song());
 
+  void RemoveDuplicateSongs(PlaylistItemPtrList &items);
+
  public Q_SLOTS:
   void set_current_row(const int i, const Playlist::AutoScroll autoscroll = Playlist::AutoScroll::Maybe, const bool is_stopping = false, const bool force_inform = false);
   void Paused();
@@ -310,7 +326,9 @@ class Playlist : public QAbstractListModel {
   void UpdateItems(SongList songs);
 
   void Clear();
-  void RemoveDuplicateSongs();
+  void RemoveDuplicateSongs() {
+    RemoveDuplicateSongs(items_);
+  }
   void RemoveUnavailableSongs();
   void Shuffle();
 
@@ -372,7 +390,10 @@ class Playlist : public QAbstractListModel {
   void RemoveItemsNotInQueue();
 
   // Removes rows with given indices from this playlist.
-  bool removeRows(QList<int> &rows);
+  bool removeRows(QList<int> &rows, PlaylistItemPtrList &items);
+  bool removeRows(QList<int> &rows) {
+    return removeRows(rows, items_);
+  }
 
   void TurnOnDynamicPlaylist(PlaylistGeneratorPtr gen);
   void InsertDynamicItems(const int count);
@@ -455,6 +476,9 @@ class Playlist : public QAbstractListModel {
   bool auto_sort_;
   Column sort_column_;
   Qt::SortOrder sort_order_;
+
+  // Variables to insert tracks
+  bool remove_duplicates_;
 };
 
 #endif  // PLAYLIST_H

--- a/src/playlist/playlistmanager.cpp
+++ b/src/playlist/playlistmanager.cpp
@@ -82,7 +82,8 @@ PlaylistManager::PlaylistManager(const SharedPtr<TaskManager> task_manager,
       playlist_container_(nullptr),
       current_(-1),
       active_(-1),
-      playlists_loading_(0) {
+      playlists_loading_(0),
+      remove_duplicates_(REMOVE_DUPLICATES_DEFAULT) {
 
   setObjectName(QLatin1String(QObject::metaObject()->className()));
 
@@ -93,6 +94,15 @@ PlaylistManager::~PlaylistManager() {
   const QList<Data> datas = playlists_.values();
   for (const Data &data : datas) delete data.p;
 
+}
+
+void PlaylistManager::update_setting(const bool remove_duplicates) {
+  remove_duplicates_ = remove_duplicates;
+
+  QList<Data> datas = playlists_.values();
+  for (Data &data : datas) {
+    data.p->update_setting(remove_duplicates);
+  }
 }
 
 void PlaylistManager::Init(PlaylistSequence *sequence, PlaylistContainer *playlist_container) {
@@ -156,7 +166,7 @@ QItemSelection PlaylistManager::selection(const int id) const {
 
 Playlist *PlaylistManager::AddPlaylist(const int id, const QString &name, const QString &special_type, const QString &ui_path, const bool favorite) {
 
-  Playlist *ret = new Playlist(task_manager_, url_handlers_, playlist_backend_, collection_backend_, tagreader_client_, id, special_type, favorite);
+  Playlist *ret = new Playlist(task_manager_, url_handlers_, playlist_backend_, collection_backend_, tagreader_client_, id, special_type, favorite, remove_duplicates_);
   ret->set_sequence(sequence_);
   ret->set_ui_path(ui_path);
 

--- a/src/playlist/playlistmanager.h
+++ b/src/playlist/playlistmanager.h
@@ -71,6 +71,10 @@ class PlaylistManager : public PlaylistManagerInterface {
   Playlist *playlist(const int id) const override { return playlists_[id].p; }
   Playlist *current() const override { return playlist(current_id()); }
   Playlist *active() const override { return playlist(active_id()); }
+  bool remove_duplicates() const { return remove_duplicates_; }
+
+  // Update the grouped before queue value : we have to do more than just update the attribute
+  void update_setting(const bool remove_duplicates);
 
   // Returns the collection of playlists managed by this PlaylistManager.
   QList<Playlist*> GetAllPlaylists() const override;
@@ -179,6 +183,7 @@ class PlaylistManager : public PlaylistManagerInterface {
   int current_;
   int active_;
   int playlists_loading_;
+  bool remove_duplicates_;
 };
 
 #endif  // PLAYLISTMANAGER_H

--- a/src/settings/playlistsettingspage.cpp
+++ b/src/settings/playlistsettingspage.cpp
@@ -92,6 +92,7 @@ void PlaylistSettingsPage::Load() {
   ui_->checkbox_writemetadata->setChecked(s.value(kWriteMetadata, kDefaultWriteMetadata).toBool());
 
   ui_->checkbox_delete_files->setChecked(s.value(kDeleteFiles, kDefaultDeleteFiles).toBool());
+  ui_->checkbox_remove_duplicates->setChecked(s.value(kRemoveDuplicates, kDefaultRemoveDuplicates).toBool());
 
   s.endGroup();
 
@@ -133,6 +134,7 @@ void PlaylistSettingsPage::Save() {
   s.setValue(kEditMetadataInline, ui_->checkbox_editmetadatainline->isChecked());
   s.setValue(kWriteMetadata, ui_->checkbox_writemetadata->isChecked());
   s.setValue(kDeleteFiles, ui_->checkbox_delete_files->isChecked());
+  s.setValue(kRemoveDuplicates, ui_->checkbox_remove_duplicates->isChecked());
   s.setValue(kAutoSort, ui_->checkbox_auto_sort->isChecked());
   s.endGroup();
 

--- a/src/settings/playlistsettingspage.ui
+++ b/src/settings/playlistsettingspage.ui
@@ -92,6 +92,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="checkbox_remove_duplicates">
+     <property name="text">
+      <string>Remove duplicates when adding tracks to the playlist</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QCheckBox" name="checkbox_auto_sort">
      <property name="text">
       <string>Automatically sort playlist when inserting songs</string>

--- a/src/smartplaylists/smartplaylistsearchpreview.cpp
+++ b/src/smartplaylists/smartplaylistsearchpreview.cpp
@@ -36,6 +36,7 @@
 
 #include "playlist/playlist.h"
 #include "playlistquerygenerator.h"
+#include "playlist/playlistmanager.h"
 
 using std::make_shared;
 
@@ -72,7 +73,7 @@ void SmartPlaylistSearchPreview::Init(const SharedPtr<Player> player,
 
   collection_backend_ = collection_backend;
 
-  model_ = new Playlist(nullptr, nullptr, nullptr, collection_backend_, nullptr, -1, QString(), false, this);
+  model_ = new Playlist(nullptr, nullptr, nullptr, collection_backend_, nullptr, -1, QString(), false, playlist_manager->remove_duplicates(), this);
   ui_->tree->setModel(model_);
   ui_->tree->SetPlaylist(model_);
 


### PR DESCRIPTION
When adding tracks to a playlist, you may have tracks in flac format for quality and mp3 format for portable devices, so when you select an album from the library to add to the playlist the flac and the mp3 will be added.
You can use the remove duplicates menu on the playlist, but if you want to have some tracks more than one time in your playlist, it will also delete theses tracks...
So I add the opportunity to automatically delete the duplicates in the added track list.

In the parameters, playlist tab, I add a checkbox to remove the added duplicates.
The data is then forwarded to the playlist object, when tracks are inserted in the playlist (Playlist::InsertSongItems), if the functionality is on, the duplicates are removed (call Playlist::RemoveDuplicateSongs)
Playlist::RemoveDuplicateSongs had been change to work on any track list, not only the playlist's tracklist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable **“Remove duplicates when adding tracks to the playlist”** option in playlist settings.
  * When enabled, duplicate songs are filtered out automatically during track insertion, including batch additions.
  * The preference is persisted and applied to both regular and smart playlist previews.
  * Player settings reload now recognizes the option immediately, without needing a restart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->