### PR TITLE
RadioBrowser: Fix fallback iteration and improve search robustness

### DIFF
--- a/src/radios/radiobrowsersearchview.cpp
+++ b/src/radios/radiobrowsersearchview.cpp
@@ -47,6 +47,7 @@ RadioBrowserSearchView::RadioBrowserSearchView(QWidget *parent)
       action_add_to_playlist_(nullptr),
       current_offset_(0),
       search_limit_(100),
+      hide_broken_(true),
       has_more_(false),
       initialized_(false) {
 
@@ -118,6 +119,7 @@ void RadioBrowserSearchView::Init(RadioBrowserService *service) {
   Settings s;
   s.beginGroup(QLatin1String(RadioBrowserSettings::kSettingsGroup));
   search_limit_ = s.value(QLatin1String(RadioBrowserSettings::kSearchLimit), RadioBrowserSettings::kSearchLimitDefault).toInt();
+  hide_broken_ = s.value(QLatin1String(RadioBrowserSettings::kHideBroken), RadioBrowserSettings::kHideBrokenDefault).toBool();
 
   const QString default_sort = s.value(u"default_sort"_s, u"votes"_s).toString();
   for (int i = 0; i < ui_->combo_sort->count(); ++i) {
@@ -158,7 +160,7 @@ void RadioBrowserSearchView::DoSearch() {
   ui_->label_status->setText(tr("Searching..."));
   ui_->stacked->setCurrentWidget(ui_->page_results);
 
-  service_->Search(query, country, QString(), QString(), order, search_limit_, current_offset_);
+  service_->Search(query, country, QString(), QString(), order, search_limit_, current_offset_, hide_broken_);
 
 }
 

--- a/src/radios/radiobrowsersearchview.h
+++ b/src/radios/radiobrowsersearchview.h
@@ -79,6 +79,7 @@ class RadioBrowserSearchView : public QWidget {
   QString default_country_;
   int current_offset_;
   int search_limit_;
+  bool hide_broken_;
   bool has_more_;
   bool initialized_;
 };

--- a/src/radios/radiobrowserservice.cpp
+++ b/src/radios/radiobrowserservice.cpp
@@ -108,30 +108,20 @@ void RadioBrowserService::DnsLookupFinished() {
 
   if (!dns_lookup_) return;
 
-  if (dns_lookup_->error() != QDnsLookup::NoError || dns_lookup_->hostAddressRecords().isEmpty()) {
-    // DNS failed, try fallback servers
-    dns_lookup_->deleteLater();
-    dns_lookup_ = nullptr;
-
-    if (fallback_index_ < kFallbackServers.size()) {
-      TestServer(kFallbackServers.at(fallback_index_));
-      ++fallback_index_;
-    }
-    else {
-      Q_EMIT SearchError(tr("Failed to discover Radio Browser server."));
-    }
-    return;
-  }
-
-  // Use first resolved hostname
-  const auto records = dns_lookup_->hostAddressRecords();
+  const bool dns_failed = dns_lookup_->error() != QDnsLookup::NoError || dns_lookup_->hostAddressRecords().isEmpty();
   dns_lookup_->deleteLater();
   dns_lookup_ = nullptr;
 
-  // Try fallback servers since we can't easily do reverse DNS in Qt
-  // The DNS lookup confirms the service exists, now use a known hostname
-  fallback_index_ = 0;
-  TestServer(kFallbackServers.at(fallback_index_));
+  // Qt has no easy reverse DNS, so we use known hostnames either way; the DNS lookup just confirms the service exists
+  // ServerTestReply advances the index on failure, so we only set the starting point here.
+  if (!dns_failed) fallback_index_ = 0;
+
+  if (fallback_index_ < kFallbackServers.size()) {
+    TestServer(kFallbackServers.at(fallback_index_));
+  }
+  else {
+    Q_EMIT SearchError(tr("Failed to discover Radio Browser server."));
+  }
 
 }
 

--- a/src/radios/radiobrowserservice.cpp
+++ b/src/radios/radiobrowserservice.cpp
@@ -167,7 +167,7 @@ void RadioBrowserService::ServerTestReply(QNetworkReply *reply) {
   // Execute pending search if any
   if (has_pending_search_) {
     has_pending_search_ = false;
-    Search(pending_search_.query, pending_search_.country, pending_search_.tag, pending_search_.language, pending_search_.order, pending_search_.limit, pending_search_.offset);
+    Search(pending_search_.query, pending_search_.country, pending_search_.tag, pending_search_.language, pending_search_.order, pending_search_.limit, pending_search_.offset, pending_search_.hide_broken);
   }
 
   // Execute pending countries fetch if any
@@ -184,11 +184,12 @@ void RadioBrowserService::Search(const QString &query,
                                   const QString &language,
                                   const QString &order,
                                   const int limit,
-                                  const int offset) {
+                                  const int offset,
+                                  const bool hide_broken) {
 
   if (!server_discovered_) {
     // Save search and discover server first
-    pending_search_ = {query, country, tag, language, order, limit, offset};
+    pending_search_ = {query, country, tag, language, order, limit, offset, hide_broken};
     has_pending_search_ = true;
     DiscoverServer();
     return;
@@ -204,7 +205,7 @@ void RadioBrowserService::Search(const QString &query,
   if (!language.isEmpty()) url_query.addQueryItem(u"language"_s, language);
   url_query.addQueryItem(u"limit"_s, QString::number(limit));
   url_query.addQueryItem(u"offset"_s, QString::number(offset));
-  url_query.addQueryItem(u"hidebroken"_s, u"true"_s);
+  if (hide_broken) url_query.addQueryItem(u"hidebroken"_s, u"true"_s);
 
   if (!order.isEmpty()) {
     url_query.addQueryItem(u"order"_s, order);
@@ -232,9 +233,14 @@ void RadioBrowserService::SearchReply(QNetworkReply *reply, const int task_id, c
 
   if (replies_.contains(reply)) replies_.removeAll(reply);
   reply->deleteLater();
+  task_manager_->SetTaskFinished(task_id);
+
+  if (reply->error() != QNetworkReply::NoError) {
+    Q_EMIT SearchError(tr("Radio Browser search failed: %1").arg(reply->errorString()));
+    return;
+  }
 
   const QJsonArray array = ExtractJsonArray(reply);
-  task_manager_->SetTaskFinished(task_id);
 
   if (array.isEmpty()) {
     Q_EMIT SearchFinished(RadioChannelList(), false);

--- a/src/radios/radiobrowserservice.h
+++ b/src/radios/radiobrowserservice.h
@@ -53,7 +53,8 @@ class RadioBrowserService : public RadioService {
               const QString &language = QString(),
               const QString &order = QString(),
               const int limit = 100,
-              const int offset = 0);
+              const int offset = 0,
+              const bool hide_broken = true);
 
   void FetchCountries();
 
@@ -89,6 +90,7 @@ class RadioBrowserService : public RadioService {
     QString order;
     int limit;
     int offset;
+    bool hide_broken;
   };
   PendingSearch pending_search_;
   bool has_pending_search_;


### PR DESCRIPTION
## Summary

Followup to #2048 with two independent fixes for the Radio Browser service.

### Fix off-by-one when iterating fallback servers

When DNS discovery failed, `fallback_index_` was incremented twice between the first `TestServer()` call and the next — once in `DnsLookupFinished` and once in `ServerTestReply`. As a result the second fallback host was skipped after the first connection attempt failed.

Drop the duplicate increment in `DnsLookupFinished` and let `ServerTestReply` own the iteration on failure. Also removes an unused `hostAddressRecords()` copy.

### Make `hidebroken` configurable and surface search errors

- The `hidebroken=true` filter was hardcoded; this PR threads the value through the search call chain (including the deferred-search replay after server discovery) and reads it from settings (`RadioBrowserSettings::kHideBroken`).
- `SearchReply` now emits `SearchError` on network failures instead of silently returning an empty result, and `task_manager_->SetTaskFinished(task_id)` runs unconditionally so a failed search doesn't leak a task.

## Test plan

- [ ] Search with default settings → results come back, broken stations hidden
- [ ] Toggle `hide_broken` in settings → broken stations appear in results
- [ ] Disconnect network mid-search → user sees a clear error instead of empty results
- [ ] Force a DNS failure (e.g. block `all.api.radio-browser.info`) → fallback servers are tried in order without skipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)