### PR TITLE
Add exponential volume option

### DIFF
--- a/src/constants/backendsettings.h
+++ b/src/constants/backendsettings.h
@@ -36,6 +36,7 @@ constexpr char kALSAPlugin[] = "alsaplugin";
 constexpr char kPlaybin3[] = "playbin3";
 constexpr char kExclusiveMode[] = "exclusive_mode";
 constexpr char kVolumeControl[] = "volume_control";
+constexpr char kVolumeExponential[] = "volume_exponential";
 constexpr char kChannelsEnabled[] = "channels_enabled";
 constexpr char kChannels[] = "channels";
 constexpr char kBS2B[] = "bs2b";

--- a/src/engine/enginebase.cpp
+++ b/src/engine/enginebase.cpp
@@ -50,6 +50,7 @@ EngineBase::EngineBase(QObject *parent)
       playbin3_enabled_(true),
       exclusive_mode_(false),
       volume_control_(true),
+      volume_exponential_(false),
       volume_(100),
       beginning_offset_nanosec_(0),
       end_offset_nanosec_(0),
@@ -163,6 +164,7 @@ void EngineBase::ReloadSettings() {
   exclusive_mode_ = s.value(BackendSettings::kExclusiveMode, false).toBool();
 
   volume_control_ = s.value(BackendSettings::kVolumeControl, true).toBool();
+  volume_exponential_ = s.value(BackendSettings::kVolumeExponential, false).toBool();
 
   channels_enabled_ = s.value(BackendSettings::kChannelsEnabled, false).toBool();
   channels_ = s.value(BackendSettings::kChannels, 0).toInt();

--- a/src/engine/enginebase.h
+++ b/src/engine/enginebase.h
@@ -132,6 +132,7 @@ class EngineBase : public QObject {
  public:
   // Simple accessors
   bool volume_control() const { return volume_control_; }
+  bool volume_exponential() const { return volume_exponential_; }
   inline uint volume() const { return volume_; }
 
   bool is_fadeout_enabled() const { return fadeout_enabled_; }
@@ -185,6 +186,7 @@ class EngineBase : public QObject {
   bool playbin3_enabled_;
   bool exclusive_mode_;
   bool volume_control_;
+  bool volume_exponential_;
   uint volume_;
   quint64 beginning_offset_nanosec_;
   qint64 end_offset_nanosec_;

--- a/src/engine/gstengine.cpp
+++ b/src/engine/gstengine.cpp
@@ -924,6 +924,7 @@ GstEnginePipelinePtr GstEngine::CreatePipeline() {
   pipeline->set_playbin3_enabled(playbin3_enabled_);
   pipeline->set_exclusive_mode(exclusive_mode_);
   pipeline->set_volume_enabled(volume_control_);
+  pipeline->set_volume_exponential(volume_exponential_);
   pipeline->set_stereo_balancer_enabled(stereo_balancer_enabled_);
   pipeline->set_equalizer_enabled(equalizer_enabled_);
   pipeline->set_replaygain(rg_enabled_, rg_mode_, rg_preamp_, rg_fallbackgain_, rg_compression_);

--- a/src/engine/gstenginepipeline.cpp
+++ b/src/engine/gstenginepipeline.cpp
@@ -129,6 +129,7 @@ GstEnginePipeline::GstEnginePipeline(QObject *parent)
       playbin3_enabled_(true),
       exclusive_mode_(false),
       volume_enabled_(true),
+      volume_exponential_(false),
       fading_enabled_(false),
       strict_ssl_enabled_(false),
       buffer_duration_nanosec_(BackendSettings::kDefaultBufferDuration * kNsecPerMsec),
@@ -276,6 +277,10 @@ void GstEnginePipeline::set_exclusive_mode(const bool exclusive_mode) {
 
 void GstEnginePipeline::set_volume_enabled(const bool enabled) {
   volume_enabled_ = enabled;
+}
+
+void GstEnginePipeline::set_volume_exponential(const bool enabled) {
+  volume_exponential_ = enabled;
 }
 
 void GstEnginePipeline::set_stereo_balancer_enabled(const bool enabled) {
@@ -1222,7 +1227,7 @@ void GstEnginePipeline::NotifyVolumeCallback(GstElement *element, GParamSpec *pa
   double volume_internal = 0.0;
   g_object_get(G_OBJECT(element), "volume", &volume_internal, nullptr);
 
-  const uint volume_percent = static_cast<uint>(qBound(0L, lround(volume_internal / 0.01), 100L));
+  const uint volume_percent = instance->InternalVolumeToPercent(volume_internal);
   bool changed = false;
   {
     // Only publish the new value if `element` is still the active volume source.
@@ -2168,9 +2173,34 @@ void GstEnginePipeline::ProcessPendingSeek(const GstState state) {
 
 }
 
+double GstEnginePipeline::PercentToInternalVolume(const uint volume_percent) const {
+
+  if (!volume_exponential_) {
+    return static_cast<double>(volume_percent) * 0.01;
+  }
+
+  // Map the percentage onto a decibel scale where each 1% step equals 0.5 dB, so 100% is 0 dB (unity gain) and 0% is silence.
+  if (volume_percent == 0) return 0.0;
+  if (volume_percent >= 100) return 1.0;
+  return std::pow(10.0, (static_cast<double>(volume_percent) - 100.0) / 40.0);
+
+}
+
+uint GstEnginePipeline::InternalVolumeToPercent(const double volume_internal) const {
+
+  if (!volume_exponential_) {
+    return static_cast<uint>(qBound(0L, lround(volume_internal / 0.01), 100L));
+  }
+
+  // Inverse of PercentToInternalVolume: dB = 20*log10(gain), percent = 100 + dB/0.5.
+  if (volume_internal <= 0.0) return 0;
+  return static_cast<uint>(qBound(0L, lround(100.0 + 40.0 * std::log10(volume_internal)), 100L));
+
+}
+
 void GstEnginePipeline::SetVolume(const uint volume_percent) {
 
-  const double volume_internal = static_cast<double>(volume_percent) * 0.01;
+  const double volume_internal = PercentToInternalVolume(volume_percent);
   bool apply_to_element = false;
   GstElement *volume = nullptr;
   {

--- a/src/engine/gstenginepipeline.h
+++ b/src/engine/gstenginepipeline.h
@@ -68,6 +68,7 @@ class GstEnginePipeline : public QObject {
   void set_playbin3_enabled(const bool playbin3_enabled);
   void set_exclusive_mode(const bool exclusive_mode);
   void set_volume_enabled(const bool enabled);
+  void set_volume_exponential(const bool enabled);
   void set_stereo_balancer_enabled(const bool enabled);
   void set_equalizer_enabled(const bool enabled);
   void set_replaygain(const bool enabled, const int mode, const double preamp, const double fallbackgain, const bool compression);
@@ -164,6 +165,8 @@ class GstEnginePipeline : public QObject {
   bool InitAudioBin(QString &error);
   void SetupVolume(GstElement *element);
   void ReapplyVolume();
+  double PercentToInternalVolume(const uint volume_percent) const;
+  uint InternalVolumeToPercent(const double volume_internal) const;
   void SetStateAsync(const GstState state);
   void SetNextUrl();
 
@@ -228,6 +231,7 @@ class GstEnginePipeline : public QObject {
   QVariant device_;
   bool exclusive_mode_;
   bool volume_enabled_;
+  bool volume_exponential_;
   bool fading_enabled_;
   std::atomic<bool> strict_ssl_enabled_;
 

--- a/src/settings/backendsettingspage.cpp
+++ b/src/settings/backendsettingspage.cpp
@@ -171,6 +171,7 @@ void BackendSettingsPage::Load() {
   Load_Output(output_current_, device_current_);
 
   ui_->checkbox_volume_control->setChecked(s.value(kVolumeControl, true).toBool());
+  ui_->checkbox_volume_exponential->setChecked(s.value(kVolumeExponential, false).toBool());
 
   ui_->checkbox_channels->setChecked(s.value(kChannelsEnabled, false).toBool());
   ui_->spinbox_channels->setValue(s.value(kChannels, 2).toInt());
@@ -436,6 +437,7 @@ void BackendSettingsPage::Save() {
 #endif
 
   s.setValue(kVolumeControl, ui_->checkbox_volume_control->isChecked());
+  s.setValue(kVolumeExponential, ui_->checkbox_volume_exponential->isChecked());
 
   s.setValue(kChannelsEnabled, ui_->checkbox_channels->isChecked());
   s.setValue(kChannels, ui_->spinbox_channels->value());

--- a/src/settings/backendsettingspage.ui
+++ b/src/settings/backendsettingspage.ui
@@ -203,6 +203,16 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="checkbox_volume_exponential">
+        <property name="toolTip">
+         <string>Map the volume slider to a decibel scale so that perceived loudness changes evenly. Each 1% step equals 0.5 dB, 100% is 0 dB and 0% is silence.</string>
+        </property>
+        <property name="text">
+         <string>Exponential volume scaling</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QWidget" name="widget_channels_enabled" native="true">
         <layout class="QHBoxLayout" name="horizontalLayout">
          <property name="leftMargin">
@@ -877,6 +887,7 @@
   <tabstop>radiobutton_alsa_pcm</tabstop>
   <tabstop>checkbox_exclusive_mode</tabstop>
   <tabstop>checkbox_volume_control</tabstop>
+  <tabstop>checkbox_volume_exponential</tabstop>
   <tabstop>checkbox_channels</tabstop>
   <tabstop>spinbox_channels</tabstop>
   <tabstop>checkbox_bs2b</tabstop>


### PR DESCRIPTION
Fixes #1967

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Exponential volume scaling" option in backend settings. Users can now toggle between standard and exponential volume control modes to customize how audio volume responds to slider adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->