### PR TITLE
CollectionModel: Eliminate multi-second UI freezes on large metadata update batches

### DIFF
--- a/src/collection/collectionmodel.cpp
+++ b/src/collection/collectionmodel.cpp
@@ -38,6 +38,7 @@
 #include <QIODevice>
 #include <QList>
 #include <QSet>
+#include <QHash>
 #include <QMap>
 #include <QMetaType>
 #include <QVariant>
@@ -61,6 +62,7 @@
 #include "core/iconloader.h"
 #include "core/settings.h"
 #include "core/songmimedata.h"
+#include "core/scopedflag.h"
 #include "collectionfilteroptions.h"
 #include "collectionquery.h"
 #include "collectionbackend.h"
@@ -96,6 +98,7 @@ CollectionModel::CollectionModel(const SharedPtr<CollectionBackend> backend, con
       total_artist_count_(0),
       total_album_count_(0),
       loading_(false),
+      bulk_mode_(false),
       icon_disk_cache_(new QNetworkDiskCache(this)) {
 
   setObjectName(backend_->source() == Song::Source::Collection ? QLatin1String(QObject::metaObject()->className()) : QStringLiteral("%1%2").arg(Song::DescriptionForSource(backend_->source()), QLatin1String(QObject::metaObject()->className())));
@@ -451,12 +454,6 @@ void CollectionModel::ScheduleAddSongs(const SongList &songs) {
 
 }
 
-void CollectionModel::ScheduleUpdateSongs(const SongList &songs) {
-
-  ScheduleUpdate(CollectionModelUpdate::Type::Update, songs);
-
-}
-
 void CollectionModel::ScheduleRemoveSongs(const SongList &songs) {
 
   ScheduleUpdate(CollectionModelUpdate::Type::Remove, songs);
@@ -470,11 +467,123 @@ void CollectionModel::ProcessUpdate() {
     return;
   }
 
-  const CollectionModelUpdate update = updates_.dequeue();
+  // Bulk-update threshold, measured in PENDING SONGS (not queue entries: the queue is just an artifact of 400-song chunking, so a queue-length test would trip on a handful of tiny updates yet miss one large one).
+  // Above this many pending songs we drain the queued run in one layout-change transaction, suppressing the per-row begin/end{Insert,Remove}Rows (and dataChanged) signals.
+  // Without this, every per-row signal makes an attached QTreeView rebuild its internal item bookkeeping (and a QSortFilterProxyModel re-evaluate filterAcceptsRow);
+  // when a large streaming-service metadata batch fans out into thousands of remove/add pairs the cost is O(rows) per signal and the UI freezes.
+  // A single layoutAboutToBeChanged/layoutChanged pair collapses it into one relayout, and unlike a model reset it keeps view state alive:
+  // persistent indexes are remapped by item identity below, so selection, scroll position and expanded containers survive.
+  // The hang is view-driven, not filter-driven, so this is deliberately NOT gated on an active filter. The value is a tunable heuristic.
+  constexpr int kBulkUpdateSongThreshold = 1000;
+
+  // Count only up to the first Reset: the bulk drain below stops there, so songs queued behind a Reset belong to a later tick and must not pull this run over the threshold.
+  int pending_songs = 0;
+  for (const CollectionModelUpdate &update : std::as_const(updates_)) {
+    if (update.type == CollectionModelUpdate::Type::Reset) break;
+    pending_songs += static_cast<int>(update.songs.count());
+  }
+
+  // A Reset carries its own begin/endResetModel transaction (asynchronously, via the SQL reload) and raises loading_, after which the *Internal handlers early-return.
+  // It must therefore never be folded into a bulk transaction: the unconditional dequeue below would otherwise drop every update queued behind it.
+  // Dispatch a leading Reset on its own, and stop a bulk drain as soon as one surfaces so it is handled on the next tick.
+  if (updates_.constFirst().type == CollectionModelUpdate::Type::Reset) {
+    DispatchUpdate(updates_.dequeue());
+  }
+  else if (pending_songs >= kBulkUpdateSongThreshold) {
+    // Identities must be captured after layoutAboutToBeChanged: attached views and proxies create their own persistent indexes in their slots,
+    // and those have to be in persistentIndexList() so they get remapped too.
+    Q_EMIT layoutAboutToBeChanged();
+    const QModelIndexList old_persistent_indexes = persistentIndexList();
+    QList<ItemIdentity> identities;
+    identities.reserve(old_persistent_indexes.count());
+    for (const QModelIndex &old_idx : old_persistent_indexes) {
+      identities << CaptureItemIdentity(old_idx);
+    }
+    {
+      // Scoped so bulk_mode_ cannot get stuck on if a dispatch returns early inside the transaction.
+      ScopedFlag bulk(bulk_mode_);
+      while (!updates_.isEmpty() && updates_.constFirst().type != CollectionModelUpdate::Type::Reset) {
+        DispatchUpdate(updates_.dequeue());
+      }
+    }
+    QModelIndexList new_persistent_indexes;
+    new_persistent_indexes.reserve(old_persistent_indexes.count());
+    for (const ItemIdentity &identity : std::as_const(identities)) {
+      new_persistent_indexes << ResolveItemIdentity(identity);
+    }
+    changePersistentIndexList(old_persistent_indexes, new_persistent_indexes);
+    Q_EMIT layoutChanged();
+  }
+  else {
+    DispatchUpdate(updates_.dequeue());
+  }
 
   if (updates_.isEmpty()) {
     timer_update_->stop();
   }
+
+}
+
+CollectionModel::ItemIdentity CollectionModel::CaptureItemIdentity(const QModelIndex &idx) const {
+
+  ItemIdentity identity;
+
+  CollectionItem *item = IndexToItem(idx);
+  if (!item || !item->parent) return identity;
+
+  identity.type = item->type;
+
+  switch (item->type) {
+    case CollectionItem::Type::Song:
+      identity.song_id = item->metadata.id();
+      break;
+    case CollectionItem::Type::Container:
+      if (IsCompilationArtistNode(item)) {
+        identity.compilation_artist = true;
+        identity.compilation_artist_parent_is_root = item->parent == root_;
+        if (!identity.compilation_artist_parent_is_root) {
+          identity.container_level = item->parent->container_level;
+          identity.container_key = item->parent->container_key;
+        }
+      }
+      else {
+        identity.container_level = item->container_level;
+        identity.container_key = item->container_key;
+      }
+      break;
+    case CollectionItem::Type::Divider:
+      identity.container_key = item->container_key;
+      break;
+    default:
+      break;
+  }
+
+  return identity;
+
+}
+
+QModelIndex CollectionModel::ResolveItemIdentity(const ItemIdentity &identity) const {
+
+  switch (identity.type) {
+    case CollectionItem::Type::Song:
+      return ItemToIndex(song_nodes_.value(identity.song_id));
+    case CollectionItem::Type::Container:
+      if (identity.compilation_artist) {
+        // A compilation-artist node nested under another compilation-artist node has no entry in container_nodes_ and resolves to invalid.
+        CollectionItem *new_parent = identity.compilation_artist_parent_is_root ? root_ : (identity.container_level >= 0 && identity.container_level <= 2 ? container_nodes_[identity.container_level].value(identity.container_key) : nullptr);
+        return new_parent ? ItemToIndex(new_parent->compilation_artist_node_) : QModelIndex();
+      }
+      if (identity.container_level < 0 || identity.container_level > 2) return QModelIndex();
+      return ItemToIndex(container_nodes_[identity.container_level].value(identity.container_key));
+    case CollectionItem::Type::Divider:
+      return ItemToIndex(divider_nodes_.value(identity.container_key));
+    default:
+      return QModelIndex();
+  }
+
+}
+
+void CollectionModel::DispatchUpdate(const CollectionModelUpdate &update) {
 
   switch (update.type) {
     case CollectionModelUpdate::Type::Reset:
@@ -539,9 +648,12 @@ void CollectionModel::AddReAddOrUpdateSongsInternal(const SongList &songs) {
     }
   }
 
-  ScheduleRemoveSongs(songs_removed);
-  ScheduleUpdateSongs(songs_updated);
-  ScheduleAddSongs(songs_added);
+  // Apply the derived changes now instead of re-queuing them.
+  // Re-queuing appended them to the back of updates_, so when this ran inside a bulk transaction the surrounding layout-change transaction wrapped no tree mutation at all (an empty relayout) and the real work landed in a *second* transaction one tick later — wasting a relayout.
+  // It also let those changes fall behind a queued Reset and be lost. Removing first keeps re-added songs (same id, new container) from being skipped.
+  RemoveSongsInternal(songs_removed);
+  UpdateSongsInternal(songs_updated);
+  AddSongsInternal(songs_added);
 
 }
 
@@ -549,6 +661,11 @@ void CollectionModel::AddSongsInternal(const SongList &songs) {
 
   if (loading_) return;
 
+  // First pass: resolve the final container for every song, creating any intermediate container/compilation-artist nodes as needed.
+  // Outside a bulk transaction those container creations emit their own beginInsertRows pair, but only when a new artist/album first appears (rare);
+  // in bulk_mode_ they are suppressed and collapse into the surrounding layout change.
+  QHash<CollectionItem*, SongList> songs_by_container;
+  QList<CollectionItem*> insertion_order;
   for (const Song &song : songs) {
 
     // Sanity check to make sure we don't add songs that are outside the user's filter
@@ -588,7 +705,25 @@ void CollectionModel::AddSongsInternal(const SongList &songs) {
         }
       }
     }
-    CreateSongItem(song, container);
+    if (!songs_by_container.contains(container)) insertion_order << container;
+    songs_by_container[container] << song;
+  }
+
+  // Second pass: bulk-insert all songs belonging to the same container in a single beginInsertRows/endInsertRows pair.
+  // Each pair triggers CollectionFilter::filterAcceptsRow re-evaluation across the proxy,
+  // so collapsing thousands of per-song inserts into a per-container handful is what keeps the UI responsive on large metadata batches.
+  for (CollectionItem *container : std::as_const(insertion_order)) {
+    const SongList &container_songs = songs_by_container.value(container);
+    const int first = static_cast<int>(container->children.count());
+    const int last = first + static_cast<int>(container_songs.count()) - 1;
+
+    if (!bulk_mode_) beginInsertRows(ItemToIndex(container), first, last);
+    for (const Song &song : container_songs) {
+      CollectionItem *item = new CollectionItem(CollectionItem::Type::Song, container);
+      SetSongItemData(item, song);
+      song_nodes_.insert(song.id(), item);
+    }
+    if (!bulk_mode_) endInsertRows();
   }
 
 }
@@ -620,7 +755,7 @@ void CollectionModel::UpdateSongsInternal(const SongList &songs) {
       qLog(Debug) << "Song metadata and title for" << new_song.id() << new_song.PrettyTitleWithArtist() << "changed, informing model";
       const QModelIndex idx = ItemToIndex(item);
       if (!idx.isValid()) continue;
-      Q_EMIT dataChanged(idx, idx);
+      if (!bulk_mode_) Q_EMIT dataChanged(idx, idx);
     }
     else {
       qLog(Debug) << "Song metadata for" << new_song.id() << new_song.PrettyTitleWithArtist() << "changed";
@@ -630,7 +765,7 @@ void CollectionModel::UpdateSongsInternal(const SongList &songs) {
   for (CollectionItem *item : std::as_const(album_parents)) {
     ClearItemPixmapCache(item);
     const QModelIndex idx = ItemToIndex(item);
-    if (idx.isValid()) {
+    if (idx.isValid() && !bulk_mode_) {
       Q_EMIT dataChanged(idx, idx);
     }
   }
@@ -641,26 +776,31 @@ void CollectionModel::RemoveSongsInternal(const SongList &songs) {
 
   if (loading_) return;
 
-  // Delete the actual song nodes first, keeping track of each parent so we might check to see if they're empty later.
+  // Group song nodes to remove by their parent.
+  // Removing siblings one row at a time forces QSortFilterProxyModel to re-evaluate filterAcceptsRow on every endRemoveRows,
+  // which dominates the cost when a collection filter is active and a streaming service emits a large metadata batch.
+  // RemoveSiblingNodes() collapses contiguous rows under each parent into a single beginRemoveRows/endRemoveRows pair so the proxy refreshes once.
+  QHash<CollectionItem*, QList<CollectionItem*>> nodes_by_parent;
   QSet<CollectionItem*> parents;
   for (const Song &song : songs) {
+    if (!song_nodes_.contains(song.id())) continue;
+    CollectionItem *node = song_nodes_.value(song.id());
+    nodes_by_parent[node->parent] << node;
+    if (node->parent != root_) parents << node->parent;
+  }
 
-    if (song_nodes_.contains(song.id())) {
-      CollectionItem *node = song_nodes_.value(song.id());
-
-      if (node->parent != root_) parents << node->parent;
-
-      beginRemoveRows(ItemToIndex(node->parent), node->row, node->row);
-      node->parent->Delete(node->row);
-      song_nodes_.remove(song.id());
-      endRemoveRows();
-
+  for (auto it = nodes_by_parent.cbegin(); it != nodes_by_parent.cend(); ++it) {
+    for (CollectionItem *node : it.value()) {
+      song_nodes_.remove(node->metadata.id());
     }
+    RemoveSiblingNodes(it.key(), it.value());
   }
 
   // Now delete empty parents
   QSet<QString> divider_keys;
   while (!parents.isEmpty()) {
+    // Same grouping trick as above: collect empty parents by their parent so we can drop them in contiguous-row batches per grandparent.
+    QHash<CollectionItem*, QList<CollectionItem*>> empty_by_grandparent;
     // Since we are going to remove elements from the container, we need a copy to iterate over.
     // If we iterate over the original, the behavior will be undefined.
     QSet<CollectionItem*> parents_copy = parents;
@@ -686,14 +826,16 @@ void CollectionModel::RemoveSongsInternal(const SongList &songs) {
 
       ClearItemPixmapCache(node);
 
-      // It was empty - delete it
-      beginRemoveRows(ItemToIndex(node->parent), node->row, node->row);
-      node->parent->Delete(node->row);
-      endRemoveRows();
+      empty_by_grandparent[node->parent] << node;
+    }
+
+    for (auto it = empty_by_grandparent.cbegin(); it != empty_by_grandparent.cend(); ++it) {
+      RemoveSiblingNodes(it.key(), it.value());
     }
   }
 
-  // Delete empty dividers
+  // Delete empty dividers. Group contiguous rows so we still benefit when many dividers vanish at once (e.g. removing every "A"-prefix artist).
+  QList<CollectionItem*> dead_dividers;
   for (const QString &divider_key : std::as_const(divider_keys)) {
     if (!divider_nodes_.contains(divider_key)) continue;
 
@@ -702,12 +844,43 @@ void CollectionModel::RemoveSongsInternal(const SongList &songs) {
       continue;
     }
 
-    // Remove the divider
-    const int row = divider_nodes_.value(divider_key)->row;
-    beginRemoveRows(ItemToIndex(root_), row, row);
-    root_->Delete(row);
-    endRemoveRows();
+    dead_dividers << divider_nodes_.value(divider_key);
     divider_nodes_.remove(divider_key);
+  }
+  if (!dead_dividers.isEmpty()) {
+    RemoveSiblingNodes(root_, dead_dividers);
+  }
+
+}
+
+void CollectionModel::RemoveSiblingNodes(CollectionItem *parent, QList<CollectionItem*> nodes) {
+
+  // Sort by row descending so each contiguous-range removal doesn't shift later ranges.
+  std::sort(nodes.begin(), nodes.end(), [](CollectionItem *a, CollectionItem *b) {
+    return a->row > b->row;
+  });
+
+  const QModelIndex parent_index = ItemToIndex(parent);
+
+  int i = 0;
+  while (i < nodes.count()) {
+    const int top_row = nodes[i]->row;
+    int run_count = 1;
+    while (i + run_count < nodes.count() && nodes[i + run_count]->row == top_row - run_count) {
+      ++run_count;
+    }
+    const int bottom_row = top_row - run_count + 1;
+
+    if (!bulk_mode_) beginRemoveRows(parent_index, bottom_row, top_row);
+    for (int r = top_row; r >= bottom_row; --r) {
+      delete parent->children.takeAt(r);
+    }
+    for (int r = bottom_row; r < parent->children.count(); ++r) {
+      parent->children[r]->row = r;
+    }
+    if (!bulk_mode_) endRemoveRows();
+
+    i += run_count;
   }
 
 }
@@ -724,7 +897,7 @@ CollectionItem *CollectionModel::CreateContainerItem(const GroupBy group_by, con
     }
   }
 
-  beginInsertRows(ItemToIndex(parent), static_cast<int>(parent->children.count()), static_cast<int>(parent->children.count()));
+  if (!bulk_mode_) beginInsertRows(ItemToIndex(parent), static_cast<int>(parent->children.count()), static_cast<int>(parent->children.count()));
 
   CollectionItem *item = new CollectionItem(CollectionItem::Type::Container, parent);
   item->container_level = container_level;
@@ -737,7 +910,7 @@ CollectionItem *CollectionModel::CreateContainerItem(const GroupBy group_by, con
 
   container_nodes_[container_level].insert(item->container_key, item);
 
-  endInsertRows();
+  if (!bulk_mode_) endInsertRows();
 
   return item;
 
@@ -745,7 +918,7 @@ CollectionItem *CollectionModel::CreateContainerItem(const GroupBy group_by, con
 
 void CollectionModel::CreateDividerItem(const QString &divider_key, const QString &display_text, CollectionItem *parent) {
 
-  beginInsertRows(ItemToIndex(parent), static_cast<int>(parent->children.count()), static_cast<int>(parent->children.count()));
+  if (!bulk_mode_) beginInsertRows(ItemToIndex(parent), static_cast<int>(parent->children.count()), static_cast<int>(parent->children.count()));
 
   CollectionItem *divider = new CollectionItem(CollectionItem::Type::Divider, root_);
   divider->container_key = divider_key;
@@ -753,19 +926,19 @@ void CollectionModel::CreateDividerItem(const QString &divider_key, const QStrin
   divider->sort_text = divider_key + "  "_L1;
   divider_nodes_[divider_key] = divider;
 
-  endInsertRows();
+  if (!bulk_mode_) endInsertRows();
 
 }
 
 void CollectionModel::CreateSongItem(const Song &song, CollectionItem *parent) {
 
-  beginInsertRows(ItemToIndex(parent), static_cast<int>(parent->children.count()), static_cast<int>(parent->children.count()));
+  if (!bulk_mode_) beginInsertRows(ItemToIndex(parent), static_cast<int>(parent->children.count()), static_cast<int>(parent->children.count()));
 
   CollectionItem *item = new CollectionItem(CollectionItem::Type::Song, parent);
   SetSongItemData(item, song);
   song_nodes_.insert(song.id(), item);
 
-  endInsertRows();
+  if (!bulk_mode_) endInsertRows();
 
 }
 
@@ -781,7 +954,7 @@ CollectionItem *CollectionModel::CreateCompilationArtistNode(CollectionItem *par
 
   Q_ASSERT(parent->compilation_artist_node_ == nullptr);
 
-  beginInsertRows(ItemToIndex(parent), static_cast<int>(parent->children.count()), static_cast<int>(parent->children.count()));
+  if (!bulk_mode_) beginInsertRows(ItemToIndex(parent), static_cast<int>(parent->children.count()), static_cast<int>(parent->children.count()));
 
   parent->compilation_artist_node_ = new CollectionItem(CollectionItem::Type::Container, parent);
   parent->compilation_artist_node_->compilation_artist_node_ = nullptr;
@@ -791,7 +964,7 @@ CollectionItem *CollectionModel::CreateCompilationArtistNode(CollectionItem *par
   parent->compilation_artist_node_->sort_text = " various"_L1;
   parent->compilation_artist_node_->container_level = parent->container_level + 1;
 
-  endInsertRows();
+  if (!bulk_mode_) endInsertRows();
 
   return parent->compilation_artist_node_;
 
@@ -889,7 +1062,7 @@ void CollectionModel::ClearItemPixmapCache(CollectionItem *item) {
 
 QVariant CollectionModel::AlbumIcon(CollectionItem *item) {
 
-  if (!item) return pixmap_no_cover_;
+  if (!albumcover_loader_ || !item) return pixmap_no_cover_;
 
   // Check the cache for a pixmap we already loaded.
   const QString cache_key = AlbumIconPixmapCacheKey(item);

--- a/src/collection/collectionmodel.h
+++ b/src/collection/collectionmodel.h
@@ -236,13 +236,29 @@ class CollectionModel : public SimpleTreeModel<CollectionItem> {
 
   void ScheduleUpdate(const CollectionModelUpdate::Type type, const SongList &songs = SongList());
   void ScheduleAddSongs(const SongList &songs);
-  void ScheduleUpdateSongs(const SongList &songs);
   void ScheduleRemoveSongs(const SongList &songs);
 
   void AddReAddOrUpdateSongsInternal(const SongList &songs);
   void AddSongsInternal(const SongList &songs);
   void UpdateSongsInternal(const SongList &songs);
   void RemoveSongsInternal(const SongList &songs);
+  void RemoveSiblingNodes(CollectionItem *parent, QList<CollectionItem*> nodes);
+  void DispatchUpdate(const CollectionModelUpdate &update);
+
+  // Identity of the item behind a persistent index, captured before a bulk update mutates the tree and resolved against the rebuilt node maps afterwards.
+  // Identity- rather than pointer-based on purpose: a node that is deleted and re-created within the same drain (a re-added song, a rebuilt container) still resolves to its successor,
+  // and a recycled heap address cannot alias an unrelated new item.
+  // For compilation-artist nodes, which live on their parent instead of in container_nodes_, container_level and container_key identify the parent.
+  struct ItemIdentity {
+    CollectionItem::Type type = CollectionItem::Type::Root;
+    int song_id = -1;                 // Type::Song
+    int container_level = -1;         // Type::Container
+    QString container_key;            // Type::Container and Type::Divider
+    bool compilation_artist = false;
+    bool compilation_artist_parent_is_root = false;
+  };
+  ItemIdentity CaptureItemIdentity(const QModelIndex &idx) const;
+  QModelIndex ResolveItemIdentity(const ItemIdentity &identity) const;
 
   void CreateDividerItem(const QString &divider_key, const QString &display_text, CollectionItem *parent);
   CollectionItem *CreateContainerItem(const GroupBy group_by, const int container_level, const QString &container_key, const Song &song, CollectionItem *parent);
@@ -300,6 +316,7 @@ class CollectionModel : public SimpleTreeModel<CollectionItem> {
   int total_album_count_;
 
   bool loading_;
+  bool bulk_mode_;
 
   QQueue<CollectionModelUpdate> updates_;
 

--- a/src/core/scopedflag.h
+++ b/src/core/scopedflag.h
@@ -1,0 +1,34 @@
+/*
+ * Strawberry Music Player
+ * Copyright 2026, Malte Zilinski <malte@zilinski.eu>
+ *
+ * Strawberry is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Strawberry is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Strawberry.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SCOPEDFLAG_H
+#define SCOPEDFLAG_H
+
+// Sets a bool for the duration of a scope and clears it on the way out, even on early return.
+class ScopedFlag {
+ public:
+  explicit ScopedFlag(bool &flag) : flag_(flag) { flag_ = true; }
+  ~ScopedFlag() { flag_ = false; }
+  ScopedFlag(const ScopedFlag&) = delete;
+  ScopedFlag &operator=(const ScopedFlag&) = delete;
+ private:
+  bool &flag_;
+};
+
+#endif  // SCOPEDFLAG_H

--- a/tests/src/collectionmodel_test.cpp
+++ b/tests/src/collectionmodel_test.cpp
@@ -19,6 +19,7 @@
  *
  */
 
+#include <algorithm>
 #include <memory>
 
 #include "gtest_include.h"
@@ -28,6 +29,14 @@
 #include <QUrl>
 #include <QThread>
 #include <QSignalSpy>
+#include <QTimer>
+#include <QEventLoop>
+#include <QElapsedTimer>
+#include <QCoreApplication>
+#include <QPersistentModelIndex>
+#include <QItemSelectionModel>
+#include <QScrollBar>
+#include <QTreeView>
 #include <QtDebug>
 
 #include "includes/scoped_ptr.h"
@@ -89,6 +98,52 @@ class CollectionModelTest : public ::testing::Test {
     song.set_mtime(0);
     song.set_ctime(0);
     return AddSong(song);
+  }
+
+  // Build n distinct songs spread over a few artists/albums, all tagged so different batches don't collide.
+  SongList MakeSongs(const int n, const QString &tag) {
+    SongList songs;
+    songs.reserve(n);
+    for (int i = 0; i < n; ++i) {
+      const QString num = QString::number(i);
+      const QString artist = tag + u"_artist_"_s + QString::number(i % 50);
+      Song song;
+      song.Init(tag + u"_title_"_s + num, artist, tag + u"_album_"_s + QString::number(i % 200), 123);
+      song.set_albumartist(artist);
+      song.set_directory_id(1);
+      song.set_mtime(1);
+      song.set_ctime(1);
+      song.set_url(QUrl(u"file:///tmp/"_s + tag + u'_' + num + u".flac"_s));
+      song.set_filesize(1);
+      songs << song;  // clazy:exclude=reserve-candidates
+    }
+    return songs;
+  }
+
+  CollectionItem *ItemForSongId(const int id) {
+    const QList<CollectionItem*> nodes = model_->song_nodes();
+    for (CollectionItem *node : nodes) {
+      if (node->metadata.id() == id) return node;
+    }
+    return nullptr;
+  }
+
+  // Pump the event loop until the model's update timer has been continuously idle for a stretch.
+  // The idle window must outlast the gap a Reset's async SQL reload leaves before it re-arms the timer, or we'd stop mid-reload.
+  void Drain(const int max_ms = 60000) {
+    QTimer *timer = model_->findChild<QTimer*>(QString(), Qt::FindDirectChildrenOnly);
+    QElapsedTimer total;
+    total.start();
+    QElapsedTimer idle;
+    idle.start();
+    while (total.elapsed() < max_ms) {
+      QCoreApplication::processEvents(QEventLoop::AllEvents, 5);
+      if (timer && timer->isActive()) {
+        idle.restart();
+        continue;
+      }
+      if (idle.elapsed() >= 250) break;
+    }
   }
 
   SharedPtr<Database> database_;  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
@@ -256,8 +311,9 @@ TEST_F(CollectionModelTest, RemoveSongs) {
   backend_->DeleteSongs(SongList() << one << two);
   loop.exec();
 
-  ASSERT_EQ(2, spy_preremove.count());
-  ASSERT_EQ(2, spy_remove.count());
+  // Title 1 and Title 2 occupy contiguous rows 0 and 1, so RemoveSiblingNodes collapses them into a single beginRemoveRows/endRemoveRows pair.
+  ASSERT_EQ(1, spy_preremove.count());
+  ASSERT_EQ(1, spy_remove.count());
   ASSERT_EQ(0, spy_reset.count());
 
   artist_index = model_->index(1, 0, QModelIndex());
@@ -316,6 +372,257 @@ TEST_F(CollectionModelTest, RemoveEmptyArtists) {
 
   // Everything should be gone - even the artist header
   ASSERT_EQ(0, model_->rowCount(QModelIndex()));
+
+}
+
+// A batch at/above the bulk threshold collapses into a layout change and emits neither per-row insert signals nor a model reset, while still producing the correct tree.
+TEST_F(CollectionModelTest, BulkUpdateSuppressesPerRowSignals) {
+
+  AddSong(u"seed"_s, u"seed"_s, u"seed"_s, 1);  // drains the ctor reset, adds the dir
+
+  const int n = 2000;  // >= kBulkUpdateSongThreshold
+  const SongList songs = MakeSongs(n, u"bulk"_s);
+
+  QSignalSpy spy_insert(&*model_, &CollectionModel::rowsInserted);
+  QSignalSpy spy_layout(&*model_, &CollectionModel::layoutChanged);
+  QSignalSpy spy_reset(&*model_, &CollectionModel::modelReset);
+
+  backend_->AddOrUpdateSongs(songs);
+  Drain();
+
+  EXPECT_EQ(0, spy_insert.count());
+  EXPECT_GE(spy_layout.count(), 1);
+  EXPECT_EQ(0, spy_reset.count());
+  EXPECT_EQ(n + 1, static_cast<int>(model_->song_nodes().count()));
+
+}
+
+// A batch below the threshold keeps the lightweight per-row path (no layout change, no reset).
+TEST_F(CollectionModelTest, SmallUpdateEmitsPerRowSignals) {
+
+  AddSong(u"seed"_s, u"seed"_s, u"seed"_s, 1);
+
+  const int n = 10;  // < kBulkUpdateSongThreshold
+  const SongList songs = MakeSongs(n, u"small"_s);
+
+  QSignalSpy spy_insert(&*model_, &CollectionModel::rowsInserted);
+  QSignalSpy spy_layout(&*model_, &CollectionModel::layoutChanged);
+  QSignalSpy spy_reset(&*model_, &CollectionModel::modelReset);
+
+  backend_->AddOrUpdateSongs(songs);
+  Drain();
+
+  EXPECT_GT(spy_insert.count(), 0);
+  EXPECT_EQ(0, spy_layout.count());
+  EXPECT_EQ(0, spy_reset.count());
+  EXPECT_EQ(n + 1, static_cast<int>(model_->song_nodes().count()));
+
+}
+
+// Regression for the empty/double transaction: a bulk batch must apply its changes inside a single layout-change transaction, not re-queue them into a second one.
+TEST_F(CollectionModelTest, LargeBatchProducesSingleLayoutChange) {
+
+  AddSong(u"seed"_s, u"seed"_s, u"seed"_s, 1);
+
+  const SongList songs = MakeSongs(2000, u"once"_s);
+
+  QSignalSpy spy_layout(&*model_, &CollectionModel::layoutChanged);
+  QSignalSpy spy_reset(&*model_, &CollectionModel::modelReset);
+
+  backend_->AddOrUpdateSongs(songs);
+  Drain();
+
+  EXPECT_EQ(1, spy_layout.count());
+  EXPECT_EQ(0, spy_reset.count());
+  EXPECT_EQ(2001, static_cast<int>(model_->song_nodes().count()));
+
+}
+
+// A Reset queued behind a bulk-sized batch must be handled outside the bulk transaction:
+// folding it in would tear the model down mid-layout-change and leave the begin/end signals of either transaction unbalanced.
+// NOTE: data preservation across the Reset cannot be checked here - the reload runs on a worker thread, which opens its own connection to the :memory: test DB and so sees it empty;
+// against a real file DB that reload restores the full collection, which is why a dropped trailing update is not actually lost in production.
+TEST_F(CollectionModelTest, ResetMixedIntoBulkBatchDoesNotNestResets) {
+
+  AddSong(u"seed"_s, u"seed"_s, u"seed"_s, 1);
+
+  QSignalSpy spy_about(&*model_, &CollectionModel::modelAboutToBeReset);
+  QSignalSpy spy_done(&*model_, &CollectionModel::modelReset);
+  QSignalSpy spy_layout_about(&*model_, &CollectionModel::layoutAboutToBeChanged);
+  QSignalSpy spy_layout_done(&*model_, &CollectionModel::layoutChanged);
+
+  // Backend signals are emitted synchronously, so these stack up in the update queue as [AddReAddOrUpdate(a)..., Reset, AddReAddOrUpdate(b)] before the timer-driven ProcessUpdate ever runs.
+  backend_->AddOrUpdateSongs(MakeSongs(1600, u"aaa"_s));
+  model_->SetGroupBy(model_->GetGroupBy());  // enqueues a Reset behind the batch
+  backend_->AddOrUpdateSongs(MakeSongs(50, u"bbb"_s));
+
+  Drain();
+
+  EXPECT_EQ(spy_about.count(), spy_done.count());
+  EXPECT_GE(spy_done.count(), 1);
+  EXPECT_EQ(spy_layout_about.count(), spy_layout_done.count());
+
+}
+
+// The bulk path must not discard view state: persistent indexes (what a view uses for selection, scroll position and expanded containers) survive the layout change.
+// Remapping is identity-based, so a song that is removed and re-added under a new container - the streaming-metadata case - keeps its persistent index too;
+// only genuinely removed items go invalid.
+TEST_F(CollectionModelTest, BulkUpdatePreservesPersistentIndexes) {
+
+  AddSong(u"seed"_s, u"seed"_s, u"seed"_s, 1);
+
+  backend_->AddOrUpdateSongs(MakeSongs(2000, u"keep"_s));
+  Drain();
+
+  // Pull the stored songs (now carrying their database ids) back out of the model, in a stable order.
+  SongList stored;
+  const QList<CollectionItem*> nodes = model_->song_nodes();
+  for (CollectionItem *node : nodes) {
+    if (node->metadata.title().startsWith(u"keep_"_s)) stored << node->metadata;  // clazy:exclude=reserve-candidates
+  }
+  ASSERT_EQ(2000, stored.count());
+  std::sort(stored.begin(), stored.end(), [](const Song &a, const Song &b) { return a.id() < b.id(); });
+
+  const int updated_id = stored[10].id();  // metadata-only change, node mutated in place
+  const int readded_id = stored[11].id();  // album change moves it to a new container
+  const int removed_id = stored[12].id();  // deleted entirely
+
+  CollectionItem *updated_item = ItemForSongId(updated_id);
+  CollectionItem *readded_item = ItemForSongId(readded_id);
+  CollectionItem *removed_item = ItemForSongId(removed_id);
+  ASSERT_TRUE(updated_item && readded_item && removed_item);
+
+  const QPersistentModelIndex p_updated(model_->ItemToIndex(updated_item));
+  const QPersistentModelIndex p_readded(model_->ItemToIndex(readded_item));
+  const QPersistentModelIndex p_removed(model_->ItemToIndex(removed_item));
+  const QPersistentModelIndex p_container(model_->ItemToIndex(updated_item).parent());  // the album node
+  ASSERT_TRUE(p_updated.isValid() && p_readded.isValid() && p_removed.isValid() && p_container.isValid());
+
+  // Touch every song's title so the whole batch goes through the bulk path, and queue one removal behind it; both drain in the same transaction.
+  SongList changed = stored;
+  changed.removeAt(12);
+  for (int i = 0; i < changed.count(); ++i) {
+    changed[i].set_title(changed[i].title() + u"_v2"_s);
+  }
+  changed[11].set_album(u"keep_album_moved"_s);
+
+  QSignalSpy spy_layout(&*model_, &CollectionModel::layoutChanged);
+  QSignalSpy spy_reset(&*model_, &CollectionModel::modelReset);
+
+  backend_->AddOrUpdateSongs(changed);
+  backend_->DeleteSongs(SongList() << stored[12]);
+  Drain();
+
+  EXPECT_GE(spy_layout.count(), 1);
+  EXPECT_EQ(0, spy_reset.count());
+  EXPECT_EQ(2000, static_cast<int>(model_->song_nodes().count()));  // 2000 keep + seed - 1 removed
+
+  // Updated in place: still valid and pointing at the same song.
+  CollectionItem *updated_item_after = ItemForSongId(updated_id);
+  ASSERT_TRUE(updated_item_after);
+  EXPECT_TRUE(p_updated.isValid());
+  EXPECT_EQ(model_->ItemToIndex(updated_item_after), QModelIndex(p_updated));
+  EXPECT_EQ(stored[10].title() + u"_v2"_s, updated_item_after->metadata.title());
+
+  // Removed and re-added under a new container: the remap follows the new node.
+  CollectionItem *readded_item_after = ItemForSongId(readded_id);
+  ASSERT_TRUE(readded_item_after);
+  EXPECT_TRUE(p_readded.isValid());
+  EXPECT_EQ(model_->ItemToIndex(readded_item_after), QModelIndex(p_readded));
+  EXPECT_EQ(u"keep_album_moved"_s, p_readded.parent().data().toString());
+
+  // Genuinely removed: invalidated instead of left dangling.
+  EXPECT_FALSE(p_removed.isValid());
+
+  // The surviving album container keeps its persistent index too.
+  EXPECT_TRUE(p_container.isValid());
+  EXPECT_EQ(p_container, p_updated.parent());
+
+}
+
+// End-to-end check of what the bulk path actually promises:
+// a real QTreeView attached through the CollectionFilter proxy keeps its expanded containers, its selection and its scroll position across a bulk update -
+// including a selected song that is removed and re-added under a new container. With the old model-reset transaction all three were discarded.
+TEST_F(CollectionModelTest, BulkUpdatePreservesViewState) {
+
+  AddSong(u"seed"_s, u"seed"_s, u"seed"_s, 1);
+  backend_->AddOrUpdateSongs(MakeSongs(2000, u"keep"_s));
+  Drain();
+
+  QTreeView view;
+  view.setSelectionMode(QAbstractItemView::ExtendedSelection);
+  view.setModel(collection_filter_);
+  view.resize(400, 300);
+  view.show();
+  QCoreApplication::processEvents();
+
+  SongList stored;
+  const QList<CollectionItem*> nodes = model_->song_nodes();
+  for (CollectionItem *node : nodes) {
+    if (node->metadata.title().startsWith(u"keep_"_s)) stored << node->metadata;  // clazy:exclude=reserve-candidates
+  }
+  ASSERT_EQ(2000, stored.count());
+  std::sort(stored.begin(), stored.end(), [](const Song &a, const Song &b) { return a.id() < b.id(); });
+
+  const int updated_id = stored[10].id();  // metadata-only change
+  const int readded_id = stored[11].id();  // album change moves it to a new container
+
+  const auto proxy_index_for_id = [this](const int id) {
+    CollectionItem *item = ItemForSongId(id);
+    return item ? collection_filter_->mapFromSource(model_->ItemToIndex(item)) : QModelIndex();
+  };
+
+  const QModelIndex updated_proxy = proxy_index_for_id(updated_id);
+  const QModelIndex readded_proxy = proxy_index_for_id(readded_id);
+  ASSERT_TRUE(updated_proxy.isValid());
+  ASSERT_TRUE(readded_proxy.isValid());
+
+  // Expand the artist and album above the updated song, select both songs, and scroll away from the top.
+  view.expand(updated_proxy.parent().parent());
+  view.expand(updated_proxy.parent());
+  ASSERT_TRUE(view.isExpanded(updated_proxy.parent()));
+  view.selectionModel()->select(updated_proxy, QItemSelectionModel::Select);
+  view.selectionModel()->select(readded_proxy, QItemSelectionModel::Select);
+  ASSERT_EQ(2, view.selectionModel()->selectedIndexes().count());
+  view.scrollToBottom();
+  QCoreApplication::processEvents();
+  ASSERT_GT(view.verticalScrollBar()->value(), 0);
+
+  // Bulk update: every title changes (in place), one selected song moves to a new album (remove + re-add).
+  SongList changed = stored;
+  for (int i = 0; i < changed.count(); ++i) {
+    changed[i].set_title(changed[i].title() + u"_v2"_s);
+  }
+  changed[11].set_album(u"keep_album_moved"_s);
+
+  QSignalSpy spy_reset(&*model_, &CollectionModel::modelReset);
+
+  backend_->AddOrUpdateSongs(changed);
+  Drain();
+
+  ASSERT_EQ(0, spy_reset.count());  // went through the bulk layout-change path
+
+  // Expansion survived.
+  CollectionItem *updated_item = ItemForSongId(updated_id);
+  ASSERT_TRUE(updated_item);
+  const QModelIndex album_proxy = collection_filter_->mapFromSource(model_->ItemToIndex(updated_item->parent));
+  const QModelIndex artist_proxy = album_proxy.parent();
+  ASSERT_TRUE(album_proxy.isValid());
+  EXPECT_TRUE(view.isExpanded(album_proxy));
+  EXPECT_TRUE(view.isExpanded(artist_proxy));
+
+  // Selection survived and still points at the right songs, including the one that now lives under a different album.
+  const QModelIndexList selected = view.selectionModel()->selectedIndexes();
+  ASSERT_EQ(2, selected.count());
+  QSet<int> selected_ids;
+  for (const QModelIndex &idx : selected) {
+    selected_ids << model_->IndexToItem(collection_filter_->mapToSource(idx))->metadata.id();
+  }
+  EXPECT_TRUE(selected_ids.contains(updated_id));
+  EXPECT_TRUE(selected_ids.contains(readded_id));
+
+  // The view was not thrown back to the top (a model reset would do that).
+  EXPECT_GT(view.verticalScrollBar()->value(), 0);
 
 }
 


### PR DESCRIPTION
Fixes #2112.

## Problem

When a streaming service (or any backend operation) delivers a large metadata batch, the collection tree freezes for multiple seconds. A batch of N changed songs fans out in `CollectionModel` into thousands of scattered remove/re-add pairs, each emitting its own `begin/endRemoveRows` / `begin/endInsertRows` pair.

This is the freeze reported in #2112. I filed that issue blaming the active collection filter — the measurements below show that diagnosis was wrong: the filter is innocent, the freeze is view-driven and happens with or without a filter. Same symptom, corrected root cause.

## Root cause (measured)

Benchmarked with the real `CollectionFilter` proxy and an expanded `QTreeView` attached, on a 6000-song library with 2000 scattered changed songs (every 3rd song moves to a new album, i.e. the remove/re-add path). The benchmark harness is posted as a comment below so the numbers can be reproduced:

| Variant | Time |
|---|---|
| Current master (no batching) | 1647 ms |
| Contiguous-run batching only (first two commits) | 1765 ms (within run-to-run noise of master — neither helps nor hurts this case) |
| Single transaction above threshold (this PR, complete) | **33 ms** |

The hang is **view-driven, not filter-driven**: with and without an active filter the numbers are identical (1655 ms vs 1688 ms), and without any view attached even unbatched processing takes only ~42 ms. The cost is QTreeView rebuilding its internal `viewItems` bookkeeping on every `rows{Inserted,Removed}` signal — O(n) per signal, O(n²) for the batch on an expanded tree. The existing code comment blaming `QSortFilterProxyModel::filterAcceptsRow` turned out to be misleading; the per-row signals are the problem, regardless of filtering.

## What the commits do

1. **Batch contiguous row removals** per parent into single `begin/endRemoveRows` pairs. Does not help the scattered case above, but collapses whole-album removals into one signal pair.
2. **Batch `beginInsertRows` per container** in `AddSongsInternal`.
3. **Collapse bulk-sized batches into one transaction.** Above a threshold of 1000 pending songs (counted across the update queue — the queue is an artifact of 400-song chunking), all per-row signals are suppressed and the whole drain becomes a single transaction. This also fixes a real bug: `AddReAddOrUpdateSongsInternal` re-queued derived changes instead of applying them inline, so a bulk transaction wrapped no tree mutation at all and the real work landed in a second transaction one tick later (an empty plus a double relayout).
4. **Use `layoutAboutToBeChanged`/`layoutChanged` instead of a model reset** for that transaction, remapping persistent indexes across the mutation. Unlike `begin/endResetModel`, this keeps view state alive: selection, scroll position and expanded containers survive — including a selected song that is removed and re-added under a new container, because remapping is identity-based (song id / container level+key / divider key) rather than pointer-based. Pointer-based matching would not be safe: the heap can hand a new item the address of one just deleted in the same drain.
5. **Tests** for all of the above.

A `Reset` queued behind a bulk batch is never folded into the transaction (it carries its own `begin/endResetModel` and raises `loading_`); the drain stops when one surfaces and handles it on the next tick.

## Verification

- New tests cover: per-row signal suppression above the threshold, the per-row path below it, exactly one layout change per bulk drain (no reset), balanced signal pairs when a `Reset` is queued mid-batch, persistent-index remapping at the model level, and an end-to-end test where a real `QTreeView` attached through `CollectionFilter` keeps its expanded containers, its selection (including the re-added song) and its scroll position across a bulk update.
- Negative control: with the bulk branch temporarily reverted to `begin/endResetModel`, both preservation tests fail (all persistent indexes invalidated, view state lost) — they measure the actual behavior, not implementation details.
- Full `collectionmodel_test` suite: 17/17 green, rebased onto current master. (Run directly: `QT_QPA_PLATFORM=offscreen ./tests/collectionmodel_test` from the build dir.)

## Notes for review

- The 1000-song threshold is a heuristic and deliberately **not** gated on an active filter (the hang is filter-independent). Happy to tune.
- Scroll position is "not thrown back to the top" (what the reset did) — content above the viewport can still shift by the row delta of the mutation.
- The layout-change transaction costs the same as the reset it replaces (33 ms vs 34 ms in the benchmark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Speed up large collection refreshes by batching updates more efficiently and reducing unnecessary UI signaling.
  * Preserve view state (expanded/collapsed containers, selection, and scroll position) across bulk changes, including in-place metadata edits and remove/re-add scenarios.
* **Bug Fixes**
  * Album artwork now more reliably shows the “no cover” icon when cover art isn’t available.
* **Tests**
  * Added/extended regression tests to verify bulk-update behavior, expected signal patterns, and persistent index/view state preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->