### PR TITLE
Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -564,6 +564,7 @@ set(SOURCES
   src/engine/gststartup.cpp
   src/engine/gstengine.cpp
   src/engine/gstenginepipeline.cpp
+  src/engine/gstbusmessageevent.cpp
 
   src/analyzer/fht.cpp
   src/analyzer/analyzerbase.cpp

--- a/src/collection/collectionbackend.cpp
+++ b/src/collection/collectionbackend.cpp
@@ -810,9 +810,10 @@ void CollectionBackend::UpdateSongsBySongID(const SongMap &new_songs) {
   // Add or update songs.
   const QList new_songs_list = new_songs.values();
   for (const Song &new_song : new_songs_list) {
-    if (old_songs.contains(new_song.song_id())) {
+    const SongMap::const_iterator old_song_it = old_songs.constFind(new_song.song_id());
+    if (old_song_it != old_songs.constEnd()) {
 
-      Song old_song = old_songs[new_song.song_id()];
+      const Song &old_song = old_song_it.value();
 
       if (!new_song.IsAllMetadataEqual(old_song) || !new_song.IsFingerprintEqual(old_song)) {  // Update existing song.
 

--- a/src/collection/collectionfilter.cpp
+++ b/src/collection/collectionfilter.cpp
@@ -46,14 +46,14 @@ CollectionFilter::CollectionFilter(QObject *parent) : QSortFilterProxyModel(pare
 
 bool CollectionFilter::filterAcceptsRow(const int source_row, const QModelIndex &source_parent) const {
 
+  if (filter_string_.isEmpty()) return true;
+
   CollectionModel *model = qobject_cast<CollectionModel*>(sourceModel());
   if (!model) return false;
   const QModelIndex idx = sourceModel()->index(source_row, 0, source_parent);
   if (!idx.isValid()) return false;
   CollectionItem *item = model->IndexToItem(idx);
   if (!item) return false;
-
-  if (filter_string_.isEmpty()) return true;
 
   if (item->type != CollectionItem::Type::Song) {
     return item->type == CollectionItem::Type::LoadingIndicator;

--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -2015,15 +2015,15 @@ bool Song::MergeFromEngineMetadata(const EngineMetadata &engine_metadata) {
 
   if (d->init_from_file_ || is_local_collection_song() || d->url_.isLocalFile()) {
     // This Song was already loaded using TagLib. Our tags are probably better than the engine's.
-    if (title() != engine_metadata.title && title().isEmpty() && !engine_metadata.title.isEmpty()) {
+    if (title().isEmpty() && !engine_metadata.title.isEmpty()) {
       set_title(engine_metadata.title);
       minor = false;
     }
-    if (artist() != engine_metadata.artist && artist().isEmpty() && !engine_metadata.artist.isEmpty()) {
+    if (artist().isEmpty() && !engine_metadata.artist.isEmpty()) {
       set_artist(engine_metadata.artist);
       minor = false;
     }
-    if (album() != engine_metadata.album && album().isEmpty() && !engine_metadata.album.isEmpty()) {
+    if (album().isEmpty() && !engine_metadata.album.isEmpty()) {
       set_album(engine_metadata.album);
       minor = false;
     }

--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -459,7 +459,7 @@ QString Song::song_id() const { return d->song_id_.isNull() ? ""_L1 : d->song_id
 
 qint64 Song::beginning_nanosec() const { return d->beginning_; }
 qint64 Song::end_nanosec() const { return d->end_; }
-qint64 Song::length_nanosec() const { return d->end_ - d->beginning_; }
+qint64 Song::length_nanosec() const { return d->end_ < 0 ? -1 : d->end_ - d->beginning_; }
 
 int Song::bitrate() const { return d->bitrate_; }
 int Song::samplerate() const { return d->samplerate_; }
@@ -576,7 +576,7 @@ void Song::set_song_id(const QString &v) { d->song_id_ = v; }
 
 void Song::set_beginning_nanosec(const qint64 v) { d->beginning_ = qMax(0LL, v); }
 void Song::set_end_nanosec(const qint64 v) { d->end_ = v; }
-void Song::set_length_nanosec(const qint64 v) { d->end_ = d->beginning_ + v; }
+void Song::set_length_nanosec(const qint64 v) { d->end_ = v < 0 ? -1 : d->beginning_ + v; }
 
 void Song::set_bitrate(const int v) { d->bitrate_ = v; }
 void Song::set_samplerate(const int v) { d->samplerate_ = v; }

--- a/src/core/song.h
+++ b/src/core/song.h
@@ -546,6 +546,8 @@ class Song {
   void ToXesam(QVariantMap *map) const;
 #endif
 
+  // Returns true if only minor fields changed, and false if a major field (title, artist or album) was updated from the engine metadata.
+  // Note the inverted polarity: true does NOT mean "merged successfully".
   bool MergeFromEngineMetadata(const EngineMetadata &engine_metadata);
 
   // Copies important statistics from the other song to this one, overwriting any data that already exists.

--- a/src/core/song.h
+++ b/src/core/song.h
@@ -80,6 +80,7 @@ class Song {
     RadioBrowser = 12
   };
   static const int kSourceCount = 16;
+  static_assert(static_cast<int>(Source::RadioBrowser) < kSourceCount, "kSourceCount must exceed the largest Song::Source value");
 
   enum class FileType {
     Unknown = 0,

--- a/src/device/filesystemdevice.cpp
+++ b/src/device/filesystemdevice.cpp
@@ -59,12 +59,13 @@ FilesystemDevice::FilesystemDevice(const QUrl &url,
       collection_watcher_(new CollectionWatcher(Song::Source::Device, task_manager, tagreader_client, collection_backend_)),
       watcher_thread_(new QThread(this)) {
 
+  // Set the device name before moving the watcher to its own thread, so this write to device_name_ happens while the watcher still has affinity here and cannot race a scan on the watcher thread.
+  collection_watcher_->set_device_name(device_manager->DeviceNameByID(unique_id));
+
   collection_watcher_->moveToThread(watcher_thread_);
   watcher_thread_->start(QThread::IdlePriority);
 
   qLog(Debug) << collection_watcher_ << "for device" << unique_id << "moved to thread" << watcher_thread_;
-
-  collection_watcher_->set_device_name(device_manager->DeviceNameByID(unique_id));
 
   QObject::connect(&*collection_backend_, &CollectionBackend::DirectoryAdded, collection_watcher_, &CollectionWatcher::AddDirectory);
   QObject::connect(&*collection_backend_, &CollectionBackend::DirectoryDeleted, collection_watcher_, &CollectionWatcher::RemoveDirectory);

--- a/src/engine/gstbusmessageevent.cpp
+++ b/src/engine/gstbusmessageevent.cpp
@@ -1,0 +1,38 @@
+/*
+ * Strawberry Music Player
+ * Copyright 2026, Jonas Kvinge <jonas@jkvinge.net>
+ *
+ * Strawberry is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Strawberry is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Strawberry.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "config.h"
+
+#include <gst/gst.h>
+
+#include <QEvent>
+
+#include "gstbusmessageevent.h"
+
+QEvent::Type GstBusMessageEvent::EventType() {
+
+  // C++ guarantees this is initialised once, so the event type is registered a single time and shared across all instances.
+  static const QEvent::Type type = static_cast<QEvent::Type>(QEvent::registerEventType());
+  return type;
+
+}
+
+GstBusMessageEvent::GstBusMessageEvent(GstMessage *message, const quint64 generation) : QEvent(EventType()), message_(gst_message_ref(message)), generation_(generation) {}
+
+GstBusMessageEvent::~GstBusMessageEvent() { gst_message_unref(message_); }

--- a/src/engine/gstbusmessageevent.h
+++ b/src/engine/gstbusmessageevent.h
@@ -1,0 +1,48 @@
+/*
+ * Strawberry Music Player
+ * Copyright 2026, Jonas Kvinge <jonas@jkvinge.net>
+ *
+ * Strawberry is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Strawberry is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Strawberry.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef GSTBUSMESSAGEEVENT_H
+#define GSTBUSMESSAGEEVENT_H
+
+#include "config.h"
+
+#include <gst/gst.h>
+
+#include <QtGlobal>
+#include <QEvent>
+
+// Carries a GstMessage from the GLib thread to the pipeline's own thread when the bus watch does not already run there (Windows/macOS).
+// The message is reference-counted for the lifetime of the event, so it stays valid until handled and is released even if Qt discards the event during teardown.
+// The generation identifies the bus-watch session the message was posted under, so the receiver can drop messages left over from a torn-down or replaced watch.
+class GstBusMessageEvent : public QEvent {
+ public:
+  static QEvent::Type EventType();
+
+  GstBusMessageEvent(GstMessage *message, const quint64 generation);
+  ~GstBusMessageEvent() override;
+
+  GstMessage *message() const { return message_; }
+  quint64 generation() const { return generation_; }
+
+ private:
+  GstMessage *message_;
+  quint64 generation_;
+};
+
+#endif  // GSTBUSMESSAGEEVENT_H

--- a/src/engine/gstenginepipeline.cpp
+++ b/src/engine/gstenginepipeline.cpp
@@ -1535,7 +1535,10 @@ void GstEnginePipeline::AboutToFinishCallback(GstPlayBin *playbin, gpointer self
 
 }
 
-// Watch callback runs on the main thread and is the single dispatch point for all message-driven state mutation in this class.
+// Watch callback and the single dispatch point for all message-driven state mutation in this class.
+// IMPORTANT: this only runs on the main thread when Qt drives the GLib default main context (i.e. the QEventDispatcherGlib build on Linux/Unix).
+// On Windows and macOS Qt uses a non-GLib event dispatcher, so Application starts a dedicated GLib thread (see Application::GLibMainLoopThreadFunc) that drives the default context instead, and this callback - and every handler it calls below - then runs on THAT thread, concurrently with the main thread.
+// Consequently every member touched here must stay safe against concurrent main-thread access (the state is mostly atomics/mutex-guarded), and the pipeline teardown in Disconnect() can race an in-flight dispatch on that thread.
 gboolean GstEnginePipeline::BusWatchCallback(GstBus *bus, GstMessage *msg, gpointer self) {
 
   Q_UNUSED(bus)
@@ -1580,7 +1583,7 @@ gboolean GstEnginePipeline::BusWatchCallback(GstBus *bus, GstMessage *msg, gpoin
 }
 
 // Sync handler runs on the GStreamer streaming thread.
-// Only do work here that genuinely needs streaming-thread context. Everything else is delivered to BusWatchCallback on the main thread via GST_BUS_PASS.
+// Only do work here that genuinely needs streaming-thread context. Everything else is passed through with GST_BUS_PASS so it is delivered to BusWatchCallback (which runs on the main thread on Linux, but on the dedicated GLib thread on Windows/macOS - see the note there).
 GstBusSyncReply GstEnginePipeline::BusSyncCallback(GstBus *bus, GstMessage *msg, gpointer self) {
 
   Q_UNUSED(bus)

--- a/src/engine/gstenginepipeline.cpp
+++ b/src/engine/gstenginepipeline.cpp
@@ -42,6 +42,8 @@
 
 #include <QObject>
 #include <QCoreApplication>
+#include <QThread>
+#include <QEvent>
 #include <QtConcurrentRun>
 #include <QThreadPool>
 #include <QFuture>
@@ -67,6 +69,7 @@
 #include "constants/backendsettings.h"
 #include "gstengine.h"
 #include "gstenginepipeline.h"
+#include "gstbusmessageevent.h"
 #include "gstbufferconsumer.h"
 
 using namespace std::chrono_literals;
@@ -194,6 +197,7 @@ GstEnginePipeline::GstEnginePipeline(QObject *parent)
       about_to_finish_(false),
       finish_requested_(false),
       finished_(false),
+      bus_message_generation_(0),
       set_state_in_progress_(0),
       set_state_async_in_progress_(0),
       last_set_state_in_progress_(GST_STATE_VOID_PENDING),
@@ -469,6 +473,10 @@ void GstEnginePipeline::Disconnect() {
         gst_object_unref(bus);
       }
     }
+
+    // End this bus-watch session: bump the generation so any GstBusMessageEvent already posted from the GLib thread (Windows/macOS) is dropped on delivery instead of handled after teardown, and remove any such events still sitting in this object's event queue.
+    bus_message_generation_.fetch_add(1);
+    QCoreApplication::removePostedEvents(this, GstBusMessageEvent::EventType());
 
   }
 
@@ -1545,40 +1553,72 @@ gboolean GstEnginePipeline::BusWatchCallback(GstBus *bus, GstMessage *msg, gpoin
 
   GstEnginePipeline *instance = reinterpret_cast<GstEnginePipeline*>(self);
 
+  if (instance->thread() == QThread::currentThread()) {
+    // We are already on the pipeline's own thread (the GLib default context is driven by Qt's main loop, i.e. the QEventDispatcherGlib build on Linux/Unix); handle synchronously, exactly as before.
+    instance->HandleBusMessage(msg);
+  }
+  else {
+    // We are on the dedicated GLib thread (Windows/macOS); marshal the message to the pipeline's own thread so the handlers run with the pipeline's affinity and cannot race main-thread access or teardown.
+    // postEvent is thread-safe; the event refs the message and unrefs it in its destructor, so the message is released even if the event is discarded when the pipeline is destroyed.
+    // The event is stamped with the current generation so it is dropped if the watch is disconnected (or replaced) before it is delivered.
+    QCoreApplication::postEvent(instance, new GstBusMessageEvent(msg, instance->bus_message_generation_.load()));
+  }
+
+  return TRUE;
+
+}
+
+// Receives the bus messages marshalled from BusWatchCallback when it runs off the pipeline's own thread (Windows/macOS).
+bool GstEnginePipeline::event(QEvent *e) {
+
+  if (e->type() == GstBusMessageEvent::EventType()) {
+    GstBusMessageEvent *bus_message_event = static_cast<GstBusMessageEvent*>(e);
+    // Drop messages left over from a bus-watch session that has since been disconnected or replaced; handling them now would emit stale EOS/error/tag events for a torn-down pipeline.
+    if (bus_message_event->generation() == bus_message_generation_.load()) {
+      HandleBusMessage(bus_message_event->message());
+    }
+    return true;
+  }
+
+  return QObject::event(e);
+
+}
+
+// Dispatches a single bus message to the handlers below; always runs on the pipeline's own thread (called directly from BusWatchCallback on Linux, via a posted event on Windows/macOS).
+void GstEnginePipeline::HandleBusMessage(GstMessage *msg) {
+
   switch (GST_MESSAGE_TYPE(msg)) {
     case GST_MESSAGE_EOS:
-      Q_EMIT instance->EndOfStreamReached(instance->id(), false);
+      Q_EMIT EndOfStreamReached(id(), false);
       break;
 
     case GST_MESSAGE_TAG:
-      instance->TagMessageReceived(msg);
+      TagMessageReceived(msg);
       break;
 
     case GST_MESSAGE_ERROR:
-      instance->ErrorMessageReceived(msg);
+      ErrorMessageReceived(msg);
       break;
 
     case GST_MESSAGE_ELEMENT:
-      instance->ElementMessageReceived(msg);
+      ElementMessageReceived(msg);
       break;
 
     case GST_MESSAGE_STATE_CHANGED:
-      instance->StateChangedMessageReceived(msg);
+      StateChangedMessageReceived(msg);
       break;
 
     case GST_MESSAGE_BUFFERING:
-      instance->BufferingMessageReceived(msg);
+      BufferingMessageReceived(msg);
       break;
 
     case GST_MESSAGE_STREAM_START:
-      instance->StreamStartMessageReceived();
+      StreamStartMessageReceived();
       break;
 
     default:
       break;
   }
-
-  return TRUE;
 
 }
 

--- a/src/engine/gstenginepipeline.h
+++ b/src/engine/gstenginepipeline.h
@@ -60,6 +60,8 @@ class GstEnginePipeline : public QObject {
   explicit GstEnginePipeline(QObject *parent = nullptr);
   ~GstEnginePipeline() override;
 
+  bool event(QEvent *e) override;
+
   // Globally unique across all pipelines.
   int id() const { return id_.load(); }
 
@@ -184,6 +186,7 @@ class GstEnginePipeline : public QObject {
   static gboolean BusWatchCallback(GstBus *bus, GstMessage *msg, gpointer self);
   static void TaskEnterCallback(GstTask *task, GThread *thread, gpointer self);
 
+  void HandleBusMessage(GstMessage *msg);
   void TagMessageReceived(GstMessage *msg);
   void ErrorMessageReceived(GstMessage *msg);
   void ElementMessageReceived(GstMessage *msg);
@@ -388,6 +391,9 @@ class GstEnginePipeline : public QObject {
   std::atomic<bool> about_to_finish_;
   std::atomic<bool> finish_requested_;
   std::atomic<bool> finished_;
+
+  // Identifies the current bus-watch session. Bumped by Disconnect() so that GstBusMessageEvents posted from the GLib thread before teardown (Windows/macOS) are dropped instead of handled after the watch is gone or replaced.
+  std::atomic<quint64> bus_message_generation_;
 
   // The state-progress counters (*_in_progress_) and their paired last_set_state_*_in_progress_ values must be updated together under mutex_state_progress_ to avoid observers seeing torn state.
   mutable QMutex mutex_state_progress_;

--- a/src/filterparser/filterparser.cpp
+++ b/src/filterparser/filterparser.cpp
@@ -157,6 +157,8 @@ FilterParser::FilterParser(const QString &filter_string) : filter_string_(filter
 
 FilterTree *FilterParser::parse() {
 
+  // Reset all parse state so the parser produces the same result if parse() is called more than once on the same instance.
+  buf_.clear();
   iter_ = filter_string_.constBegin();
   end_ = filter_string_.constEnd();
 

--- a/src/filterparser/filterparserfloateqcomparator.cpp
+++ b/src/filterparser/filterparserfloateqcomparator.cpp
@@ -22,5 +22,6 @@
 FilterParserFloatEqComparator::FilterParserFloatEqComparator(const float search_term) : search_term_(search_term) {}
 
 bool FilterParserFloatEqComparator::Matches(const QVariant &value) const {
-  return value.toFloat() == search_term_;
+  // Quantize both sides (CAST((x + 0.05) * 10 AS INTEGER)) so the in-memory and database rating filters agree, instead of relying on fragile exact float equality.
+  return static_cast<int>((value.toFloat() + 0.05F) * 10.0F) == static_cast<int>((search_term_ + 0.05F) * 10.0F);
 }

--- a/src/filterparser/filterparserfloatnecomparator.cpp
+++ b/src/filterparser/filterparserfloatnecomparator.cpp
@@ -22,5 +22,6 @@
 FilterParserFloatNeComparator::FilterParserFloatNeComparator(const float value) : search_term_(value) {}
 
 bool FilterParserFloatNeComparator::Matches(const QVariant &value) const {
-  return value.toFloat() != search_term_;
+  // Quantize both sides (CAST((x + 0.05) * 10 AS INTEGER)) so the in-memory and database rating filters agree, instead of relying on fragile exact float inequality.
+  return static_cast<int>((value.toFloat() + 0.05F) * 10.0F) != static_cast<int>((search_term_ + 0.05F) * 10.0F);
 }

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -408,7 +408,7 @@ QVariant Playlist::data(const QModelIndex &idx, const int role) const {
       return QVariant(column_alignments_.value(idx.column(), (Qt::AlignLeft | Qt::AlignVCenter)));
 
     case Qt::ForegroundRole:
-      if (data(idx, Role_IsCurrent).toBool()) {
+      if (current_item_index_.isValid() && idx.row() == current_item_index_.row()) {
         // Ignore any custom colours for the currently playing item - they might clash with the glowing current track indicator.
         return QVariant();
       }
@@ -423,7 +423,7 @@ QVariant Playlist::data(const QModelIndex &idx, const int role) const {
       return QVariant();
 
     case Qt::BackgroundRole:
-      if (data(idx, Role_IsCurrent).toBool()) {
+      if (current_item_index_.isValid() && idx.row() == current_item_index_.row()) {
         // Ignore any custom colours for the currently playing item - they might clash with the glowing current track indicator.
         return QVariant();
       }

--- a/src/playlist/playlistfilter.cpp
+++ b/src/playlist/playlistfilter.cpp
@@ -32,8 +32,7 @@
 
 PlaylistFilter::PlaylistFilter(QObject *parent)
     : QSortFilterProxyModel(parent),
-      filter_tree_(new FilterTreeNop),
-      query_hash_(0) {
+      filter_tree_(new FilterTreeNop) {
 
   setDynamicSortFilter(true);
 
@@ -57,13 +56,6 @@ bool PlaylistFilter::filterAcceptsRow(const int source_row, const QModelIndex &s
 
   if (filter_string_.isEmpty()) return true;
 
-  size_t hash = qHash(filter_string_);
-  if (hash != query_hash_) {
-    FilterParser p(filter_string_);
-    filter_tree_.reset(p.parse());
-    query_hash_ = hash;
-  }
-
   return filter_tree_->accept(item->EffectiveMetadata());
 
 }
@@ -71,6 +63,10 @@ bool PlaylistFilter::filterAcceptsRow(const int source_row, const QModelIndex &s
 void PlaylistFilter::SetFilterString(const QString &filter_string) {
 
   filter_string_ = filter_string;
+
+  FilterParser p(filter_string_);
+  filter_tree_.reset(p.parse());
+
   setFilterFixedString(filter_string);
 
 }

--- a/src/playlist/playlistfilter.h
+++ b/src/playlist/playlistfilter.h
@@ -48,9 +48,7 @@ class PlaylistFilter : public QSortFilterProxyModel {
   QString filter_string() const { return filter_string_; }
 
  private:
-  // Mutable because they're modified from filterAcceptsRow() const
-  mutable QScopedPointer<FilterTree> filter_tree_;
-  mutable size_t query_hash_;
+  QScopedPointer<FilterTree> filter_tree_;
   QString filter_string_;
 };
 

--- a/src/playlistparsers/asxparser.cpp
+++ b/src/playlistparsers/asxparser.cpp
@@ -30,12 +30,18 @@
 #include <QXmlStreamWriter>
 
 #include "includes/shared_ptr.h"
+#include "core/logging.h"
 #include "utilities/xmlutils.h"
 #include "constants/playlistsettings.h"
 #include "xmlparser.h"
 #include "asxparser.h"
 
 using namespace Qt::Literals::StringLiterals;
+
+namespace {
+// A real ASX playlist is tiny; we load the whole file into memory and run regex rewrites over it, so cap the size to avoid a memory-exhaustion DoS from a hostile file.
+constexpr qint64 kMaxFileSize = 50 * 1024 * 1024;
+}  // namespace
 
 class CollectionBackendInterface;
 
@@ -46,8 +52,15 @@ ParserBase::LoadResult ASXParser::Load(QIODevice *device, const QString &playlis
 
   Q_UNUSED(playlist_path);
 
-  // We have to load everything first, so we can munge the "XML".
-  QByteArray data = device->readAll();
+  // QIODevice::size() is unreliable for sequential devices, so bound the actual read instead of trusting it: request one byte past the limit and treat any overflow as too large.
+  // This caps memory use even when size() under-reports, and the failure is reported via Error() so it is not mistaken for a valid empty playlist.
+  // We have to load everything first anyway, so we can munge the "XML".
+  QByteArray data = device->read(kMaxFileSize + 1);
+  if (data.size() > kMaxFileSize) {
+    qLog(Error) << "ASX playlist is too large; refusing to load more than" << kMaxFileSize << "bytes";
+    Q_EMIT Error(tr("ASX playlist is too large"));
+    return SongList();
+  }
 
   // Some playlists have unescaped & characters in URLs :(
   static const QRegularExpression ex(u"(href\\s*=\\s*\")([^\"]+)\""_s, QRegularExpression::CaseInsensitiveOption);
@@ -158,6 +171,11 @@ void ASXParser::Save(const QString &playlist_name, const SongList &songs, QIODev
     }
   }
   writer.writeEndDocument();
+
+  if (writer.hasError()) {
+    qLog(Error) << "Error writing ASX playlist to device";
+    Q_EMIT Error(tr("Failed to write ASX playlist"));
+  }
 
 }
 

--- a/src/playlistparsers/xspfparser.cpp
+++ b/src/playlistparsers/xspfparser.cpp
@@ -30,6 +30,7 @@
 #include <QXmlStreamWriter>
 
 #include "includes/shared_ptr.h"
+#include "core/logging.h"
 #include "core/settings.h"
 #include "utilities/xmlutils.h"
 #include "constants/timeconstants.h"
@@ -206,6 +207,11 @@ void XSPFParser::Save(const QString &playlist_name, const SongList &songs, QIODe
   }
 
   writer.writeEndDocument();
+
+  if (writer.hasError()) {
+    qLog(Error) << "Error writing XSPF playlist to device";
+    Q_EMIT Error(tr("Failed to write XSPF playlist"));
+  }
 
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playlist filtering consistency and responsiveness, including correct handling of empty filters and consistent results across repeated filter changes; parsing state is reset each time.
  * Made float-based filter comparisons more reliable using quantized matching.
  * Fixed track duration/length handling for negative/unknown end times and refined metadata merging to only fill missing title/artist/album values.
  * Improved currently playing row color highlighting.
  * Added safer ASX playlist size limits plus clearer ASX/XSPF load/save error reporting.
  * Hardened playback stability with thread-aware GStreamer bus message handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->