### PR TITLE
Use QtConcurrent for lyrics parsing instead of dedicated thread

### DIFF
--- a/src/lyrics/azlyricscomlyricsprovider.cpp
+++ b/src/lyrics/azlyricscomlyricsprovider.cpp
@@ -1,6 +1,6 @@
 /*
  * Strawberry Music Player
- * Copyright 2023, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2023-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,8 +17,6 @@
  *
  */
 
-#include <QApplication>
-#include <QThread>
 #include <QString>
 #include <QUrl>
 #include <QRegularExpression>
@@ -48,8 +46,6 @@ QUrl AzLyricsComLyricsProvider::Url(const LyricsSearchRequest &request) {
 }
 
 QString AzLyricsComLyricsProvider::StringFixup(const QString &text) {
-
-  Q_ASSERT(QThread::currentThread() != qApp->thread());
 
   static const QRegularExpression regex_words_numbers_and_dash(u"[^\\w0-9\\-]"_s);
   return Utilities::Transliterate(text).remove(regex_words_numbers_and_dash).toLower();

--- a/src/lyrics/azlyricscomlyricsprovider.h
+++ b/src/lyrics/azlyricscomlyricsprovider.h
@@ -1,6 +1,6 @@
 /*
  * Strawberry Music Player
- * Copyright 2023, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2023-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/lyrics/elyricsnetlyricsprovider.cpp
+++ b/src/lyrics/elyricsnetlyricsprovider.cpp
@@ -1,6 +1,6 @@
 /*
  * Strawberry Music Player
- * Copyright 2023, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2023-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,8 +17,6 @@
  *
  */
 
-#include <QApplication>
-#include <QThread>
 #include <QString>
 #include <QUrl>
 #include <QRegularExpression>
@@ -48,8 +46,6 @@ QUrl ElyricsNetLyricsProvider::Url(const LyricsSearchRequest &request) {
 }
 
 QString ElyricsNetLyricsProvider::StringFixup(const QString &text) {
-
-  Q_ASSERT(QThread::currentThread() != qApp->thread());
 
   static const QRegularExpression regex_illegal_characters(u"[^\\w0-9_,&\\-\\(\\) ]"_s);
   static const QRegularExpression regex_duplicate_whitespaces(u" {2,}"_s);

--- a/src/lyrics/elyricsnetlyricsprovider.h
+++ b/src/lyrics/elyricsnetlyricsprovider.h
@@ -1,6 +1,6 @@
 /*
  * Strawberry Music Player
- * Copyright 2023, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2023-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/lyrics/geniuslyricsprovider.cpp
+++ b/src/lyrics/geniuslyricsprovider.cpp
@@ -1,6 +1,6 @@
 /*
  * Strawberry Music Player
- * Copyright 2020-2025, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2020-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,8 +21,9 @@
 
 #include <memory>
 
-#include <QApplication>
-#include <QThread>
+#include <QtConcurrent>
+#include <QFuture>
+#include <QFutureWatcher>
 #include <QByteArray>
 #include <QVariant>
 #include <QString>
@@ -128,8 +129,6 @@ void GeniusLyricsProvider::OAuthFinished(const bool success, const QString &erro
 
 void GeniusLyricsProvider::StartSearch(const int id, const LyricsSearchRequest &request) {
 
-  Q_ASSERT(QThread::currentThread() != qApp->thread());
-
   if (!authenticated()) {
     EndSearch(id, request);
     return;
@@ -213,8 +212,6 @@ GeniusLyricsProvider::JsonObjectResult GeniusLyricsProvider::ParseJsonObject(QNe
 }
 
 void GeniusLyricsProvider::HandleSearchReply(QNetworkReply *reply, const int id) {
-
-  Q_ASSERT(QThread::currentThread() != qApp->thread());
 
   if (!replies_.contains(reply)) return;
   replies_.removeAll(reply);
@@ -333,8 +330,6 @@ void GeniusLyricsProvider::HandleSearchReply(QNetworkReply *reply, const int id)
 
 void GeniusLyricsProvider::HandleLyricReply(QNetworkReply *reply, const int search_id, const QUrl &url) {
 
-  Q_ASSERT(QThread::currentThread() != qApp->thread());
-
   if (!replies_.contains(reply)) return;
   replies_.removeAll(reply);
   QObject::disconnect(reply, nullptr, this, nullptr);
@@ -376,14 +371,26 @@ void GeniusLyricsProvider::HandleLyricReply(QNetworkReply *reply, const int sear
   static const QRegularExpression regex_html_tag_h2(u"<h2 [^>]*>[^<]*</h2>"_s);
   static const QList<QRegularExpression> regex_removes{ regex_html_lyrics_header, regex_html_tag_h2 };
 
-  const QString lyrics = HtmlLyricsProvider::ParseLyricsFromHTML(QString::fromUtf8(data), start_tag, end_tag, lyrics_start, true, regex_removes);
+   QFutureWatcher<QString> *watcher = new QFutureWatcher<QString>(this);
+  QObject::connect(watcher, &QFutureWatcher<QString>::finished, this, [this, watcher, search, lyric]() {
+    ParseLyricsFromHTMLFinished(watcher, search, lyric);
+  });
+  watcher->setFuture(QtConcurrent::run([content = QString::fromUtf8(data)]() {
+    return HtmlLyricsProvider::ParseLyricsFromHTML(content, start_tag, end_tag, lyrics_start, true, regex_removes);
+  }));
+
+}
+
+void GeniusLyricsProvider::ParseLyricsFromHTMLFinished(QFutureWatcher<QString> *watcher, GeniusLyricsSearchContextPtr search, const GeniusLyricsLyricContext &lyric) {
+
+  watcher->deleteLater();
+  const QString lyrics = watcher->result();
   if (!lyrics.isEmpty()) {
     LyricsSearchResult result(lyrics);
     result.artist = lyric.artist;
     result.title = lyric.title;
     search->results.append(result);
   }
-
   EndSearch(search, lyric);
 
 }

--- a/src/lyrics/geniuslyricsprovider.h
+++ b/src/lyrics/geniuslyricsprovider.h
@@ -1,6 +1,6 @@
 /*
  * Strawberry Music Player
- * Copyright 2020-2025, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2020-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,10 +22,11 @@
 
 #include "config.h"
 
+#include <QFutureWatcher>
+#include <QMutex>
 #include <QMap>
 #include <QString>
 #include <QUrl>
-#include <QMutex>
 
 #include "includes/shared_ptr.h"
 #include "jsonlyricsprovider.h"
@@ -71,6 +72,7 @@ class GeniusLyricsProvider : public JsonLyricsProvider {
 
  private:
   JsonObjectResult ParseJsonObject(QNetworkReply *reply);
+  void ParseLyricsFromHTMLFinished(QFutureWatcher<QString> *watcher, GeniusLyricsSearchContextPtr search, const GeniusLyricsLyricContext &lyric);
   void EndSearch(GeniusLyricsSearchContextPtr search, const GeniusLyricsLyricContext &lyric = GeniusLyricsLyricContext());
   void EndSearch(const int id, const LyricsSearchRequest &request, const LyricsSearchResults &results = LyricsSearchResults());
 

--- a/src/lyrics/htmllyricsprovider.cpp
+++ b/src/lyrics/htmllyricsprovider.cpp
@@ -1,6 +1,6 @@
 /*
  * Strawberry Music Player
- * Copyright 2022, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2022-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,8 +19,9 @@
 
 #include "config.h"
 
-#include <QApplication>
-#include <QThread>
+#include <QtConcurrent>
+#include <QFuture>
+#include <QFutureWatcher>
 #include <QByteArray>
 #include <QVariant>
 #include <QString>
@@ -39,21 +40,21 @@
 using namespace Qt::Literals::StringLiterals;
 
 HtmlLyricsProvider::HtmlLyricsProvider(const QString &name, const bool enabled, const QString &start_tag, const QString &end_tag, const QString &lyrics_start, const bool multiple, const SharedPtr<NetworkAccessManager> network, QObject *parent)
-    : LyricsProvider(name, enabled, false, network, parent), start_tag_(start_tag), end_tag_(end_tag), lyrics_start_(lyrics_start), multiple_(multiple) {}
-
-bool HtmlLyricsProvider::StartSearchAsync(const int id, const LyricsSearchRequest &request) {
-
-  if (request.artist.isEmpty() || request.title.isEmpty()) return false;
-
-  QMetaObject::invokeMethod(this, "StartSearch", Qt::QueuedConnection, Q_ARG(int, id), Q_ARG(LyricsSearchRequest, request));
-
-  return true;
-
-}
+    : LyricsProvider(name, enabled, false, network, parent),
+      start_tag_(start_tag),
+      end_tag_(end_tag),
+      lyrics_start_(lyrics_start),
+      multiple_(multiple),
+      start_tag_re_(start_tag),
+      end_tag_re_(end_tag),
+      lyrics_start_re_(lyrics_start) {}
 
 void HtmlLyricsProvider::StartSearch(const int id, const LyricsSearchRequest &request) {
 
-  Q_ASSERT(QThread::currentThread() != qApp->thread());
+  if (request.artist.isEmpty() || request.title.isEmpty()) {
+    Q_EMIT SearchFinished(id);
+    return;
+  }
 
   const QUrl url = Url(request);
   QNetworkReply *reply = CreateGetRequest(url, true);
@@ -65,16 +66,10 @@ void HtmlLyricsProvider::StartSearch(const int id, const LyricsSearchRequest &re
 
 void HtmlLyricsProvider::HandleLyricsReply(QNetworkReply *reply, const int id, const LyricsSearchRequest &request) {
 
-  Q_ASSERT(QThread::currentThread() != qApp->thread());
-
   if (!replies_.contains(reply)) return;
   replies_.removeAll(reply);
   QObject::disconnect(reply, nullptr, this, nullptr);
   reply->deleteLater();
-
-  LyricsSearchResults results;
-
-  const QScopeGuard search_finished = qScopeGuard([this, id, &results]() { Q_EMIT SearchFinished(id, results); });
 
   if (reply->error() != QNetworkReply::NoError) {
     if (reply->error() >= 200) {
@@ -86,14 +81,16 @@ void HtmlLyricsProvider::HandleLyricsReply(QNetworkReply *reply, const int id, c
     else {
       qLog(Error) << name_ << reply->errorString() << reply->error();
     }
+    Q_EMIT SearchFinished(id);
     return;
   }
 
   if (reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).isValid()) {
     const int http_status_code = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
     if (http_status_code < 200 || http_status_code > 207) {
-      qLog(Error) << name_ << "Received HTTP code" << reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+      qLog(Error) << name_ << "Received HTTP code" << http_status_code;
       reply->readAll(); // QTBUG-135641
+      Q_EMIT SearchFinished(id);
       return;
     }
   }
@@ -101,24 +98,21 @@ void HtmlLyricsProvider::HandleLyricsReply(QNetworkReply *reply, const int id, c
   const QByteArray data = reply->readAll();
   if (data.isEmpty()) {
     qLog(Error) << name_ << "Empty reply received from server.";
+    Q_EMIT SearchFinished(id);
     return;
   }
 
-  const QString lyrics = ParseLyricsFromHTML(QString::fromUtf8(data), QRegularExpression(start_tag_), QRegularExpression(end_tag_), QRegularExpression(lyrics_start_), multiple_);
-  if (lyrics.isEmpty() || lyrics.contains("we do not have the lyrics for"_L1, Qt::CaseInsensitive)) {
-    qLog(Debug) << name_ << "No lyrics for" << request.artist << request.album << request.title;
-    return;
-  }
-
-  qLog(Debug) << name_ << "Got lyrics for" << request.artist << request.album << request.title;
-
-  results << LyricsSearchResult(lyrics);
+  QFutureWatcher<QString> *watcher = new QFutureWatcher<QString>(this);
+  QObject::connect(watcher, &QFutureWatcher<QString>::finished, this, [this, watcher, id, request]() {
+    ParseLyricsFromHTMLFinished(watcher, id, request);
+  });
+  watcher->setFuture(QtConcurrent::run([content = QString::fromUtf8(data), start_re = start_tag_re_, end_re = end_tag_re_, lyrics_re = lyrics_start_re_, multiple = multiple_]() {
+    return ParseLyricsFromHTML(content, start_re, end_re, lyrics_re, multiple);
+  }));
 
 }
 
 QString HtmlLyricsProvider::ParseLyricsFromHTML(const QString &content, const QRegularExpression &start_tag, const QRegularExpression &end_tag, const QRegularExpression &lyrics_start, const bool multiple, const QList<QRegularExpression> &regex_removes) {
-
-  Q_ASSERT(QThread::currentThread() != qApp->thread());
 
   QString lyrics;
   qint64 start_idx = 0;
@@ -188,5 +182,21 @@ QString HtmlLyricsProvider::ParseLyricsFromHTML(const QString &content, const QR
   }
 
   return Utilities::DecodeHtmlEntities(lyrics);
+
+}
+
+void HtmlLyricsProvider::ParseLyricsFromHTMLFinished(QFutureWatcher<QString> *watcher, const int id, const LyricsSearchRequest &request) {
+
+  watcher->deleteLater();
+  const QString lyrics = watcher->result();
+  LyricsSearchResults results;
+  if (lyrics.isEmpty() || lyrics.contains("we do not have the lyrics for"_L1, Qt::CaseInsensitive)) {
+    qLog(Debug) << name_ << "No lyrics for" << request.artist << request.album << request.title;
+  }
+  else {
+    qLog(Debug) << name_ << "Got lyrics for" << request.artist << request.album << request.title;
+    results << LyricsSearchResult(lyrics);
+  }
+  Q_EMIT SearchFinished(id, results);
 
 }

--- a/src/lyrics/htmllyricsprovider.h
+++ b/src/lyrics/htmllyricsprovider.h
@@ -1,6 +1,6 @@
 /*
  * Strawberry Music Player
- * Copyright 2022, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2022-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,9 +22,11 @@
 
 #include "config.h"
 
+#include <QFutureWatcher>
 #include <QVariant>
 #include <QString>
 #include <QUrl>
+#include <QRegularExpression>
 
 #include "includes/shared_ptr.h"
 #include "core/networkaccessmanager.h"
@@ -39,12 +41,11 @@ class HtmlLyricsProvider : public LyricsProvider {
  public:
   explicit HtmlLyricsProvider(const QString &name, const bool enabled, const QString &start_tag, const QString &end_tag, const QString &lyrics_start, const bool multiple, const SharedPtr<NetworkAccessManager> network, QObject *parent);
 
-  virtual bool StartSearchAsync(const int id, const LyricsSearchRequest &request) override;
-
   static QString ParseLyricsFromHTML(const QString &content, const QRegularExpression &start_tag, const QRegularExpression &end_tag, const QRegularExpression &lyrics_start, const bool multiple, const QList<QRegularExpression> &regex_removes = {});
 
  protected:
   virtual QUrl Url(const LyricsSearchRequest &request) = 0;
+  void ParseLyricsFromHTMLFinished(QFutureWatcher<QString> *watcher, const int id, const LyricsSearchRequest &request);
 
  protected Q_SLOTS:
   virtual void StartSearch(const int id, const LyricsSearchRequest &request) override;
@@ -55,6 +56,9 @@ class HtmlLyricsProvider : public LyricsProvider {
   const QString end_tag_;
   const QString lyrics_start_;
   const bool multiple_;
+  const QRegularExpression start_tag_re_;
+  const QRegularExpression end_tag_re_;
+  const QRegularExpression lyrics_start_re_;
 };
 
 #endif  // HTMLLYRICSPROVIDER_H

--- a/src/lyrics/letraslyricsprovider.cpp
+++ b/src/lyrics/letraslyricsprovider.cpp
@@ -19,13 +19,14 @@
 
 #include "config.h"
 
-#include <QApplication>
-#include <QThread>
+#include <QFuture>
+#include <QFutureWatcher>
+#include <QtConcurrent>
+#include <QCoreApplication>
 #include <QByteArray>
 #include <QString>
 #include <QUrl>
 #include <QRegularExpression>
-#include <QScopeGuard>
 #include <QNetworkRequest>
 #include <QNetworkReply>
 
@@ -56,8 +57,6 @@ QUrl LetrasLyricsProvider::Url(const LyricsSearchRequest &request) {
 
 void LetrasLyricsProvider::StartSearch(const int id, const LyricsSearchRequest &request) {
 
-  Q_ASSERT(QThread::currentThread() != qApp->thread());
-
   // letras.mus.br's Akamai edge blocks generic browser User-Agents (Mozilla/Firefox/Chrome strings all return 403)
   // but lets through identifiable HTTP-client UAs in the `name/version (+url)` form.
   // Send a Strawberry-identifying UA instead of the default fake browser UA used by other HTML providers.
@@ -76,16 +75,10 @@ void LetrasLyricsProvider::StartSearch(const int id, const LyricsSearchRequest &
 
 void LetrasLyricsProvider::HandleLyricsReply(QNetworkReply *reply, const int id, const LyricsSearchRequest &request) {
 
-  Q_ASSERT(QThread::currentThread() != qApp->thread());
-
   if (!replies_.contains(reply)) return;
   replies_.removeAll(reply);
   QObject::disconnect(reply, nullptr, this, nullptr);
   reply->deleteLater();
-
-  LyricsSearchResults results;
-
-  const QScopeGuard search_finished = qScopeGuard([this, id, &results]() { Q_EMIT SearchFinished(id, results); });
 
   if (reply->error() != QNetworkReply::NoError) {
     if (reply->error() >= 200) {
@@ -97,6 +90,7 @@ void LetrasLyricsProvider::HandleLyricsReply(QNetworkReply *reply, const int id,
     else {
       qLog(Error) << name_ << reply->errorString() << reply->error();
     }
+    Q_EMIT SearchFinished(id);
     return;
   }
 
@@ -105,6 +99,7 @@ void LetrasLyricsProvider::HandleLyricsReply(QNetworkReply *reply, const int id,
     if (http_status_code < 200 || http_status_code > 207) {
       qLog(Error) << name_ << "Received HTTP code" << http_status_code;
       reply->readAll();  // QTBUG-135641
+      Q_EMIT SearchFinished(id);
       return;
     }
   }
@@ -112,6 +107,7 @@ void LetrasLyricsProvider::HandleLyricsReply(QNetworkReply *reply, const int id,
   const QByteArray data = reply->readAll();
   if (data.isEmpty()) {
     qLog(Error) << name_ << "Empty reply received from server.";
+    Q_EMIT SearchFinished(id);
     return;
   }
 
@@ -128,25 +124,22 @@ void LetrasLyricsProvider::HandleLyricsReply(QNetworkReply *reply, const int id,
     // (e.g. " (feat. Stéphane Grappelli)", " (Live)") don't cause a false reject.
     if (!resolved_title.startsWith(request.title, Qt::CaseInsensitive)) {
       qLog(Debug) << name_ << "Slug resolved to a different track" << resolved_title << "for requested" << request.title;
+      Q_EMIT SearchFinished(id);
       return;
     }
   }
 
-  const QString lyrics = ParseLyricsFromHTML(content, QRegularExpression(start_tag_), QRegularExpression(end_tag_), QRegularExpression(lyrics_start_), multiple_);
-  if (lyrics.isEmpty() || lyrics.contains("we do not have the lyrics for"_L1, Qt::CaseInsensitive)) {
-    qLog(Debug) << name_ << "No lyrics for" << request.artist << request.album << request.title;
-    return;
-  }
-
-  qLog(Debug) << name_ << "Got lyrics for" << request.artist << request.album << request.title;
-
-  results << LyricsSearchResult(lyrics);
+  auto *watcher = new QFutureWatcher<QString>(this);
+  QObject::connect(watcher, &QFutureWatcher<QString>::finished, this, [this, watcher, id, request]() {
+    ParseLyricsFromHTMLFinished(watcher, id, request);
+  });
+  watcher->setFuture(QtConcurrent::run([content, start_re = start_tag_re_, end_re = end_tag_re_, lyrics_re = lyrics_start_re_, multiple = multiple_]() {
+    return ParseLyricsFromHTML(content, start_re, end_re, lyrics_re, multiple);
+  }));
 
 }
 
 QString LetrasLyricsProvider::StringFixup(const QString &text) {
-
-  Q_ASSERT(QThread::currentThread() != qApp->thread());
 
   // letras.mus.br slugs are strictly lowercase ASCII alpha-num with hyphens for word breaks; punctuation in the title is dropped.
   static const QRegularExpression regex_illegal_characters(u"[^A-Za-z0-9 -]"_s);

--- a/src/lyrics/lrcliblyricsprovider.cpp
+++ b/src/lyrics/lrcliblyricsprovider.cpp
@@ -19,8 +19,6 @@
 
 #include "config.h"
 
-#include <QApplication>
-#include <QThread>
 #include <QByteArray>
 #include <QVariant>
 #include <QString>
@@ -49,8 +47,6 @@ constexpr char kApiUrl[] = "https://lrclib.net/api/get";
 LrcLibLyricsProvider::LrcLibLyricsProvider(const SharedPtr<NetworkAccessManager> network, QObject *parent) : JsonLyricsProvider(u"LrcLib"_s, true, false, network, parent) {}
 
 void LrcLibLyricsProvider::StartSearch(const int id, const LyricsSearchRequest &request) {
-
-  Q_ASSERT(QThread::currentThread() != qApp->thread());
 
   const QUrl url(QString::fromUtf8(kApiUrl));
   QUrlQuery url_query;
@@ -117,8 +113,6 @@ LrcLibLyricsProvider::JsonObjectResult LrcLibLyricsProvider::ParseJsonObject(QNe
 }
 
 void LrcLibLyricsProvider::HandleSearchReply(QNetworkReply *reply, const int id, const LyricsSearchRequest &request) {
-
-  Q_ASSERT(QThread::currentThread() != qApp->thread());
 
   LyricsSearchResults results;
   const QScopeGuard end_search = qScopeGuard([this, id, request, &results]() { EndSearch(id, request, results); });

--- a/src/lyrics/lyricsproviders.cpp
+++ b/src/lyrics/lyricsproviders.cpp
@@ -42,27 +42,13 @@ int LyricsProviders::NextOrderId = 0;
 
 using std::make_shared;
 
-LyricsProviders::LyricsProviders(QObject *parent) : QObject(parent), thread_(new QThread(this)), network_(make_shared<NetworkAccessManager>()) {
+LyricsProviders::LyricsProviders(QObject *parent) : QObject(parent), network_(make_shared<NetworkAccessManager>()) {
 
   setObjectName(QLatin1String(QObject::metaObject()->className()));
-  thread_->setObjectName(objectName());
-  network_->moveToThread(thread_);
-  thread_->start();
 
 }
 
 LyricsProviders::~LyricsProviders() {
-
-  // Abort pending network replies from the worker thread while its event loop is still running.
-  // Aborting from the main thread after the worker stops triggers Qt's cross-thread sendEvent assert.
-  const QList<LyricsProvider*> providers = lyrics_providers_.keys();
-  for (LyricsProvider *provider : providers) {
-    QMetaObject::invokeMethod(provider, &HttpBaseRequest::AbortNetworkReplies, Qt::BlockingQueuedConnection);
-  }
-
-  // Stop the worker thread - the providers were moved to it, and deleting a QObject while its owning thread is still running is undefined behaviour.
-  thread_->quit();
-  thread_->wait(1000);
 
   while (!lyrics_providers_.isEmpty()) {
     delete lyrics_providers_.firstKey();
@@ -116,8 +102,6 @@ LyricsProvider *LyricsProviders::ProviderByName(const QString &name) const {
 }
 
 void LyricsProviders::AddProvider(LyricsProvider *provider) {
-
-  provider->moveToThread(thread_);
 
   {
     QMutexLocker locker(&mutex_);

--- a/src/lyrics/lyricsproviders.h
+++ b/src/lyrics/lyricsproviders.h
@@ -29,7 +29,6 @@
 #include <QMap>
 #include <QString>
 #include <QAtomicInt>
-#include <QThread>
 
 #include "includes/shared_ptr.h"
 
@@ -62,11 +61,9 @@ class LyricsProviders : public QObject {
 
   static int NextOrderId;
 
-  QThread *thread_;
   const SharedPtr<NetworkAccessManager> network_;
 
   QMap<LyricsProvider*, QString> lyrics_providers_;
-  QList<LyricsProvider*> ordered_providers_;
   QMutex mutex_;
 
   QAtomicInt next_id_;

--- a/src/lyrics/musixmatchlyricsprovider.cpp
+++ b/src/lyrics/musixmatchlyricsprovider.cpp
@@ -1,6 +1,6 @@
 /*
  * Strawberry Music Player
- * Copyright 2020-2025, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2020-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,8 +22,6 @@
 #include <utility>
 #include <memory>
 
-#include <QApplication>
-#include <QThread>
 #include <QByteArray>
 #include <QVariant>
 #include <QString>
@@ -57,8 +55,6 @@ constexpr char kApiKey[] = "Y2FhMDRlN2Y4OWE5OTIxYmZlOGMzOWQzOGI3ZGU4MjE=";
 MusixmatchLyricsProvider::MusixmatchLyricsProvider(const SharedPtr<NetworkAccessManager> network, QObject *parent) : JsonLyricsProvider(u"Musixmatch"_s, false, false, network, parent), use_api_(true) {}
 
 void MusixmatchLyricsProvider::StartSearch(const int id, const LyricsSearchRequest &request) {
-
-  Q_ASSERT(QThread::currentThread() != qApp->thread());
 
   LyricsSearchContextPtr search = make_shared<LyricsSearchContext>();
   search->id = id;
@@ -150,8 +146,6 @@ MusixmatchLyricsProvider::JsonObjectResult MusixmatchLyricsProvider::ParseJsonOb
 }
 
 void MusixmatchLyricsProvider::HandleSearchReply(QNetworkReply *reply, LyricsSearchContextPtr search) {
-
-  Q_ASSERT(QThread::currentThread() != qApp->thread());
 
   const QScopeGuard end_search = qScopeGuard([this, search]() { EndSearch(search); });
 
@@ -306,8 +300,6 @@ bool MusixmatchLyricsProvider::SendLyricsRequest(LyricsSearchContextPtr search, 
 }
 
 void MusixmatchLyricsProvider::HandleLyricsReply(QNetworkReply *reply, LyricsSearchContextPtr search, const QUrl &url) {
-
-  Q_ASSERT(QThread::currentThread() != qApp->thread());
 
   const QScopeGuard end_search = qScopeGuard([this, search, url]() { EndSearch(search, url); });
 

--- a/src/lyrics/musixmatchlyricsprovider.h
+++ b/src/lyrics/musixmatchlyricsprovider.h
@@ -1,6 +1,6 @@
 /*
  * Strawberry Music Player
- * Copyright 2020-2025, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2020-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/lyrics/ovhlyricsprovider.cpp
+++ b/src/lyrics/ovhlyricsprovider.cpp
@@ -1,6 +1,6 @@
 /*
  * Strawberry Music Player
- * Copyright 2019-2025, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2019-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,8 +19,6 @@
 
 #include "config.h"
 
-#include <QApplication>
-#include <QThread>
 #include <QVariant>
 #include <QString>
 #include <QUrl>
@@ -46,8 +44,6 @@ constexpr char kUrlSearch[] = "https://api.lyrics.ovh/v1/";
 OVHLyricsProvider::OVHLyricsProvider(const SharedPtr<NetworkAccessManager> network, QObject *parent) : JsonLyricsProvider(u"Lyrics.ovh"_s, true, false, network, parent) {}
 
 void OVHLyricsProvider::StartSearch(const int id, const LyricsSearchRequest &request) {
-
-  Q_ASSERT(QThread::currentThread() != qApp->thread());
 
   const QUrl url(QLatin1String(kUrlSearch) + QString::fromLatin1(QUrl::toPercentEncoding(request.artist)) + '/'_L1 + QString::fromLatin1(QUrl::toPercentEncoding(request.title)));
   QNetworkReply *reply = CreateGetRequest(url);

--- a/src/lyrics/ovhlyricsprovider.h
+++ b/src/lyrics/ovhlyricsprovider.h
@@ -1,6 +1,6 @@
 /*
  * Strawberry Music Player
- * Copyright 2019-2025, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2019-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/lyrics/songlyricscomlyricsprovider.cpp
+++ b/src/lyrics/songlyricscomlyricsprovider.cpp
@@ -1,6 +1,6 @@
 /*
  * Strawberry Music Player
- * Copyright 2023, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2023-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,8 +17,6 @@
  *
  */
 
-#include <QApplication>
-#include <QThread>
 #include <QString>
 #include <QUrl>
 #include <QRegularExpression>
@@ -47,8 +45,6 @@ QUrl SongLyricsComLyricsProvider::Url(const LyricsSearchRequest &request) {
 }
 
 QString SongLyricsComLyricsProvider::StringFixup(QString text) {
-
-  Q_ASSERT(QThread::currentThread() != qApp->thread());
 
   static const QRegularExpression regex_illegal_characters(u"[^\\w0-9\\- ]"_s);
   static const QRegularExpression regex_multiple_whitespaces(u" {2,}"_s);

--- a/src/lyrics/songlyricscomlyricsprovider.h
+++ b/src/lyrics/songlyricscomlyricsprovider.h
@@ -1,6 +1,6 @@
 /*
  * Strawberry Music Player
- * Copyright 2023, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2023-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lyrics search now completes parsing work in the background for faster, smoother results.
  * Several lyric sources now use a more flexible matching approach for extracting lyrics.

* **Bug Fixes**
  * Improved handling of empty, failed, or mismatched lyric responses.
  * Reduced unnecessary delays and improved overall lyrics provider stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->