### PR TITLE
ListenBrainzScrobbler: report release group mbid

### DIFF
--- a/src/scrobbler/listenbrainzscrobbler.cpp
+++ b/src/scrobbler/listenbrainzscrobbler.cpp
@@ -219,6 +219,9 @@ QJsonObject ListenBrainzScrobbler::JsonTrackMetadata(const ScrobbleMetadata &met
   else if (!metadata.musicbrainz_original_album_id.isEmpty()) {
     object_additional_info.insert("release_mbid"_L1, metadata.musicbrainz_original_album_id);
   }
+  if (!metadata.musicbrainz_release_group_id.isEmpty()) {
+    object_additional_info.insert("release_group_mbid"_L1, metadata.musicbrainz_release_group_id);
+  }
 
   if (!metadata.musicbrainz_recording_id.isEmpty()) {
     object_additional_info.insert("recording_mbid"_L1, metadata.musicbrainz_recording_id);


### PR DESCRIPTION
Strawberry already grabs the release group tag but doesn't include it in its scrobbles, as a result the ListenBrainz API [doesn't](https://api.listenbrainz.org/1/user/hakase/listens?max_ts=1776891576&min_ts=1776890074) include it with the listen when fetched later.