### PR TITLE
Write MUSICBRAINZ_TRACKID to file tags on "Complete tags automatically"

### DIFF
--- a/src/dialogs/trackselectiondialog.cpp
+++ b/src/dialogs/trackselectiondialog.cpp
@@ -287,6 +287,7 @@ void TrackSelectionDialog::SaveData(const QList<Data> &_data) const {
     copy.set_album(new_metadata.album());
     copy.set_track(new_metadata.track());
     copy.set_year(new_metadata.year());
+    copy.set_musicbrainz_recording_id(new_metadata.musicbrainz_recording_id());
 
     const TagReaderResult result = tagreader_client_->WriteFileBlocking(copy.url().toLocalFile(), copy, TagReaderClient::SaveOption::Tags, SaveTagCoverData());
     if (!result.success()) {

--- a/src/musicbrainz/musicbrainzclient.cpp
+++ b/src/musicbrainz/musicbrainzclient.cpp
@@ -190,14 +190,14 @@ void MusicBrainzClient::SendMbIdRequest(const MbIdRequest &request) {
   url_query.addQueryItem(u"fmt"_s, u"json"_s);
 
   QNetworkReply *reply = CreateGetRequest(QUrl(QString::fromLatin1(kTrackUrl) + request.mbid), url_query);
-  QObject::connect(reply, &QNetworkReply::finished, this, [this, reply, request]() { MbIdRequestFinished(reply, request.id, request.number); });
+  QObject::connect(reply, &QNetworkReply::finished, this, [this, reply, request]() { MbIdRequestFinished(reply, request.id, request.number, request.mbid); });
   mbid_requests_.insert(request.id, reply);
 
   timeouts_->AddReply(reply);
 
 }
 
-void MusicBrainzClient::MbIdRequestFinished(QNetworkReply *reply, const int id, const int request_number) {
+void MusicBrainzClient::MbIdRequestFinished(QNetworkReply *reply, const int id, const int request_number, const QString &mbid) {
 
   if (replies_.contains(reply)) {
     replies_.removeAll(reply);
@@ -223,7 +223,11 @@ void MusicBrainzClient::MbIdRequestFinished(QNetworkReply *reply, const int id, 
   if (object_root.contains("releases"_L1) && object_root.value("releases"_L1).isArray()) {
     const ReleaseList releases = ParseReleases(object_root.value("releases"_L1).toArray());
     if (!releases.isEmpty()) {
-      pending_results_[id] << PendingResults(request_number, ResultListFromReleases(releases));
+      ResultList results = ResultListFromReleases(releases);
+      for (Result &result : results) {
+        result.musicbrainz_recording_id_ = mbid;
+      }
+      pending_results_[id] << PendingResults(request_number, results);
     }
   }
 

--- a/src/musicbrainz/musicbrainzclient.h
+++ b/src/musicbrainz/musicbrainzclient.h
@@ -87,6 +87,7 @@ class MusicBrainzClient : public JsonBaseRequest {
     int duration_msec_;
     int track_;
     int year_;
+    QString musicbrainz_recording_id_;
   };
   using ResultList = QList<Result>;
 
@@ -105,7 +106,7 @@ class MusicBrainzClient : public JsonBaseRequest {
  private Q_SLOTS:
   void FlushRequests();
   // ID identifies the track, and request_number means it's the 'request_number'th request for this track
-  void MbIdRequestFinished(QNetworkReply *reply, const int id, const int request_number);
+  void MbIdRequestFinished(QNetworkReply *reply, const int id, const int request_number, const QString &mbid);
   void DiscIdRequestFinished(const QString &discid, QNetworkReply *reply);
 
  private:

--- a/src/musicbrainz/tagfetcher.cpp
+++ b/src/musicbrainz/tagfetcher.cpp
@@ -149,6 +149,7 @@ void TagFetcher::TagsFetched(const int index, const MusicBrainzClient::ResultLis
     song.set_artistsort(result.sort_artist_);
     song.set_track(result.track_);
     song.set_year(result.year_);
+    song.set_musicbrainz_recording_id(result.musicbrainz_recording_id_);
     if (!result.album_artist_.isEmpty() && result.album_artist_ != result.artist_) {
       song.set_albumartist(result.album_artist_);
     }

--- a/src/tagreader/tagreadertaglib.cpp
+++ b/src/tagreader/tagreadertaglib.cpp
@@ -708,6 +708,9 @@ void TagReaderTagLib::ParseID3v2Tags(TagLib::ID3v2::Tag *tag, QString *disc, QSt
         if (frame->description() == kID3v2_AcoustId_Fingerprint) {
           song->set_acoustid_fingerprint(frame_field_list.back());
         }
+        if (frame->description() == kID3v2_MusicBrainz_RecordingId) {
+          song->set_musicbrainz_recording_id(frame_field_list.back());
+        }
         if (frame->description() == kID3v2_MusicBrainz_AlbumArtistId) {
           song->set_musicbrainz_album_artist_id(TagLibStringListToSlashSeparatedString(frame_field_list, 1));
         }
@@ -1199,6 +1202,9 @@ TagReaderResult TagReaderTagLib::WriteFile(const QString &filename, const Song &
         tag->setItem(kMP4_Lyrics, TagLib::StringList(QStringToTagLibString(song.lyrics())));
         tag->setItem(kMP4_AlbumArtist, TagLib::StringList(QStringToTagLibString(song.albumartist())));
         tag->setItem(kMP4_Compilation, TagLib::MP4::Item(song.compilation()));
+        if (!song.musicbrainz_recording_id().isEmpty()) {
+          tag->setItem(kMP4_MusicBrainz_RecordingId, TagLib::StringList(QStringToTagLibString(song.musicbrainz_recording_id())));
+        }
       }
       if (save_playcount) {
         SetPlaycount(tag, song.playcount());
@@ -1330,6 +1336,9 @@ void TagReaderTagLib::SetID3v2Tag(TagLib::ID3v2::Tag *tag, const Song &song) con
   SetTextFrame(kID3v2_TitleSort, song.titlesort().isEmpty() ? QString() : song.titlesort(), tag);
   SetTextFrame(kID3v2_Compilation, song.compilation() ? QString::number(1) : QString(), tag);
   SetUnsyncLyricsFrame(song.lyrics().isEmpty() ? QString() : song.lyrics(), tag);
+  if (!song.musicbrainz_recording_id().isEmpty()) {
+    SetUserTextFrame(QLatin1String(kID3v2_MusicBrainz_RecordingId), song.musicbrainz_recording_id(), tag);
+  }
 
 }
 
@@ -1433,6 +1442,9 @@ void TagReaderTagLib::SetVorbisComments(TagLib::Ogg::XiphComment *vorbis_comment
 
   vorbis_comment->addField(kVorbisComment_Lyrics, QStringToTagLibString(song.lyrics()), true);
   vorbis_comment->removeFields(kVorbisComment_UnsyncedLyrics);
+  if (!song.musicbrainz_recording_id().isEmpty()) {
+    vorbis_comment->addField(kVorbisComment_MusicBrainz_TackId, QStringToTagLibString(song.musicbrainz_recording_id()), true);
+  }
 
 }
 
@@ -1445,6 +1457,9 @@ void TagReaderTagLib::SetAPETag(TagLib::APE::Tag *tag, const Song &song) const {
   tag->setItem(kAPE_Performer, TagLib::APE::Item(kAPE_Performer, TagLib::StringList(QStringToTagLibString(song.performer()))));
   tag->setItem(kAPE_Lyrics, TagLib::APE::Item(kAPE_Lyrics, QStringToTagLibString(song.lyrics())));
   tag->addValue(kAPE_Compilation, QStringToTagLibString(song.compilation() ? QString::number(1) : QString()), true);
+  if (!song.musicbrainz_recording_id().isEmpty()) {
+    tag->setItem(kAPE_MusicBrainz_TackId, TagLib::APE::Item(kAPE_MusicBrainz_TackId, TagLib::StringList(QStringToTagLibString(song.musicbrainz_recording_id()))));
+  }
 
 }
 
@@ -1456,6 +1471,7 @@ void TagReaderTagLib::SetASFTag(TagLib::ASF::Tag *tag, const Song &song) const {
   SetAsfAttribute(tag, kASF_Disc, song.disc());
   SetAsfAttribute(tag, kASF_OriginalDate, song.originalyear());
   SetAsfAttribute(tag, kASF_OriginalYear, song.originalyear());
+  SetAsfAttribute(tag, kASF_MusicBrainz_RecordingId, song.musicbrainz_recording_id());
 
 }
 


### PR DESCRIPTION
## Problem

\"Complete tags automatically\" retrieves the MusicBrainz recording UUID via AcoustID, uses it to query the MusicBrainz API for metadata, then silently discards it. The UUID never enters the `Result` struct and cannot reach the tag-write path. Only standard metadata (title, artist, album, year, track number) is written to files.

## Solution

Wire the recording UUID through the full pipeline so it is written to file tags alongside the other metadata.

### Changes

**`src/musicbrainz/musicbrainzclient.h` / `.cpp`**
- `Result` gains a `musicbrainz_recording_id_` field
- `MbIdRequestFinished` receives the `mbid` it looked up (already captured in the lambda) and stamps it onto every `Result` produced from that request

**`src/musicbrainz/tagfetcher.cpp`**
- `TagsFetched` copies `musicbrainz_recording_id_` onto the `Song` built from each `Result`

**`src/dialogs/trackselectiondialog.cpp`**
- `SaveData` includes `musicbrainz_recording_id` in the set of fields copied to the file on user confirmation

**`src/tagreader/tagreadertaglib.cpp`**
- ID3v2 (MP3, WAV, AIFF): TXXX frame with description `MUSICBRAINZ_TRACKID`
- Vorbis comments (FLAC, OGG, Opus): `MUSICBRAINZ_TRACKID` field
- APE tags (WavPack, Musepack, Monkey's Audio): `MUSICBRAINZ_TRACKID` item
- MP4/iTunes (M4A, AAC): `----:com.apple.iTunes:MusicBrainz Track Id`
- ASF/WMA: `MusicBrainz/Track Id` attribute
- Added TXXX read path for `MUSICBRAINZ_TRACKID` so tags written by this code are read back into the database on the next scan

## Notes

- All writes are guarded with `!isEmpty()` — no empty tags are written
- The existing UFID read path for `musicbrainz_recording_id` is preserved for files tagged by external tools (Picard, beets)
- The ASF write uses the existing `SetAsfAttribute` helper which already handles empty-string removal