### PR TITLE
Fix build when neither moodbar nor waveform is enabled

### DIFF
--- a/src/widgets/trackslider.h
+++ b/src/widgets/trackslider.h
@@ -29,9 +29,7 @@
 #include <QString>
 #include <QSize>
 
-#if defined(HAVE_MOODBAR) || defined(HAVE_WAVEFORM)
-#  include "constants/seekbarsettings.h"
-#endif
+#include "constants/seekbarsettings.h"
 
 class QAction;
 class QActionGroup;
@@ -120,9 +118,8 @@ class TrackSlider : public QWidget {
   WaveformProxyStyle *waveform_proxy_style_;
 #endif
 
-#if defined(HAVE_MOODBAR) || defined(HAVE_WAVEFORM)
   SeekbarMode seekbar_mode_;
-
+#if defined(HAVE_MOODBAR) || defined(HAVE_WAVEFORM)
   // Unified seekbar right-click menu, built in the constructor.
   QMenu *seekbar_menu_;
   QActionGroup *seekbar_mode_group_;


### PR DESCRIPTION
The SeekbarSettings and seekbar_mode_ are referenced in unprotected parts of trackslider.h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Internal code organization improvements to enhance build system flexibility and code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->