### PR TITLE
Prevent duplicate songs with identical URL

### DIFF
--- a/data/data.qrc
+++ b/data/data.qrc
@@ -14,6 +14,7 @@
         <file>schema/schema-20.sql</file>
         <file>schema/schema-21.sql</file>
         <file>schema/schema-22.sql</file>
+        <file>schema/schema-23.sql</file>
         <file>schema/device-schema.sql</file>
         <file>style/strawberry.css</file>
         <file>style/smartplaylistsearchterm.css</file>

--- a/data/schema/schema-23.sql
+++ b/data/schema/schema-23.sql
@@ -1,0 +1,5 @@
+DELETE FROM songs WHERE ROWID NOT IN (SELECT (SELECT keep.ROWID FROM songs AS keep WHERE keep.url = songs.url AND keep.beginning = songs.beginning ORDER BY keep.unavailable ASC, keep.ROWID ASC LIMIT 1) FROM songs);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_songs_url_beginning ON songs (url, beginning);
+
+UPDATE schema_version SET version=23;

--- a/data/schema/schema.sql
+++ b/data/schema/schema.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS schema_version (
 
 DELETE FROM schema_version;
 
-INSERT INTO schema_version (version) VALUES (22);
+INSERT INTO schema_version (version) VALUES (23);
 
 CREATE TABLE IF NOT EXISTS directories (
   path TEXT NOT NULL,
@@ -1148,6 +1148,8 @@ CREATE TABLE IF NOT EXISTS radio_channels (
 );
 
 CREATE INDEX IF NOT EXISTS idx_url ON songs (url);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_songs_url_beginning ON songs (url, beginning);
 
 CREATE INDEX IF NOT EXISTS idx_comp_artist ON songs (compilation_effective, artist);
 

--- a/src/collection/collectionbackend.cpp
+++ b/src/collection/collectionbackend.cpp
@@ -707,6 +707,46 @@ void CollectionBackend::AddOrUpdateSongs(const SongList &songs) {
         continue;
       }
     }
+    else {
+      // Local/device song without a unique song ID: guard against inserting a duplicate URL.
+      // The callers (collection watcher / organize) are responsible for setting the id when a song already exists,
+      // but a missed match (different directory_id, Unicode NFC/NFD normalization, or a scan racing a not-yet-committed insert) would otherwise insert a second row for a URL that is already present,
+      // and there is no UNIQUE(url) constraint to catch it.
+      // Match by url and beginning (so distinct CUE tracks sharing one file are kept apart) and include unavailable rows, so a returning file restores its existing row instead of being duplicated.
+      Song existing_song(source_);
+      {
+        SqlQuery q(db);
+        q.prepare(QStringLiteral("SELECT %1 FROM %2 WHERE (url = :url1 OR url = :url2 OR url = :url3 OR url = :url4) AND beginning = :beginning ORDER BY unavailable ASC LIMIT 1").arg(Song::kRowIdColumnSpec, songs_table_));
+        q.BindValue(u":url1"_s, song.url().toString());
+        q.BindValue(u":url2"_s, song.url().toString(QUrl::FullyEncoded));
+        q.BindValue(u":url3"_s, song.url().toEncoded(QUrl::FullyDecoded));
+        q.BindValue(u":url4"_s, song.url().toEncoded(QUrl::FullyEncoded));
+        q.BindValue(u":beginning"_s, song.beginning_nanosec());
+        if (!q.Exec()) {
+          db_->ReportErrors(q);
+          return;
+        }
+        if (q.next()) {
+          existing_song.InitFromQuery(q, true);
+        }
+      }
+      if (existing_song.is_valid() && existing_song.id() != -1) {
+        Song new_song = song;
+        new_song.set_id(existing_song.id());
+        // Don't lose user data: a missed match means the incoming song carries freshly-read (zeroed) statistics.
+        new_song.MergeUserSetData(existing_song, true, true);
+        SqlQuery q(db);
+        q.prepare(QStringLiteral("UPDATE %1 SET %2 WHERE ROWID = :id").arg(songs_table_, Song::kUpdateSpec));
+        new_song.BindToQuery(&q);
+        q.BindValue(u":id"_s, new_song.id());
+        if (!q.Exec()) {
+          db_->ReportErrors(q);
+          return;
+        }
+        changed_songs << new_song;
+        continue;
+      }
+    }
 
     // Create new song
 

--- a/src/collection/collectionwatcher.cpp
+++ b/src/collection/collectionwatcher.cpp
@@ -393,14 +393,16 @@ SongList CollectionWatcher::ScanTransaction::FindSongsInSubdirectory(const QStri
   if (cached_songs_dirty_) {
     const SongList songs = watcher_->backend_->FindSongsInDirectory(dir_id_);
     for (const Song &song : songs) {
-      const QString p = song.url().toLocalFile().section(u'/', 0, -2);
+      // Key by the NFC-normalized parent directory so a file that differs only in Unicode normalization (NFC vs NFD) between disk and database still matches
+      const QString p = song.url().toLocalFile().normalized(QString::NormalizationForm_C).section(u'/', 0, -2);
       cached_songs_.insert(p, song);
     }
     cached_songs_dirty_ = false;
   }
 
-  if (cached_songs_.contains(path)) {
-    return cached_songs_.values(path);
+  const QString nfc_path = path.normalized(QString::NormalizationForm_C);
+  if (cached_songs_.contains(nfc_path)) {
+    return cached_songs_.values(nfc_path);
   }
 
   return SongList();
@@ -836,10 +838,17 @@ void CollectionWatcher::ScanSubdirectory(const CollectionDirectory &dir, const Q
     t->AddToProgress(1);
   }
 
-  // Look for deleted songs
+  // Look for deleted songs.
+  // files_on_disk holds the on-disk path spelling while the database stores its own; the two can differ purely by Unicode normalization form (NFC vs NFD).
+  // Compare in NFC so a song that was just matched (FindSongsByPath normalizes too) is not also treated as deleted within the same scan.
+  QSet<QString> files_on_disk_nfc;
+  files_on_disk_nfc.reserve(files_on_disk.count());
+  for (const QString &file : std::as_const(files_on_disk)) {
+    files_on_disk_nfc.insert(file.normalized(QString::NormalizationForm_C));
+  }
   for (const Song &song : std::as_const(songs_in_db)) {
-    QString file = song.url().toLocalFile();
-    if (!song.unavailable() && !files_on_disk.contains(file) && !t->files_changed_path_.contains(file)) {
+    const QString file = song.url().toLocalFile();
+    if (!song.unavailable() && !files_on_disk_nfc.contains(file.normalized(QString::NormalizationForm_C)) && !t->files_changed_path_.contains(file)) {
       qLog(Debug) << "Song deleted from disk:" << file;
       t->deleted_songs << song;
     }
@@ -1161,8 +1170,10 @@ void CollectionWatcher::RemoveDirectory(const CollectionDirectory &dir) {
 
 bool CollectionWatcher::FindSongsByPath(const SongList &songs, const QString &path, SongList *out) {
 
+  // Compare on the NFC-normalized path so a file that differs only in Unicode normalization (NFC vs NFD) between disk and database still matches, instead of being treated as a new file and duplicated.
+  const QString nfc_path = path.normalized(QString::NormalizationForm_C);
   for (const Song &song : songs) {
-    if (song.url().toLocalFile() == path) {
+    if (song.url().toLocalFile().normalized(QString::NormalizationForm_C) == nfc_path) {
       *out << song;
     }
   }

--- a/src/core/database.cpp
+++ b/src/core/database.cpp
@@ -50,7 +50,7 @@
 
 using namespace Qt::Literals::StringLiterals;
 
-const int Database::kSchemaVersion = 22;
+const int Database::kSchemaVersion = 23;
 
 namespace {
 constexpr char kDatabaseFilename[] = "strawberry.db";

--- a/tests/src/collectionbackend_test.cpp
+++ b/tests/src/collectionbackend_test.cpp
@@ -64,8 +64,8 @@ class CollectionBackendTest : public ::testing::Test {
     return ret;
   }
 
-  SharedPtr<Database> database_;  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
-  ScopedPtr<CollectionBackend> backend_;  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
+  SharedPtr<Database> database_;
+  ScopedPtr<CollectionBackend> backend_;
 };
 
 TEST_F(CollectionBackendTest, EmptyDatabase) {
@@ -154,7 +154,7 @@ class SingleSong : public CollectionBackendTest {
     EXPECT_EQ(1, list[0].directory_id());
   }
 
-  Song song_;  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
+  Song song_;
 
 };
 
@@ -348,6 +348,122 @@ TEST_F(SingleSong, MarkSongsUnavailable) {
 
   CollectionBackend::AlbumList albums = backend_->GetAllAlbums();
   EXPECT_EQ(0, albums.size());
+
+}
+
+// Regression tests for duplicate-URL insertion: AddOrUpdateSongs() must not create a second row when a song with id == -1 arrives for a URL that is already in the database.
+
+TEST_F(SingleSong, ReAddSameUrlDoesNotDuplicate) {
+
+  AddDummySong();
+  if (HasFatalFailure()) return;
+
+  // The collection watcher would normally set the id, but a missed match hands us a fresh song
+  // (id == -1) for a URL that already exists.
+  Song readd(song_);
+  readd.set_id(-1);
+  readd.set_title(u"Title changed"_s);
+
+  QSignalSpy added_spy(&*backend_, &CollectionBackend::SongsAdded);
+  QSignalSpy changed_spy(&*backend_, &CollectionBackend::SongsChanged);
+
+  backend_->AddOrUpdateSongs(SongList() << readd);
+
+  EXPECT_EQ(0, added_spy.count());
+  EXPECT_EQ(1, changed_spy.count());
+
+  const SongList all = backend_->GetAllSongs();
+  ASSERT_EQ(1, all.count());
+  EXPECT_EQ(1, all[0].id());
+  EXPECT_EQ(u"Title changed"_s, all[0].title());
+
+}
+
+TEST_F(SingleSong, ReAddSameUrlUnderDifferentDirectoryDoesNotDuplicate) {
+
+  AddDummySong();
+  if (HasFatalFailure()) return;
+
+  backend_->AddDirectory(u"/tmp/sub"_s);  // ID 2
+
+  // Same URL discovered under a different directory_id (the watcher's match snapshot is dir-scoped).
+  Song readd(song_);
+  readd.set_id(-1);
+  readd.set_directory_id(2);
+
+  backend_->AddOrUpdateSongs(SongList() << readd);
+
+  const SongList all = backend_->GetAllSongs();
+  ASSERT_EQ(1, all.count());           // not duplicated across directories
+  EXPECT_EQ(2, all[0].directory_id());  // and the existing row is healed to the new directory
+
+}
+
+TEST_F(SingleSong, ReAddSameUrlPreservesPlaycountAndRating) {
+
+  song_.set_playcount(7);
+  song_.set_rating(0.8F);
+  AddDummySong();
+  if (HasFatalFailure()) return;
+
+  // A re-scan hands us freshly-read (zeroed) statistics.
+  Song readd(song_);
+  readd.set_id(-1);
+  readd.set_playcount(0);
+  readd.set_rating(0.0F);
+
+  backend_->AddOrUpdateSongs(SongList() << readd);
+
+  const SongList all = backend_->GetAllSongs();
+  ASSERT_EQ(1, all.count());
+  EXPECT_EQ(7U, all[0].playcount());
+  EXPECT_FLOAT_EQ(0.8F, all[0].rating());
+
+}
+
+TEST_F(SingleSong, ReAddRestoresUnavailableSongWithoutDuplicating) {
+
+  AddDummySong();
+  if (HasFatalFailure()) return;
+
+  Song unavailable(song_);
+  unavailable.set_id(1);
+  backend_->MarkSongsUnavailable(SongList() << unavailable);
+  ASSERT_TRUE(backend_->GetSongById(1).unavailable());
+
+  // The file reappears and the watcher misses the (unavailable) row: it must be restored, not duplicated.
+  Song readd(song_);
+  readd.set_id(-1);
+
+  backend_->AddOrUpdateSongs(SongList() << readd);
+
+  const SongList all = backend_->GetAllSongs();
+  ASSERT_EQ(1, all.count());
+  EXPECT_EQ(1, all[0].id());
+  EXPECT_FALSE(all[0].unavailable());
+
+}
+
+TEST_F(CollectionBackendTest, SameUrlDifferentBeginningKeptSeparate) {
+
+  backend_->AddDirectory(u"/tmp"_s);
+
+  // Two CUE tracks share one media file (same URL) but have different beginnings: they must stay distinct.
+  Song track1 = MakeDummySong(1);
+  track1.set_title(u"Track 1"_s);
+  track1.set_artist(u"Artist"_s);
+  track1.set_album(u"Album"_s);
+  track1.set_beginning_nanosec(0);
+
+  Song track2 = MakeDummySong(1);
+  track2.set_title(u"Track 2"_s);
+  track2.set_artist(u"Artist"_s);
+  track2.set_album(u"Album"_s);
+  track2.set_beginning_nanosec(180000000000LL);
+
+  backend_->AddOrUpdateSongs(SongList() << track1 << track2);
+
+  EXPECT_EQ(2, backend_->GetAllSongs().count());
 
 }
 

--- a/tests/src/collectionmodel_test.cpp
+++ b/tests/src/collectionmodel_test.cpp
@@ -58,7 +58,7 @@ namespace {
 
 class CollectionModelTest : public ::testing::Test {
  public:
-  CollectionModelTest() : collection_filter_(nullptr), added_dir_(false) {}
+  CollectionModelTest() : collection_filter_(nullptr), added_dir_(false), song_number_(0) {}
 
  protected:
   void SetUp() override {
@@ -76,7 +76,7 @@ class CollectionModelTest : public ::testing::Test {
     song.set_directory_id(1);
     if (song.mtime() == 0) song.set_mtime(1);
     if (song.ctime() == 0) song.set_ctime(1);
-    if (song.url().isEmpty()) song.set_url(QUrl(u"file:///tmp/foo"_s));
+    if (song.url().isEmpty()) song.set_url(QUrl(QStringLiteral("file:///tmp/foo%1").arg(++song_number_)));
     if (song.filesize() == -1) song.set_filesize(1);
 
     if (!added_dir_) {
@@ -146,12 +146,13 @@ class CollectionModelTest : public ::testing::Test {
     }
   }
 
-  SharedPtr<Database> database_;  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
-  SharedPtr<CollectionBackend> backend_;  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
-  ScopedPtr<CollectionModel> model_;  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
-  CollectionFilter *collection_filter_;  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
+  SharedPtr<Database> database_;
+  SharedPtr<CollectionBackend> backend_;
+  ScopedPtr<CollectionModel> model_;
+  CollectionFilter *collection_filter_;
 
-  bool added_dir_;  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
+  bool added_dir_;
+  int song_number_;
 };
 
 TEST_F(CollectionModelTest, Initialization) {


### PR DESCRIPTION
Fixes #1341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate song records by deduplicating on `(url, beginning)` and reusing existing entries when rescan items arrive without database IDs.
  * Improved rescans and directory scanning by NFC-normalizing paths, avoiding false “deleted” matches and correctly restoring unavailable tracks.
* **Tests**
  * Added regression coverage for duplicate-URL updates, directory healing on rediscovery, preservation of existing play/rating stats, and separation of same-URL multi-part tracks.
* **Chores**
  * Updated the database schema to version 23 and expanded bundled schema resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->