### PR TITLE
fix: refine automatic album art detection in generic folders

### DIFF
--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -1670,23 +1670,36 @@ void Song::InitArtAutomatic() {
 
   if (d->art_automatic_.isEmpty() && d->source_ == Source::LocalFile && d->url_.isLocalFile()) {
     const QFileInfo fileinfo(d->url_.toLocalFile());
-    const QDir dir(fileinfo.path());
+    const QString path = fileinfo.path();
+    const QDir dir(path);
+
+    // Check if it's a generic location where we should avoid grabbing any image
+    const QStringList generic_locations = QStandardPaths::standardLocations(QStandardPaths::DownloadLocation) <<
+                                          QStandardPaths::standardLocations(QStandardPaths::DesktopLocation) <<
+                                          QStandardPaths::standardLocations(QStandardPaths::DocumentsLocation) <<
+                                          QStandardPaths::standardLocations(QStandardPaths::HomeLocation);
+    const bool is_generic_location = generic_locations.contains(path);
+
     const QStringList cover_files = dir.entryList(QStringList() << u"*.jpg"_s << u"*.png"_s << u"*.gif"_s << u"*.jpeg"_s, QDir::Files|QDir::Readable, QDir::Name);
     QString best_cover_file;
     for (const QString &cover_file : cover_files) {
       if (cover_file.contains("back"_L1, Qt::CaseInsensitive)) {
         continue;
       }
-      if (cover_file.contains("front"_L1, Qt::CaseInsensitive) || cover_file.startsWith("cover"_L1, Qt::CaseInsensitive)) {
+      if (cover_file.contains("front"_L1, Qt::CaseInsensitive) ||
+          cover_file.contains("cover"_L1, Qt::CaseInsensitive) ||
+          cover_file.contains("folder"_L1, Qt::CaseInsensitive) ||
+          cover_file.contains("albumart"_L1, Qt::CaseInsensitive) ||
+          cover_file.contains("album"_L1, Qt::CaseInsensitive)) {
         best_cover_file = cover_file;
         break;
       }
-      if (best_cover_file.isEmpty()) {
+      if (!is_generic_location && best_cover_file.isEmpty()) {
         best_cover_file = cover_file;
       }
     }
     if (!best_cover_file.isEmpty()) {
-      d->art_automatic_ = QUrl::fromLocalFile(fileinfo.path() + QDir::separator() + best_cover_file);
+      d->art_automatic_ = QUrl::fromLocalFile(path + QDir::separator() + best_cover_file);
     }
   }
 


### PR DESCRIPTION
### Description
This PR refines the automatic album art detection logic in `Song::InitArtAutomatic` to prevent unrelated images from being picked up when music files are stored in generic system folders.

### Motivation
When a user plays a song from a folder like `Downloads`, `Desktop`, or `Documents`, Strawberry would often pick the first available image in that folder as the album art. This results in incorrect and distracting cover art (e.g., screenshots or downloaded icons) being assigned to songs.

### Changes
- Added a check to identify if a song's directory is a standard system location (`Downloads`, `Desktop`, `Documents`, or `Home`).
- Priority Matching: When scanning for images, the logic now explicitly prioritizes standard cover art filenames (`cover`, `front`, `folder`, `albumart`, `album`).
- Fallback Restriction: The "take any image" fallback is now disabled if the song is in a generic system folder. In dedicated music folders, the existing fallback behavior remains unchanged to preserve user workflows.

### Testing
- Verified that arbitrary images in `~/Downloads` are no longer picked up as album art.
- Verified that standard filenames (e.g., `cover.jpg`) are still detected in `~/Downloads`.
- Verified that the fallback still works in non-system folders.