### PR TITLE
Re-point playlist items that references a duplicate before removal

### DIFF
--- a/data/schema/schema-23.sql
+++ b/data/schema/schema-23.sql
@@ -1,3 +1,5 @@
+UPDATE playlist_items SET collection_id = (SELECT keep.ROWID FROM songs AS keep, songs AS cur WHERE cur.ROWID = playlist_items.collection_id AND keep.url = cur.url AND keep.beginning = cur.beginning ORDER BY keep.unavailable ASC, keep.ROWID ASC LIMIT 1) WHERE playlist_items.type = 2 AND playlist_items.collection_id IN (SELECT ROWID FROM songs);
+
 DELETE FROM songs WHERE ROWID NOT IN (SELECT (SELECT keep.ROWID FROM songs AS keep WHERE keep.url = songs.url AND keep.beginning = songs.beginning ORDER BY keep.unavailable ASC, keep.ROWID ASC LIMIT 1) FROM songs);
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_songs_url_beginning ON songs (url, beginning);


### PR DESCRIPTION
Fixes #2168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playlist item matching so affected entries point to the best available song record when playlist data is inconsistent.
  * Reduced the chance of broken or incorrect playlist associations for certain items with matching track details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->