### PR TITLE
LyricsProviders: Abort pending network replies from the worker thread…

### DIFF
--- a/src/core/httpbaserequest.cpp
+++ b/src/core/httpbaserequest.cpp
@@ -1,6 +1,6 @@
 /*
  * Strawberry Music Player
- * Copyright 2025, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2025-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -41,12 +41,18 @@ HttpBaseRequest::~HttpBaseRequest() {
 
   if (!replies_.isEmpty()) {
     qLog(Debug) << "Aborting" << replies_.count() << "network replies";
-    while (!replies_.isEmpty()) {
-      QNetworkReply *reply = replies_.takeFirst();
-      QObject::disconnect(reply, nullptr, this, nullptr);
-      reply->abort();
-      reply->deleteLater();
-    }
+    AbortNetworkReplies();
+  }
+
+}
+
+void HttpBaseRequest::AbortNetworkReplies() {
+
+  while (!replies_.isEmpty()) {
+    QNetworkReply *reply = replies_.takeFirst();
+    QObject::disconnect(reply, nullptr, this, nullptr);
+    reply->abort();
+    reply->deleteLater();
   }
 
 }

--- a/src/core/httpbaserequest.h
+++ b/src/core/httpbaserequest.h
@@ -1,6 +1,6 @@
 /*
  * Strawberry Music Player
- * Copyright 2025, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2025-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -97,6 +97,7 @@ class HttpBaseRequest : public QObject {
   virtual void Error(const QString &error_message, const QVariant &debug_output = QVariant());
 
  public Q_SLOTS:
+  void AbortNetworkReplies();
   void HandleSSLErrors(const QList<QSslError> &ssl_errors);
 
  Q_SIGNALS:

--- a/src/lyrics/lyricsproviders.cpp
+++ b/src/lyrics/lyricsproviders.cpp
@@ -1,6 +1,6 @@
 /*
  * Strawberry Music Player
- * Copyright 2018-2021, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2018-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -53,7 +53,14 @@ LyricsProviders::LyricsProviders(QObject *parent) : QObject(parent), thread_(new
 
 LyricsProviders::~LyricsProviders() {
 
-  // Stop the worker thread first - the providers were moved to it, and deleting a QObject while its owning thread is still running is undefined behaviour.
+  // Abort pending network replies from the worker thread while its event loop is still running.
+  // Aborting from the main thread after the worker stops triggers Qt's cross-thread sendEvent assert.
+  const QList<LyricsProvider*> providers = lyrics_providers_.keys();
+  for (LyricsProvider *provider : providers) {
+    QMetaObject::invokeMethod(provider, &HttpBaseRequest::AbortNetworkReplies, Qt::BlockingQueuedConnection);
+  }
+
+  // Stop the worker thread - the providers were moved to it, and deleting a QObject while its owning thread is still running is undefined behaviour.
   thread_->quit();
   thread_->wait(1000);
 

--- a/src/lyrics/lyricsproviders.h
+++ b/src/lyrics/lyricsproviders.h
@@ -1,6 +1,6 @@
 /*
  * Strawberry Music Player
- * Copyright 2018-2021, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2018-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
… while its event loop is still running

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of pending network activity when closing lyrics-related features, reducing the chance of lingering requests or shutdown issues.
  * Made request shutdown more reliable by ensuring in-flight network operations are stopped before background processing ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->