### PR TITLE
nsi: Make gnutls optional for MSVC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1201,7 +1201,7 @@ jobs:
         run: |
           files_missing=
           for i in $(ls -1 *.dll *.exe); do
-            nsi_file_entry=$(grep -i "^\s\+File\s\+\"$i\"$" strawberry.nsi || true)
+            nsi_file_entry=$(grep -i "^\s\+File\s\+\(/nonfatal\s\+\)\?\"$i\"$" strawberry.nsi || true)
             if [ "${nsi_file_entry}" = "" ]; then
               echo "File ${i} is missing File entry."
             fi
@@ -1550,7 +1550,7 @@ jobs:
         run: |
           files_missing=
           for i in $(ls -1 *.dll *.exe); do
-            nsi_file_entry=$(grep -i "^\s\+File\s\+\"$i\"$" strawberry.nsi || true)
+            nsi_file_entry=$(grep -i "^\s\+File\s\+\(/nonfatal\s\+\)\?\"$i\"$" strawberry.nsi || true)
             if [ "${nsi_file_entry}" = "" ]; then
               echo "File ${i} is missing File entry."
             fi

--- a/dist/windows/strawberry.nsi.in
+++ b/dist/windows/strawberry.nsi.in
@@ -448,9 +448,7 @@ Section "Strawberry" Strawberry
   File "vorbisfile.dll"
   File "wavpackdll.dll"
 
-!ifndef arch_arm64
-  File "gnutls.dll"
-!endif
+  File /nonfatal "gnutls.dll"
 
 !ifdef release
   File "freetype.dll"
@@ -570,11 +568,8 @@ Section "GIO modules" gio-modules
   File "/oname=libgiognutls.dll" "gio-modules\libgiognutls.dll"
 !endif
 !ifdef msvc
-!ifdef arch_arm64
   File "/oname=gioopenssl.dll" "gio-modules\gioopenssl.dll"
-!else
-  File "/oname=giognutls.dll" "gio-modules\giognutls.dll"
-!endif
+  File /nonfatal "/oname=giognutls.dll" "gio-modules\giognutls.dll"
 !endif
 SectionEnd
 
@@ -1018,9 +1013,7 @@ Section "Uninstall"
   Delete "$INSTDIR\vorbisfile.dll"
   Delete "$INSTDIR\wavpackdll.dll"
 
-!ifndef arch_arm64
   Delete "$INSTDIR\gnutls.dll"
-!endif
 
 !ifdef release
   Delete "$INSTDIR\freetype.dll"
@@ -1105,11 +1098,8 @@ Section "Uninstall"
   Delete "$INSTDIR\gio-modules\libgiognutls.dll"
 !endif
 !ifdef msvc
-!ifdef arch_arm64
   Delete "$INSTDIR\gio-modules\gioopenssl.dll"
-!else
   Delete "$INSTDIR\gio-modules\giognutls.dll"
-!endif
 !endif
 
 !ifdef msvc && debug


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release verification checks for bundled Windows installer files to recognize an additional valid file declaration format.
  * Installer packaging validation now accepts optional non-fatal file entries, reducing false failures during build checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->