### PR TITLE
Only workaround crash on exit with win32 threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,16 @@ endif()
 
 find_package(PkgConfig REQUIRED)
 find_package(Threads REQUIRED)
+
+# Detect whether the MinGW GCC toolchain uses the posix (winpthreads) threading model.
+# This is reported by "gcc -v" as "Thread model: posix" (as opposed to "win32").
+if(WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  execute_process(COMMAND ${CMAKE_CXX_COMPILER} -v OUTPUT_QUIET ERROR_VARIABLE GCC_VERBOSE_OUTPUT)
+  if(GCC_VERBOSE_OUTPUT MATCHES "Thread model: posix")
+    set(HAVE_WINPTHREADS ON)
+  endif()
+endif()
+
 find_package(Backtrace)
 if(Backtrace_FOUND)
   set(HAVE_BACKTRACE ON)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -7,6 +7,8 @@
 
 #cmakedefine USE_INSTALL_PREFIX
 
+#cmakedefine HAVE_WINPTHREADS
+
 #cmakedefine HAVE_BACKTRACE
 #cmakedefine HAVE_ALSA
 #cmakedefine HAVE_PULSE

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -397,8 +397,8 @@ int main(int argc, char *argv[]) {
 
   int ret = QCoreApplication::exec();
 
-#ifdef __MINGW32__
-  // Workaround crash on exit with win32 threads
+#if defined(__MINGW32__) && !defined(HAVE_WINPTHREADS)
+  // Workaround crash on exit with the GCC win32 threading model (not needed with winpthreads).
   TerminateProcess(GetCurrentProcess(), 0);
 #endif
 


### PR DESCRIPTION
@coderabbitai full review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability for Windows/MinGW users by enhancing POSIX threading model detection and refining the application's shutdown behavior to prevent potential crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->