### PR TITLE
Save settings on session manager commit data

### DIFF
--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -72,6 +72,9 @@
 #include <QClipboard>
 #include <QShowEvent>
 #include <QCloseEvent>
+#if QT_CONFIG(sessionmanager)
+#  include <QSessionManager>
+#endif
 #include <QKeyEvent>
 #ifdef HAVE_DBUS
 #  include <QDBusConnection>
@@ -1426,6 +1429,15 @@ void MainWindow::DoExit() {
   app_->Exit();
 
 }
+
+#if QT_CONFIG(sessionmanager)
+void MainWindow::CommitData(QSessionManager &session_manager) {
+
+  session_manager.setRestartHint(QSessionManager::RestartIfRunning);
+  SaveSettings();
+
+}
+#endif
 
 void MainWindow::ExitFinished() {
 

--- a/src/core/mainwindow.h
+++ b/src/core/mainwindow.h
@@ -96,6 +96,9 @@ class Windows7ThumbBar;
 class AddStreamDialog;
 class LastFMImportDialog;
 class RadioViewContainer;
+#if QT_CONFIG(sessionmanager)
+class QSessionManager;
+#endif
 
 #ifdef HAVE_DISCORD_RPC
 class DiscordRichPresence;
@@ -281,6 +284,9 @@ class MainWindow : public QMainWindow, public PlatformInterface {
   void CommandlineOptionsReceived(const QByteArray &string_options);
   void Raise();
   void Exit();
+#if QT_CONFIG(sessionmanager)
+  void CommitData(QSessionManager &manager);
+#endif
 
  private:
   void SaveSettings();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -386,6 +386,10 @@ int main(int argc, char *argv[]) {
   QObject::connect(&unix_signal_watcher, &UnixSignalWatcher::UnixSignal, &w, &MainWindow::Exit);
 #endif
 
+#if QT_CONFIG(sessionmanager)
+  QObject::connect(&a, &QApplication::commitDataRequest, &w, &MainWindow::CommitData, Qt::DirectConnection);
+#endif
+
 #ifdef Q_OS_MACOS
   mac::EnableFullScreen(w);
 #endif  // Q_OS_MACOS


### PR DESCRIPTION
Fixes #1818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added system session management support to automatically save and restore application state. When the system initiates a shutdown or logout, the application now properly persists all current settings and data, seamlessly restoring everything when relaunched. This ensures you never lose progress during system restarts or unexpected closures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->