### PR TITLE
GstEnginePipeline: Add device warmup delay

### DIFF
--- a/src/constants/backendsettings.h
+++ b/src/constants/backendsettings.h
@@ -45,6 +45,7 @@ constexpr char kStrictSSL[] = "strict_ssl";
 constexpr char kBufferDuration[] = "bufferduration";
 constexpr char kBufferLowWatermark[] = "bufferlowwatermark";
 constexpr char kBufferHighWatermark[] = "bufferhighwatermark";
+constexpr char kDeviceWarmupDuration[] = "devicewarmupduration";
 constexpr char kRgEnabled[] = "rgenabled";
 constexpr char kRgMode[] = "rgmode";
 constexpr char kRgPreamp[] = "rgpreamp";
@@ -63,6 +64,7 @@ constexpr char kFadeoutPauseDuration[] = "FadeoutPauseDuration";
 constexpr qint64 kDefaultBufferDuration = 4000;
 constexpr double kDefaultBufferLowWatermark = 0.33;
 constexpr double kDefaultBufferHighWatermark = 0.99;
+constexpr int kDefaultDeviceWarmupDuration = 500;
 
 }  // namespace BackendSettings
 

--- a/src/engine/enginebase.cpp
+++ b/src/engine/enginebase.cpp
@@ -68,6 +68,7 @@ EngineBase::EngineBase(QObject *parent)
       buffer_duration_nanosec_(BackendSettings::kDefaultBufferDuration * kNsecPerMsec),
       buffer_low_watermark_(BackendSettings::kDefaultBufferLowWatermark),
       buffer_high_watermark_(BackendSettings::kDefaultBufferHighWatermark),
+      device_warmup_duration_ms_(BackendSettings::kDefaultDeviceWarmupDuration),
       fadeout_enabled_(true),
       crossfade_enabled_(true),
       autocrossfade_enabled_(false),
@@ -172,6 +173,8 @@ void EngineBase::ReloadSettings() {
   buffer_duration_nanosec_ = s.value(BackendSettings::kBufferDuration, BackendSettings::kDefaultBufferDuration).toULongLong() * kNsecPerMsec;
   buffer_low_watermark_ = s.value(BackendSettings::kBufferLowWatermark, BackendSettings::kDefaultBufferLowWatermark).toDouble();
   buffer_high_watermark_ = s.value(BackendSettings::kBufferHighWatermark, BackendSettings::kDefaultBufferHighWatermark).toDouble();
+
+  device_warmup_duration_ms_ = s.value(BackendSettings::kDeviceWarmupDuration, BackendSettings::kDefaultDeviceWarmupDuration).toInt();
 
   rg_enabled_ = s.value(BackendSettings::kRgEnabled, false).toBool();
   rg_mode_ = s.value(BackendSettings::kRgMode, 0).toInt();

--- a/src/engine/enginebase.h
+++ b/src/engine/enginebase.h
@@ -217,6 +217,9 @@ class EngineBase : public QObject {
   double buffer_low_watermark_;
   double buffer_high_watermark_;
 
+  // Audio device (DAC) warm-up delay in milliseconds inserted between preroll (PAUSED) and playback (PLAYING) to give the device time to become ready, avoiding the start of the track being cut off.
+  int device_warmup_duration_ms_;
+
   // Fadeout
   bool fadeout_enabled_;
   bool crossfade_enabled_;

--- a/src/engine/gstengine.cpp
+++ b/src/engine/gstengine.cpp
@@ -932,6 +932,7 @@ GstEnginePipelinePtr GstEngine::CreatePipeline() {
   pipeline->set_buffer_duration_nanosec(buffer_duration_nanosec_);
   pipeline->set_buffer_low_watermark(buffer_low_watermark_);
   pipeline->set_buffer_high_watermark(buffer_high_watermark_);
+  pipeline->set_device_warmup_duration_ms(device_warmup_duration_ms_);
   pipeline->set_proxy_settings(proxy_address_, proxy_authentication_, proxy_user_, proxy_pass_);
   pipeline->set_channels(channels_enabled_, channels_);
   pipeline->set_bs2b_enabled(bs2b_enabled_);

--- a/src/engine/gstenginepipeline.cpp
+++ b/src/engine/gstenginepipeline.cpp
@@ -138,6 +138,9 @@ GstEnginePipeline::GstEnginePipeline(QObject *parent)
       buffer_duration_nanosec_(BackendSettings::kDefaultBufferDuration * kNsecPerMsec),
       buffer_low_watermark_(BackendSettings::kDefaultBufferLowWatermark),
       buffer_high_watermark_(BackendSettings::kDefaultBufferHighWatermark),
+      device_warmup_duration_ms_(BackendSettings::kDefaultDeviceWarmupDuration),
+      device_warmup_pending_(false),
+      device_warmup_generation_(0),
       proxy_authentication_(false),
       channels_enabled_(false),
       channels_(0),
@@ -323,6 +326,10 @@ void GstEnginePipeline::set_buffer_low_watermark(const double value) {
 
 void GstEnginePipeline::set_buffer_high_watermark(const double value) {
   buffer_high_watermark_ = value;
+}
+
+void GstEnginePipeline::set_device_warmup_duration_ms(const int duration_ms) {
+  device_warmup_duration_ms_ = duration_ms;
 }
 
 void GstEnginePipeline::set_proxy_settings(const QString &address, const bool authentication, const QString &user, const QString &pass) {
@@ -1883,6 +1890,13 @@ void GstEnginePipeline::StateChangedMessageReceived(GstMessage *msg) {
     SetVolume(volume_percent_.load());
   }
 
+  // Warm-up delay for a fresh start without an offset: the pipeline has prerolled (the audio device is now open), so wait before starting playback to let the device (DAC) become ready, then go to PLAYING.
+  // (The offset/seek start applies the same delay from Seek() once the seek completes.)
+  if (new_state == GST_STATE_PAUSED && device_warmup_pending_.exchange(false)) {
+    StartPlaybackAfterWarmup();
+    return;
+  }
+
   if (next_uri_set_.load() && next_uri_need_reset_.load() && new_state == GST_STATE_READY && pending_seek_nanosec_.load() != -1) {
     qLog(Debug) << "Reverting next uri and going to pause state.";
     next_uri_set_ = false;
@@ -2052,6 +2066,9 @@ QFuture<GstStateChangeReturn> GstEnginePipeline::SetState(const GstState state) 
 
   qLog(Debug) << "Setting pipeline" << id() << "state to" << GstStateText(state);
 
+  // Every explicit transition invalidates any warm-up timer waiting to resume playback, so a stale timer cannot override a newer pause/stop/start.
+  ++device_warmup_generation_;
+
   QFutureWatcher<GstStateChangeReturn> *watcher = new QFutureWatcher<GstStateChangeReturn>(this);
   QObject::connect(watcher, &QFutureWatcher<GstStateChangeReturn>::finished, this, [this, watcher, state]() {
     const GstStateChangeReturn state_change_return = watcher->result();
@@ -2126,9 +2143,45 @@ QFuture<GstStateChangeReturn> GstEnginePipeline::Play(const bool pause, const qu
     return SetState(GST_STATE_PAUSED);
   }
 
-  // No offset: go straight to the requested state.
-  // playbin prerolls (opens the audio device and fills buffers) during READY->PAUSED regardless of whether PAUSED or PLAYING is requested, so an explicit PAUSED->PLAYING hop here changes nothing - it does not give the audio device (DAC) any additional time to become ready.
+  if (!pause && device_warmup_duration_ms_ > 0) {
+    // Preroll to PAUSED first, then wait device_warmup_duration_ms_ before going to PLAYING (handled in StateChangedMessageReceived once PAUSED is reached).
+    // This gives the audio device (DAC) time to become ready after it is opened during preroll, so the start of the track is not cut off while the hardware is still warming up.
+    device_warmup_pending_ = true;
+    return SetState(GST_STATE_PAUSED);
+  }
+
+  // No offset and no warm-up: go straight to the requested state.
+  // playbin prerolls (opens the audio device and fills buffers) during READY->PAUSED regardless of whether PAUSED or PLAYING is requested, so an explicit PAUSED->PLAYING hop on its own changes nothing.
   return SetState(pause ? GST_STATE_PAUSED : GST_STATE_PLAYING);
+
+}
+
+void GstEnginePipeline::StartPlaybackAfterWarmup() {
+
+  // Nothing to do if the pipeline is already playing.
+  if (state() == GST_STATE_PLAYING) return;
+
+  // The pipeline has prerolled and the audio device is open; wait for the configured warm-up delay (if any) so the device (DAC) has time to become ready before playback starts, then transition to PLAYING.
+  if (device_warmup_duration_ms_ > 0) {
+    qLog(Debug) << "Waiting" << device_warmup_duration_ms_ << "ms for the audio device to warm up before playing";
+    const quint64 device_warmup_generation = device_warmup_generation_.load();
+    QTimer::singleShot(device_warmup_duration_ms_, this, [this, device_warmup_generation]() {
+      // Only resume if no newer transition happened while we were waiting (e.g. the user paused/stopped or a newer start superseded this one)...
+      if (device_warmup_generation != device_warmup_generation_.load()) {
+        qLog(Debug) << "Warm-up delay elapsed but a newer state change superseded it, not starting playback";
+        return;
+      }
+      // ...and the pipeline is still paused (it was not stopped and did not otherwise leave the prerolled state).
+      if (state() != GST_STATE_PAUSED) {
+        qLog(Debug) << "Warm-up delay elapsed but pipeline is" << GstStateText(state()) << "not paused, not starting playback";
+        return;
+      }
+      SetStateAsync(GST_STATE_PLAYING);
+    });
+  }
+  else {
+    SetStateAsync(GST_STATE_PLAYING);
+  }
 
 }
 
@@ -2165,10 +2218,14 @@ bool GstEnginePipeline::Seek(const qint64 nanosec) {
 
   if (success) {
     qLog(Debug) << "Seek succeeded";
-    if (pending_state_.load() != GST_STATE_NULL) {
-      qLog(Debug) << "Setting state from pending state" << GstStateText(pending_state_.load());
-      SetState(pending_state_.load());
-      pending_state_ = GST_STATE_NULL;
+    const GstState state = pending_state_.exchange(GST_STATE_NULL);
+    if (state == GST_STATE_PLAYING) {
+      // Starting playback from an offset (saved position or CUE-sheet start): the device was opened during preroll, so honour the warm-up delay here too before going to PLAYING.
+      StartPlaybackAfterWarmup();
+    }
+    else if (state != GST_STATE_NULL) {
+      qLog(Debug) << "Setting state from pending state" << GstStateText(state);
+      SetState(state);
     }
   }
 

--- a/src/engine/gstenginepipeline.h
+++ b/src/engine/gstenginepipeline.h
@@ -78,6 +78,7 @@ class GstEnginePipeline : public QObject {
   void set_buffer_duration_nanosec(const quint64 duration_nanosec);
   void set_buffer_low_watermark(const double value);
   void set_buffer_high_watermark(const double value);
+  void set_device_warmup_duration_ms(const int duration_ms);
   void set_proxy_settings(const QString &address, const bool authentication, const QString &user, const QString &pass);
   void set_channels(const bool enabled, const int channels);
   void set_bs2b_enabled(const bool enabled);
@@ -171,6 +172,7 @@ class GstEnginePipeline : public QObject {
   double PercentToInternalVolume(const uint volume_percent) const;
   uint InternalVolumeToPercent(const double volume_internal) const;
   void SetStateAsync(const GstState state);
+  void StartPlaybackAfterWarmup();
   void EmitFinishedIfQuiescent();
   void SetNextUrl();
 
@@ -244,6 +246,13 @@ class GstEnginePipeline : public QObject {
   quint64 buffer_duration_nanosec_;
   double buffer_low_watermark_;
   double buffer_high_watermark_;
+
+  // Audio device (DAC) warm-up delay in milliseconds inserted between preroll (PAUSED) and playback (PLAYING); 0 disables it.
+  int device_warmup_duration_ms_;
+  // Set for a fresh non-paused start with a warm-up delay configured, so the first time the pipeline reaches PAUSED we wait before going to PLAYING.  One-shot per Play().
+  std::atomic<bool> device_warmup_pending_;
+  // Bumped by every SetState() call so a scheduled warm-up timer can detect that a newer transition (e.g. the user paused/stopped, or a newer start) superseded it and skip resuming playback.
+  std::atomic<quint64> device_warmup_generation_;
 
   // Proxy
   QString proxy_address_;

--- a/src/settings/backendsettingspage.cpp
+++ b/src/settings/backendsettingspage.cpp
@@ -187,6 +187,7 @@ void BackendSettingsPage::Load() {
   ui_->spinbox_bufferduration->setValue(s.value(kBufferDuration, kDefaultBufferDuration).toInt());
   ui_->spinbox_low_watermark->setValue(s.value(kBufferLowWatermark, kDefaultBufferLowWatermark).toDouble());
   ui_->spinbox_high_watermark->setValue(s.value(kBufferHighWatermark, kDefaultBufferHighWatermark).toDouble());
+  ui_->spinbox_device_warmup->setValue(s.value(kDeviceWarmupDuration, kDefaultDeviceWarmupDuration).toInt());
 
   ui_->radiobutton_replaygain->setChecked(s.value(kRgEnabled, false).toBool());
   ui_->combobox_replaygainmode->setCurrentIndex(s.value(kRgMode, 0).toInt());
@@ -452,6 +453,7 @@ void BackendSettingsPage::Save() {
   s.setValue(kBufferDuration, ui_->spinbox_bufferduration->value());
   s.setValue(kBufferLowWatermark, ui_->spinbox_low_watermark->value());
   s.setValue(kBufferHighWatermark, ui_->spinbox_high_watermark->value());
+  s.setValue(kDeviceWarmupDuration, ui_->spinbox_device_warmup->value());
 
   s.setValue(kRgEnabled, ui_->radiobutton_replaygain->isChecked());
   s.setValue(kRgMode, ui_->combobox_replaygainmode->currentIndex());
@@ -766,6 +768,7 @@ void BackendSettingsPage::BufferDefaults() {
   ui_->spinbox_bufferduration->setValue(kDefaultBufferDuration);
   ui_->spinbox_low_watermark->setValue(kDefaultBufferLowWatermark);
   ui_->spinbox_high_watermark->setValue(kDefaultBufferHighWatermark);
+  ui_->spinbox_device_warmup->setValue(kDefaultDeviceWarmupDuration);
 
 }
 

--- a/src/settings/backendsettingspage.ui
+++ b/src/settings/backendsettingspage.ui
@@ -432,6 +432,45 @@
           </property>
          </spacer>
         </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_device_warmup">
+          <property name="text">
+           <string>Device warm-up</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QSpinBox" name="spinbox_device_warmup">
+          <property name="toolTip">
+           <string>Delay between opening the audio device and starting playback, to avoid the start of the track being cut off while the device (DAC) is still becoming ready.  Set to 0 to disable.</string>
+          </property>
+          <property name="suffix">
+           <string> ms</string>
+          </property>
+          <property name="maximum">
+           <number>5000</number>
+          </property>
+          <property name="singleStep">
+           <number>50</number>
+          </property>
+          <property name="value">
+           <number>500</number>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="2">
+         <spacer name="spacer_buffer_4">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
        </layout>
       </item>
       <item>
@@ -897,6 +936,7 @@
   <tabstop>spinbox_bufferduration</tabstop>
   <tabstop>spinbox_low_watermark</tabstop>
   <tabstop>spinbox_high_watermark</tabstop>
+  <tabstop>spinbox_device_warmup</tabstop>
   <tabstop>button_buffer_defaults</tabstop>
   <tabstop>radiobutton_no_audio_normalization</tabstop>
   <tabstop>radiobutton_replaygain</tabstop>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Device warm-up** setting (ms) to configure an optional delay before playback starts.
  * The setting is saved and restored (default: **500 ms**); setting **0** disables the delay.
  * Playback now inserts this warm-up step between preroll and audio output.

* **Bug Fixes**
  * Improved warm-up timing so outdated warm-up delays can’t trigger playback after later state changes.
  * Seek-based starts now respect the warm-up behavior when starting playback after the seek.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->