### PR TITLE
CollectionWatcher: Avoid multiple scan for the same directory

### DIFF
--- a/src/collection/collectionwatcher.cpp
+++ b/src/collection/collectionwatcher.cpp
@@ -456,6 +456,18 @@ bool CollectionWatcher::ScanTransaction::HasSeenSubdir(const QString &path) {
 
 }
 
+bool CollectionWatcher::ScanTransaction::HasScannedPath(const QString &path) {
+
+  return scanned_paths_.contains(path);
+
+}
+
+void CollectionWatcher::ScanTransaction::MarkPathScanned(const QString &path) {
+
+  scanned_paths_.insert(path);
+
+}
+
 CollectionSubdirectoryList CollectionWatcher::ScanTransaction::GetImmediateSubdirs(const QString &path) {
 
   if (known_subdirs_dirty_) {
@@ -544,6 +556,13 @@ void CollectionWatcher::AddDirectory(const CollectionDirectory &dir, const Colle
 }
 
 void CollectionWatcher::ScanSubdirectory(const CollectionDirectory &dir, const QString &path, const CollectionSubdirectory &subdir, const quint64 files_count, ScanTransaction *t, const bool force_noincremental) {
+
+  // A renamed directory can be reached both from its own queued change notification and from its parent's vanished-child check below, so skip it if it was already scanned in this transaction to avoid deleting/adding its songs twice.
+  if (t->HasScannedPath(path)) {
+    t->AddToProgress(files_count);
+    return;
+  }
+  t->MarkPathScanned(path);
 
   const QFileInfo path_info(path);
   const qint64 path_mtime = path_info.exists() && path_info.lastModified().isValid() ? path_info.lastModified().toSecsSinceEpoch() : 0;

--- a/src/collection/collectionwatcher.h
+++ b/src/collection/collectionwatcher.h
@@ -113,6 +113,8 @@ class CollectionWatcher : public QObject {
     bool HasSongsWithMissingFingerprint(const QString &path);
     bool HasSongsWithMissingLoudnessCharacteristics(const QString &path);
     bool HasSeenSubdir(const QString &path);
+    bool HasScannedPath(const QString &path);
+    void MarkPathScanned(const QString &path);
     void SetKnownSubdirs(const CollectionSubdirectoryList &subdirs);
     CollectionSubdirectoryList GetImmediateSubdirs(const QString &path);
     CollectionSubdirectoryList GetAllSubdirs();
@@ -172,6 +174,8 @@ class CollectionWatcher : public QObject {
 
     CollectionSubdirectoryList known_subdirs_;
     bool known_subdirs_dirty_;
+
+    QSet<QString> scanned_paths_;
   };
 
  private Q_SLOTS:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved collection scanning by tracking which directory paths have already been processed during the same scan transaction. If a path is encountered again, scanning now skips redundant work and only updates progress, reducing unnecessary processing and improving responsiveness for large, deep, or complex directory structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->