### PR TITLE
RadioBrowser: Pick a random API server, fail over on errors, and cleanups

### DIFF
--- a/src/constants/radiobrowsersettings.h
+++ b/src/constants/radiobrowsersettings.h
@@ -23,11 +23,13 @@
 namespace RadioBrowserSettings {
 
 constexpr char kSettingsGroup[] = "RadioBrowser";
-constexpr char kServerUrl[] = "server_url";
 constexpr char kSearchLimit[] = "search_limit";
 constexpr int kSearchLimitDefault = 100;
 constexpr char kHideBroken[] = "hide_broken";
 constexpr bool kHideBrokenDefault = true;
+constexpr char kDefaultSort[] = "default_sort";
+constexpr char kDefaultSortDefault[] = "votes";
+constexpr char kDefaultCountry[] = "default_country";
 
 }  // namespace RadioBrowserSettings
 

--- a/src/radios/radiobrowsersearchview.cpp
+++ b/src/radios/radiobrowsersearchview.cpp
@@ -49,7 +49,7 @@ RadioBrowserSearchView::RadioBrowserSearchView(QWidget *parent)
       search_limit_(100),
       hide_broken_(true),
       has_more_(false),
-      initialized_(false) {
+      countries_loaded_(false) {
 
   ui_->setupUi(this);
 
@@ -101,9 +101,9 @@ void RadioBrowserSearchView::showEvent(QShowEvent *e) {
 
   Q_UNUSED(e)
 
-  if (!initialized_ && service_) {
+  // Retried on every show until the fetch succeeds, so a failed fetch doesn't leave the country filter empty until restart.
+  if (!countries_loaded_ && service_) {
     service_->FetchCountries();
-    initialized_ = true;
   }
 
 }
@@ -187,6 +187,8 @@ void RadioBrowserSearchView::SearchError(const QString &error) {
 }
 
 void RadioBrowserSearchView::CountriesLoaded(const QList<QPair<QString, QString>> &countries) {
+
+  countries_loaded_ = true;
 
   ui_->combo_country->clear();
   ui_->combo_country->addItem(tr("All countries"), QString());

--- a/src/radios/radiobrowsersearchview.cpp
+++ b/src/radios/radiobrowsersearchview.cpp
@@ -121,7 +121,7 @@ void RadioBrowserSearchView::Init(RadioBrowserService *service) {
   search_limit_ = s.value(QLatin1String(RadioBrowserSettings::kSearchLimit), RadioBrowserSettings::kSearchLimitDefault).toInt();
   hide_broken_ = s.value(QLatin1String(RadioBrowserSettings::kHideBroken), RadioBrowserSettings::kHideBrokenDefault).toBool();
 
-  const QString default_sort = s.value(u"default_sort"_s, u"votes"_s).toString();
+  const QString default_sort = s.value(QLatin1String(RadioBrowserSettings::kDefaultSort), QLatin1String(RadioBrowserSettings::kDefaultSortDefault)).toString();
   for (int i = 0; i < ui_->combo_sort->count(); ++i) {
     if (ui_->combo_sort->itemData(i).toString() == default_sort) {
       ui_->combo_sort->setCurrentIndex(i);
@@ -129,7 +129,7 @@ void RadioBrowserSearchView::Init(RadioBrowserService *service) {
     }
   }
 
-  default_country_ = s.value(u"default_country"_s).toString();
+  default_country_ = s.value(QLatin1String(RadioBrowserSettings::kDefaultCountry)).toString();
   s.endGroup();
 
 }

--- a/src/radios/radiobrowsersearchview.h
+++ b/src/radios/radiobrowsersearchview.h
@@ -81,7 +81,7 @@ class RadioBrowserSearchView : public QWidget {
   int search_limit_;
   bool hide_broken_;
   bool has_more_;
-  bool initialized_;
+  bool countries_loaded_;
 };
 
 #endif  // RADIOBROWSERSEARCHVIEW_H

--- a/src/radios/radiobrowserservice.cpp
+++ b/src/radios/radiobrowserservice.cpp
@@ -283,6 +283,13 @@ void RadioBrowserService::CountriesReply(QNetworkReply *reply) {
   if (replies_.contains(reply)) replies_.removeAll(reply);
   reply->deleteLater();
 
+  if (reply->error() != QNetworkReply::NoError) {
+    // The server may have gone down since discovery; rediscover on the next request.
+    server_discovered_ = false;
+    Error(QStringLiteral("Fetching countries failed: %1").arg(reply->errorString()));
+    return;
+  }
+
   const QJsonArray array = ExtractJsonArray(reply);
 
   // Collect country codes that have stations

--- a/src/radios/radiobrowserservice.cpp
+++ b/src/radios/radiobrowserservice.cpp
@@ -105,7 +105,6 @@ void RadioBrowserService::TestServer(const QString &hostname) {
   url.setPath(u"/json/stats"_s);
 
   QNetworkRequest request(url);
-  request.setHeader(QNetworkRequest::ContentTypeHeader, u"application/json"_s);
   QNetworkReply *reply = network_->get(request);
   replies_ << reply;
   QObject::connect(reply, &QNetworkReply::finished, this, [this, reply]() { ServerTestReply(reply); });
@@ -193,7 +192,6 @@ void RadioBrowserService::Search(const QString &query,
   url.setQuery(url_query);
 
   QNetworkRequest request(url);
-  request.setHeader(QNetworkRequest::ContentTypeHeader, u"application/json"_s);
   QNetworkReply *reply = network_->get(request);
   replies_ << reply;
   const int task_id = task_manager_->StartTask(tr("Searching Radio Browser"));
@@ -271,7 +269,6 @@ void RadioBrowserService::FetchCountries() {
   url.setPath(u"/json/countrycodes"_s);
 
   QNetworkRequest request(url);
-  request.setHeader(QNetworkRequest::ContentTypeHeader, u"application/json"_s);
   QNetworkReply *reply = network_->get(request);
   replies_ << reply;
   QObject::connect(reply, &QNetworkReply::finished, this, [this, reply]() { CountriesReply(reply); });

--- a/src/radios/radiobrowserservice.cpp
+++ b/src/radios/radiobrowserservice.cpp
@@ -29,7 +29,7 @@
 #include <QJsonValue>
 #include <QJsonObject>
 #include <QJsonArray>
-#include <QDnsLookup>
+#include <QRandomGenerator>
 
 #include "core/networkaccessmanager.h"
 #include "core/taskmanager.h"
@@ -40,7 +40,7 @@
 
 using namespace Qt::Literals::StringLiterals;
 
-const QStringList RadioBrowserService::kFallbackServers = {
+const QStringList RadioBrowserService::kServers = {
     u"de1.api.radio-browser.info"_s,
     u"de2.api.radio-browser.info"_s,
     u"nl1.api.radio-browser.info"_s,
@@ -49,11 +49,11 @@ const QStringList RadioBrowserService::kFallbackServers = {
 
 RadioBrowserService::RadioBrowserService(const SharedPtr<TaskManager> task_manager, const SharedPtr<NetworkAccessManager> network, QObject *parent)
     : RadioService(Song::Source::RadioBrowser, u"Radio Browser"_s, IconLoader::Load(u"radiobrowser"_s), task_manager, network, parent),
-      dns_lookup_(nullptr),
       server_discovered_(false),
       has_pending_search_(false),
       has_pending_countries_(false),
-      fallback_index_(0) {}
+      server_index_(0),
+      servers_tried_(0) {}
 
 RadioBrowserService::~RadioBrowserService() {
   Abort();
@@ -76,12 +76,6 @@ void RadioBrowserService::Abort() {
   }
   pending_search_tasks_.clear();
 
-  if (dns_lookup_) {
-    dns_lookup_->abort();
-    dns_lookup_->deleteLater();
-    dns_lookup_ = nullptr;
-  }
-
   has_pending_search_ = false;
   has_pending_countries_ = false;
 
@@ -95,38 +89,11 @@ void RadioBrowserService::GetChannels() {
 
 void RadioBrowserService::DiscoverServer() {
 
-  if (dns_lookup_) {
-    dns_lookup_->abort();
-    dns_lookup_->deleteLater();
-    dns_lookup_ = nullptr;
-  }
+  // The API guidelines ask clients to spread load across the mirrors, so start at a random server and advance round-robin on failure.
+  server_index_ = QRandomGenerator::global()->bounded(static_cast<int>(kServers.size()));
+  servers_tried_ = 0;
 
-  fallback_index_ = 0;
-
-  dns_lookup_ = new QDnsLookup(QDnsLookup::A, u"all.api.radio-browser.info"_s, this);
-  QObject::connect(dns_lookup_, &QDnsLookup::finished, this, &RadioBrowserService::DnsLookupFinished);
-  dns_lookup_->lookup();
-
-}
-
-void RadioBrowserService::DnsLookupFinished() {
-
-  if (!dns_lookup_) return;
-
-  const bool dns_failed = dns_lookup_->error() != QDnsLookup::NoError || dns_lookup_->hostAddressRecords().isEmpty();
-  dns_lookup_->deleteLater();
-  dns_lookup_ = nullptr;
-
-  // Qt has no easy reverse DNS, so we use known hostnames either way; the DNS lookup just confirms the service exists
-  // ServerTestReply advances the index on failure, so we only set the starting point here.
-  if (!dns_failed) fallback_index_ = 0;
-
-  if (fallback_index_ < kFallbackServers.size()) {
-    TestServer(kFallbackServers.at(fallback_index_));
-  }
-  else {
-    Q_EMIT SearchError(tr("Failed to discover Radio Browser server."));
-  }
+  TestServer(kServers.at(server_index_));
 
 }
 
@@ -151,10 +118,10 @@ void RadioBrowserService::ServerTestReply(QNetworkReply *reply) {
   reply->deleteLater();
 
   if (reply->error() != QNetworkReply::NoError) {
-    // Try next fallback
-    ++fallback_index_;
-    if (fallback_index_ < kFallbackServers.size()) {
-      TestServer(kFallbackServers.at(fallback_index_));
+    ++servers_tried_;
+    if (servers_tried_ < kServers.size()) {
+      server_index_ = (server_index_ + 1) % kServers.size();
+      TestServer(kServers.at(server_index_));
     }
     else {
       Q_EMIT SearchError(tr("No Radio Browser server available."));

--- a/src/radios/radiobrowserservice.cpp
+++ b/src/radios/radiobrowserservice.cpp
@@ -210,6 +210,8 @@ void RadioBrowserService::SearchReply(QNetworkReply *reply, const int task_id, c
   pending_search_tasks_.removeAll(task_id);
 
   if (reply->error() != QNetworkReply::NoError) {
+    // The server may have gone down since discovery; rediscover on the next search.
+    server_discovered_ = false;
     Q_EMIT SearchError(tr("Radio Browser search failed: %1").arg(reply->errorString()));
     return;
   }

--- a/src/radios/radiobrowserservice.h
+++ b/src/radios/radiobrowserservice.h
@@ -30,7 +30,6 @@
 #include "radiochannel.h"
 
 class QNetworkReply;
-class QDnsLookup;
 
 class TaskManager;
 class NetworkAccessManager;
@@ -67,7 +66,6 @@ class RadioBrowserService : public RadioService {
   void GetChannels() override;
 
  private Q_SLOTS:
-  void DnsLookupFinished();
   void ServerTestReply(QNetworkReply *reply);
   void SearchReply(QNetworkReply *reply, const int task_id, const int limit);
   void CountriesReply(QNetworkReply *reply);
@@ -78,7 +76,6 @@ class RadioBrowserService : public RadioService {
 
   QList<QNetworkReply*> replies_;
   QList<int> pending_search_tasks_;
-  QDnsLookup *dns_lookup_;
   QUrl server_url_;
   bool server_discovered_;
 
@@ -97,8 +94,9 @@ class RadioBrowserService : public RadioService {
   bool has_pending_search_;
   bool has_pending_countries_;
 
-  static const QStringList kFallbackServers;
-  int fallback_index_;
+  static const QStringList kServers;
+  int server_index_;
+  int servers_tried_;
 };
 
 #endif  // RADIOBROWSERSERVICE_H

--- a/src/settings/radiosettingspage.cpp
+++ b/src/settings/radiosettingspage.cpp
@@ -119,8 +119,8 @@ void RadioSettingsPage::Load() {
     s.beginGroup(QLatin1String(RadioBrowserSettings::kSettingsGroup));
     ui_->spin_search_limit->setValue(s.value(QLatin1String(RadioBrowserSettings::kSearchLimit), RadioBrowserSettings::kSearchLimitDefault).toInt());
     ui_->check_hide_broken->setChecked(s.value(QLatin1String(RadioBrowserSettings::kHideBroken), RadioBrowserSettings::kHideBrokenDefault).toBool());
-    ComboBoxLoadFromSettings(s, ui_->combo_default_sort, u"default_sort"_s, u"votes"_s);
-    ComboBoxLoadFromSettings(s, ui_->combo_default_country, u"default_country"_s, QString());
+    ComboBoxLoadFromSettings(s, ui_->combo_default_sort, QLatin1String(RadioBrowserSettings::kDefaultSort), QLatin1String(RadioBrowserSettings::kDefaultSortDefault));
+    ComboBoxLoadFromSettings(s, ui_->combo_default_country, QLatin1String(RadioBrowserSettings::kDefaultCountry), QString());
     s.endGroup();
   }
 
@@ -144,8 +144,8 @@ void RadioSettingsPage::Save() {
     s.beginGroup(QLatin1String(RadioBrowserSettings::kSettingsGroup));
     s.setValue(QLatin1String(RadioBrowserSettings::kSearchLimit), ui_->spin_search_limit->value());
     s.setValue(QLatin1String(RadioBrowserSettings::kHideBroken), ui_->check_hide_broken->isChecked());
-    s.setValue(u"default_sort"_s, ui_->combo_default_sort->currentData().toString());
-    s.setValue(u"default_country"_s, ui_->combo_default_country->currentData().toString());
+    s.setValue(QLatin1String(RadioBrowserSettings::kDefaultSort), ui_->combo_default_sort->currentData().toString());
+    s.setValue(QLatin1String(RadioBrowserSettings::kDefaultCountry), ui_->combo_default_country->currentData().toString());
     s.endGroup();
   }
 


### PR DESCRIPTION
Follow-ups to the Radio Browser integration, all in the server discovery and request plumbing:

- **Remove the DNS lookup.** It lost its last behavioral effect in d34d8fc3: since then both the success and failure path probed the same hardcoded server list starting at index 0, so the lookup only added a DNS round trip of latency before the first search.
- **Pick a random API server.** The radio-browser.info API guidelines ask clients to spread load across the mirrors instead of always hitting the same one. Discovery now starts at a random server and advances round-robin until every server has been tried once.
- **Fail over when the server goes down later.** `server_discovered_` was never reset, so once the chosen server went down every subsequent search failed against it. A failed search or countries fetch now resets discovery, so the next request can fail over to another mirror.
- **Retry the country list fetch.** A failed fetch used to leave the country filter empty until restart; the view now retries when it is shown again.
- **Cleanups:** drop the meaningless `Content-Type` header from GET requests, move the `default_sort`/`default_country` settings keys to `RadioBrowserSettings` constants, and remove the unused `kServerUrl` constant.

No functional change to search itself; all changes are in how the API server is chosen and how errors are handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)