### PR TITLE
Improve collection divider handling to prevent orphaned dividers when removing songs

### DIFF
--- a/src/collection/collectionitem.h
+++ b/src/collection/collectionitem.h
@@ -40,6 +40,7 @@ class CollectionItem : public SimpleTreeItem<CollectionItem> {
   int container_level;
   Song metadata;
   CollectionItem *compilation_artist_node_;
+  QString divider_key;
 
  private:
   Q_DISABLE_COPY(CollectionItem)

--- a/src/collection/collectionmodel.cpp
+++ b/src/collection/collectionmodel.cpp
@@ -1743,38 +1743,6 @@ void CollectionModel::ClearIconDiskCache() {
 
 }
 
-void CollectionModel::RowsInserted(const QModelIndex &parent, const int first, const int last) {
-
-  SongList songs;
-  for (int i = first; i <= last; i++) {
-    const QModelIndex idx = index(i, 0, parent);
-    if (!idx.isValid()) continue;
-    CollectionItem *item = IndexToItem(idx);
-    if (!item || item->type != CollectionItem::Type::Song) continue;
-    songs << item->metadata;
-  }
-
-  if (!songs.isEmpty()) {
-    Q_EMIT SongsAdded(songs);
-  }
-
-}
-
-void CollectionModel::RowsRemoved(const QModelIndex &parent, const int first, const int last) {
-
-  SongList songs;
-  for (int i = first; i <= last; i++) {
-    const QModelIndex idx = index(i, 0, parent);
-    if (!idx.isValid()) continue;
-    CollectionItem *item = IndexToItem(idx);
-    if (!item || item->type != CollectionItem::Type::Song) continue;
-    songs << item->metadata;
-  }
-
-  Q_EMIT SongsRemoved(songs);
-
-}
-
 QDataStream &operator<<(QDataStream &s, const CollectionModel::Grouping g) {
   s << static_cast<quint32>(g.first) << static_cast<quint32>(g.second) << static_cast<quint32>(g.third);
   return s;

--- a/src/collection/collectionmodel.cpp
+++ b/src/collection/collectionmodel.cpp
@@ -810,9 +810,10 @@ void CollectionModel::RemoveSongsInternal(const SongList &songs) {
       // Consider its parent for the next round
       if (node->parent != root_) parents << node->parent;
 
-      // Maybe consider its divider node
-      if (node->container_level == 0) {
-        divider_keys << DividerKey(options_active_.group_by[0], node->metadata, node->sort_text);
+      // Maybe consider its divider node.
+      // Use the key captured at creation: a container's own metadata is never populated, so recomputing DividerKey here would be wrong for group-bys that derive the key from song fields (e.g. year/samplerate), leaving the divider orphaned.
+      if (node->container_level == 0 && !node->divider_key.isEmpty()) {
+        divider_keys << node->divider_key;
       }
 
       // Special case the Various Artists node
@@ -839,7 +840,7 @@ void CollectionModel::RemoveSongsInternal(const SongList &songs) {
     if (!divider_nodes_.contains(divider_key)) continue;
 
     // Look to see if there are any other items still under this divider
-    if (std::any_of(container_nodes_[0].cbegin(), container_nodes_[0].cend(), [this, divider_key](CollectionItem *node) { return DividerKey(options_active_.group_by[0], node->metadata, node->sort_text) == divider_key; })) {
+    if (std::any_of(container_nodes_[0].cbegin(), container_nodes_[0].cend(), [divider_key](CollectionItem *node) { return node->divider_key == divider_key; })) {
       continue;
     }
 
@@ -906,6 +907,7 @@ CollectionItem *CollectionModel::CreateContainerItem(const GroupBy group_by, con
   if (!divider_key.isEmpty()) {
     item->sort_text.prepend(divider_key + QLatin1Char(' '));
   }
+  item->divider_key = divider_key;
 
   container_nodes_[container_level].insert(item->container_key, item);
 

--- a/src/collection/collectionmodel.h
+++ b/src/collection/collectionmodel.h
@@ -214,8 +214,6 @@ class CollectionModel : public SimpleTreeModel<CollectionItem> {
   void TotalArtistCountUpdated(const int count);
   void TotalAlbumCountUpdated(const int count);
   void GroupingChanged(const CollectionModel::Grouping g, const bool separate_albums_by_grouping);
-  void SongsAdded(const SongList &songs);
-  void SongsRemoved(const SongList &songs);
 
  public Q_SLOTS:
   void SetFilterMode(const CollectionFilterOptions::FilterMode filter_mode);
@@ -291,9 +289,6 @@ class CollectionModel : public SimpleTreeModel<CollectionItem> {
   void TotalSongCountUpdatedSlot(const int count);
   void TotalArtistCountUpdatedSlot(const int count);
   void TotalAlbumCountUpdatedSlot(const int count);
-
-  void RowsInserted(const QModelIndex &parent, const int first, const int last);
-  void RowsRemoved(const QModelIndex &parent, const int first, const int last);
 
  private:
   const SharedPtr<CollectionBackend> backend_;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collection divider handling to prevent orphaned dividers when removing songs.

* **Refactor**
  * Restructured internal collection update signaling mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->