### PR TITLE
CollectionModel: Handle empty available sizes

### DIFF
--- a/src/collection/collectionmodel.cpp
+++ b/src/collection/collectionmodel.cpp
@@ -111,10 +111,10 @@ CollectionModel::CollectionModel(const SharedPtr<CollectionBackend> backend, con
     QObject::connect(&*albumcover_loader_, &AlbumCoverLoader::AlbumCoverLoaded, this, &CollectionModel::AlbumCoverLoaded);
   }
 
-  QIcon nocover = IconLoader::Load(u"cdcase"_s);
+  const QIcon nocover = IconLoader::Load(u"cdcase"_s);
   if (!nocover.isNull()) {
-    QList<QSize> nocover_sizes = nocover.availableSizes();
-    pixmap_no_cover_ = nocover.pixmap(nocover_sizes.last()).scaled(kPrettyCoverSize, kPrettyCoverSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    const QList<QSize> nocover_sizes = nocover.availableSizes();
+    pixmap_no_cover_ = nocover_sizes.isEmpty() ? nocover.pixmap(kPrettyCoverSize, kPrettyCoverSize) : nocover.pixmap(nocover_sizes.last()).scaled(kPrettyCoverSize, kPrettyCoverSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
   }
 
   icon_disk_cache_->setCacheDirectory(StandardPaths::WritableLocation(StandardPaths::StandardLocation::CacheLocation) + u'/' + QLatin1String(kPixmapDiskCacheDir) + u'-' + Song::TextForSource(backend_->source()));

--- a/src/playlist/playlistsequence.cpp
+++ b/src/playlist/playlistsequence.cpp
@@ -2,7 +2,7 @@
  * Strawberry Music Player
  * This file was part of Clementine.
  * Copyright 2010, David Sansome <me@davidsansome.com>
- * Copyright 2020-2021, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2020-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -120,16 +120,20 @@ void PlaylistSequence::Save() {
 
 QIcon PlaylistSequence::AddDesaturatedIcon(const QIcon &icon) {
 
-  QIcon ret;
-  const QList<QSize> sizes = icon.availableSizes();
-  for (const QSize &size : sizes) {
-    QPixmap on(icon.pixmap(size));
-    QPixmap off(DesaturatedPixmap(on));
-
-    ret.addPixmap(off, QIcon::Normal, QIcon::Off);
-    ret.addPixmap(on, QIcon::Normal, QIcon::On);
+  const QList<QSize> icon_sizes = icon.availableSizes();
+  if (icon_sizes.isEmpty()) {
+    return icon;
   }
-  return ret;
+
+  QIcon new_icon;
+  for (const QSize &icon_size : icon_sizes) {
+    QPixmap on_pixmap(icon.pixmap(icon_size));
+    QPixmap off_pixmap(DesaturatedPixmap(on_pixmap));
+    new_icon.addPixmap(off_pixmap, QIcon::Normal, QIcon::Off);
+    new_icon.addPixmap(on_pixmap, QIcon::Normal, QIcon::On);
+  }
+
+  return new_icon;
 
 }
 

--- a/src/playlist/playlistsequence.h
+++ b/src/playlist/playlistsequence.h
@@ -2,7 +2,7 @@
  * Strawberry Music Player
  * This file was part of Clementine.
  * Copyright 2010, David Sansome <me@davidsansome.com>
- * Copyright 2020-2021, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2020-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/widgets/ratingwidget.cpp
+++ b/src/widgets/ratingwidget.cpp
@@ -62,8 +62,8 @@ RatingPainter::RatingPainter() {
       else if (rating - 0.75 <= y) {  // Half full
         const QRect target_left(rect.x(), rect.y(), kStarSize / 2, kStarSize);
         const QRect target_right(rect.x() + kStarSize / 2, rect.y(), kStarSize / 2, kStarSize);
-        const QRect source_left(0, 0, kStarSize / 2, kStarSize);
-        const QRect source_right(kStarSize / 2, 0, kStarSize / 2, kStarSize);
+        const QRect source_left(0, 0, star_on_pixmap.width() / 2, star_on_pixmap.height());
+        const QRect source_right(star_off_pixmap.width() / 2, 0, star_off_pixmap.width() / 2, star_off_pixmap.height());
         p.drawPixmap(target_left, star_on_pixmap, source_left);
         p.drawPixmap(target_right, star_off_pixmap, source_right);
       }

--- a/src/widgets/ratingwidget.cpp
+++ b/src/widgets/ratingwidget.cpp
@@ -2,6 +2,7 @@
  * Strawberry Music Player
  * This file was part of Clementine.
  * Copyright 2010, David Sansome <me@davidsansome.com>
+ * Copyright 2018-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,13 +34,13 @@ using namespace Qt::Literals::StringLiterals;
 
 RatingPainter::RatingPainter() {
 
-  // Load the base pixmaps
-  QIcon star_on(u":/pictures/star-on.png"_s);
-  QList<QSize> star_on_sizes = star_on.availableSizes();
-  QPixmap on(star_on.pixmap(star_on_sizes.last()));
-  QIcon star_off(u":/pictures/star-off.png"_s);
-  QList<QSize> star_off_sizes = star_off.availableSizes();
-  QPixmap off(star_off.pixmap(star_off_sizes.last()));
+  const QIcon star_on_icon(u":/pictures/star-on.png"_s);
+  const QList<QSize> star_on_icon_sizes = star_on_icon.availableSizes();
+  const QPixmap star_on_pixmap = star_on_icon_sizes.isEmpty() ? star_on_icon.pixmap(kStarSize, kStarSize) : star_on_icon.pixmap(star_on_icon_sizes.last());
+
+  const QIcon star_off_icon(u":/pictures/star-off.png"_s);
+  const QList<QSize> star_off_icon_sizes = star_off_icon.availableSizes();
+  const QPixmap star_off_pixmap = star_off_icon_sizes.isEmpty() ? star_off_icon.pixmap(kStarSize, kStarSize) : star_off_icon.pixmap(star_off_icon_sizes.last());
 
   // Generate the 10 states, better to do it now than on the fly
   for (int i = 0; i < kStarCount * 2 + 1; ++i) {
@@ -56,21 +57,22 @@ RatingPainter::RatingPainter() {
       const QRect rect(x, 0, kStarSize, kStarSize);
 
       if (rating - 0.25 <= y) {  // Totally empty
-        p.drawPixmap(rect, off);
+        p.drawPixmap(rect, star_off_pixmap);
       }
       else if (rating - 0.75 <= y) {  // Half full
         const QRect target_left(rect.x(), rect.y(), kStarSize / 2, kStarSize);
         const QRect target_right(rect.x() + kStarSize / 2, rect.y(), kStarSize / 2, kStarSize);
         const QRect source_left(0, 0, kStarSize / 2, kStarSize);
         const QRect source_right(kStarSize / 2, 0, kStarSize / 2, kStarSize);
-        p.drawPixmap(target_left, on, source_left);
-        p.drawPixmap(target_right, off, source_right);
+        p.drawPixmap(target_left, star_on_pixmap, source_left);
+        p.drawPixmap(target_right, star_off_pixmap, source_right);
       }
       else {  // Totally full
-        p.drawPixmap(rect, on);
+        p.drawPixmap(rect, star_on_pixmap);
       }
     }
   }
+
 }
 
 QRect RatingPainter::Contents(const QRect rect) {

--- a/src/widgets/ratingwidget.h
+++ b/src/widgets/ratingwidget.h
@@ -2,6 +2,7 @@
  * Strawberry Music Player
  * This file was part of Clementine.
  * Copyright 2010, David Sansome <me@davidsansome.com>
+ * Copyright 2018-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Fixes crash with svg nocover icon.

Fixes #2171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “no cover” icon handling to safely render when an icon reports no available pixmap sizes.
  * Updated rating star rendering to select an available pixmap size when present, including accurate half-star composition based on the actual loaded dimensions.
  * Improved desaturated playlist icons by reusing available pixmap sizes and preserving the original icon when no sizes are available.
* **Chores**
  * Refreshed copyright years across the affected components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->