### PR TITLE
Use temporary file when editing tag for files on GVFS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -443,6 +443,7 @@ set(SOURCES
   src/core/sqlrow.cpp
   src/core/metatypes.cpp
   src/core/deletefiles.cpp
+  src/core/filewriteguard.cpp
   src/core/filesystemmusicstorage.cpp
   src/core/filesystemwatcherinterface.cpp
   src/core/mergedproxymodel.cpp

--- a/src/core/filewriteguard.cpp
+++ b/src/core/filewriteguard.cpp
@@ -1,0 +1,99 @@
+/*
+ * Strawberry Music Player
+ * Copyright 2026, Jonas Kvinge <jonas@jkvinge.net>
+ *
+ * Strawberry is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Strawberry is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Strawberry.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "config.h"
+
+#include <cstdio>
+
+#include <QtGlobal>
+#include <QFileInfo>
+#include <QDir>
+#include <QFile>
+#include <QTemporaryFile>
+#include <QString>
+
+#include "core/logging.h"
+#include "utilities/fileutils.h"
+#include "filewriteguard.h"
+
+using namespace Qt::Literals::StringLiterals;
+
+FileWriteGuard::FileWriteGuard(const QString &filename)
+    : filename_(filename),
+      working_filename_(filename),
+      active_(Utilities::FilenameOnGVFS(filename)) {}
+
+bool FileWriteGuard::Init() {
+
+  if (!active_) return true;
+
+  temp_file_.setFileTemplate(QDir::tempPath() + "/strawberry_tag_XXXXXX."_L1 + QFileInfo(filename_).suffix());
+  if (!temp_file_.open()) {
+    qLog(Error) << "Failed to create temporary file for" << filename_ << ":" << temp_file_.errorString();
+    return false;
+  }
+  working_filename_ = temp_file_.fileName();
+  temp_file_.close();
+
+  qLog(Debug) << "File" << filename_ << "is on a GVFS mount, editing via temporary file" << working_filename_;
+
+  return Utilities::CopyFileContents(filename_, working_filename_);
+
+}
+
+bool FileWriteGuard::Commit() {
+
+  if (!active_) return true;
+
+  // Write to a temporary file in the same directory as the destination and then atomically rename it into place.
+  // Copying directly over the destination would truncate it up front and leave it corrupted if the write failed partway; renaming means the original is only ever replaced by a complete file.
+  // active_ is only set for GVFS paths (Linux), so std::rename here always operates on POSIX, where it atomically replaces an existing destination on the same filesystem.
+  const QFileInfo fileinfo(filename_);
+
+  // Capture the original file's permissions so they can be restored: QTemporaryFile creates the temporary file with restrictive (owner-only) permissions, and it would otherwise carry those over to the destination once renamed into place.
+  const QFile::Permissions permissions = QFile::permissions(filename_);
+
+  QTemporaryFile temp_file(fileinfo.absolutePath() + "/.strawberry_tag_XXXXXX"_L1);
+  if (!temp_file.open()) {
+    qLog(Error) << "Failed to create temporary file next to" << filename_ << ":" << temp_file.errorString();
+    return false;
+  }
+  const QString temp_filename = temp_file.fileName();
+  temp_file.close();
+
+  if (!Utilities::CopyFileContents(working_filename_, temp_filename)) {
+    return false;
+  }
+
+  // Restore the destination's original permissions on the temporary file before it replaces the destination.
+  if (permissions != QFile::Permissions() && !QFile::setPermissions(temp_filename, permissions)) {
+    qLog(Warning) << "Failed to restore permissions on" << temp_filename;
+  }
+
+  if (std::rename(QFile::encodeName(temp_filename).constData(), QFile::encodeName(filename_).constData()) != 0) {
+    qLog(Error) << "Failed to rename temporary file" << temp_filename << "to" << filename_;
+    return false;
+  }
+
+  // The temporary file has been renamed over the destination, so don't try to remove it on destruction.
+  temp_file.setAutoRemove(false);
+
+  return true;
+
+}

--- a/src/core/filewriteguard.h
+++ b/src/core/filewriteguard.h
@@ -1,0 +1,58 @@
+/*
+ * Strawberry Music Player
+ * Copyright 2026, Jonas Kvinge <jonas@jkvinge.net>
+ *
+ * Strawberry is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Strawberry is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Strawberry.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef FILEWRITEGUARD_H
+#define FILEWRITEGUARD_H
+
+#include "config.h"
+
+#include <QtGlobal>
+#include <QString>
+#include <QTemporaryFile>
+
+// Helper for writing to files on filesystems that do not support the random, in-place writes TagLib performs when a tag's size changes, currently GVFS mounts (GNOME's virtual filesystem, e.g. /run/user/<uid>/gvfs/... or the older ~/.gvfs/...).
+// Those mounts expose backends such as sftp, smb and mtp where the whole file has to be rewritten instead.
+// For such files this edits a local temporary copy (with the same extension so TagLib detects the type) and, once TagLib is done, the caller copies it back over the original with a full sequential write via Commit().
+// For ordinary files (and other FUSE filesystems like sshfs, which do support in-place writes) it is a no-op passthrough. The temporary file is removed when the guard goes out of scope.
+class FileWriteGuard {
+ public:
+  explicit FileWriteGuard(const QString &filename);
+
+  // Whether the file needs to be edited via a temporary copy.
+  bool active() const { return active_; }
+
+  // Prepares the working file (copies the original to a local temporary file when needed). Returns false on failure.
+  bool Init();
+
+  // The file TagLib should open (a local temporary copy when needed, otherwise the original).
+  const QString &working_filename() const { return working_filename_; }
+
+  // Copies the edited temporary file back over the original. Only call after the TagLib stream has been closed so all data is flushed. A no-op for ordinary files.
+  bool Commit();
+
+ private:
+  QString filename_;
+  QString working_filename_;
+  bool active_;
+  QTemporaryFile temp_file_;
+
+  Q_DISABLE_COPY(FileWriteGuard)
+};
+
+#endif  // FILEWRITEGUARD_H

--- a/src/tagreader/tagreadertaglib.cpp
+++ b/src/tagreader/tagreadertaglib.cpp
@@ -103,6 +103,7 @@
 #include "includes/scoped_ptr.h"
 #include "core/logging.h"
 #include "core/song.h"
+#include "core/filewriteguard.h"
 #include "constants/timeconstants.h"
 
 #include "albumcovertagdata.h"
@@ -1104,10 +1105,15 @@ TagReaderResult TagReaderTagLib::WriteFile(const QString &filename, const Song &
     cover = LoadAlbumCoverTagData(filename, save_tag_cover_data);
   }
 
-  ScopedPtr<TagLib::IOStream> stream(factory_->GetReadWriteStream(filename));
+  FileWriteGuard write_guard(filename);
+  if (!write_guard.Init()) {
+    return TagReaderResult::ErrorCode::FileOpenError;
+  }
+
+  ScopedPtr<TagLib::IOStream> stream(factory_->GetReadWriteStream(write_guard.working_filename()));
   ScopedPtr<TagLib::FileRef> fileref(factory_->GetFileRef(&*stream));
   if (!fileref || fileref->isNull()) {
-    qLog(Error) << "TagLib could not open file" << filename;
+    qLog(Error) << "TagLib could not open file" << write_guard.working_filename();
     return TagReaderResult::ErrorCode::FileOpenError;
   }
 
@@ -1323,6 +1329,14 @@ TagReaderResult TagReaderTagLib::WriteFile(const QString &filename, const Song &
   // For all other file types, use default save
   else {
     success = fileref->save();
+  }
+
+  // Tear down the TagLib stream first so all writes are flushed and the temporary file is closed before it is copied back.
+  fileref.reset();
+  stream.reset();
+  if (success && !write_guard.Commit()) {
+    qLog(Error) << "Failed to write edited file back to" << filename;
+    return TagReaderResult::ErrorCode::FileSaveError;
   }
 
   return success ? TagReaderResult(TagReaderResult::ErrorCode::Success) : TagReaderResult(TagReaderResult::ErrorCode::FileSaveError);
@@ -1784,10 +1798,15 @@ TagReaderResult TagReaderTagLib::SaveEmbeddedCover(const QString &filename, cons
     return TagReaderResult::ErrorCode::FileDoesNotExist;
   }
 
-  ScopedPtr<TagLib::IOStream> stream(factory_->GetReadWriteStream(filename));
+  FileWriteGuard write_guard(filename);
+  if (!write_guard.Init()) {
+    return TagReaderResult::ErrorCode::FileOpenError;
+  }
+
+  ScopedPtr<TagLib::IOStream> stream(factory_->GetReadWriteStream(write_guard.working_filename()));
   ScopedPtr<TagLib::FileRef> fileref(factory_->GetFileRef(&*stream));
   if (!fileref || fileref->isNull()) {
-    qLog(Error) << "TagLib could not open file" << filename;
+    qLog(Error) << "TagLib could not open file" << write_guard.working_filename();
     return TagReaderResult::ErrorCode::FileOpenError;
   }
 
@@ -1843,6 +1862,13 @@ TagReaderResult TagReaderTagLib::SaveEmbeddedCover(const QString &filename, cons
   }
 
   const bool success = fileref->file()->save();
+
+  fileref.reset();
+  stream.reset();
+  if (success && !write_guard.Commit()) {
+    qLog(Error) << "Failed to write edited file back to" << filename;
+    return TagReaderResult::ErrorCode::FileSaveError;
+  }
 
   return success ? TagReaderResult::ErrorCode::Success : TagReaderResult::ErrorCode::FileSaveError;
 
@@ -1933,10 +1959,15 @@ TagReaderResult TagReaderTagLib::SaveSongPlaycount(const QString &filename, cons
     return TagReaderResult::ErrorCode::FileDoesNotExist;
   }
 
-  ScopedPtr<TagLib::IOStream> stream(factory_->GetReadWriteStream(filename));
+  FileWriteGuard write_guard(filename);
+  if (!write_guard.Init()) {
+    return TagReaderResult::ErrorCode::FileOpenError;
+  }
+
+  ScopedPtr<TagLib::IOStream> stream(factory_->GetReadWriteStream(write_guard.working_filename()));
   ScopedPtr<TagLib::FileRef> fileref(factory_->GetFileRef(&*stream));
   if (!fileref || fileref->isNull()) {
-    qLog(Error) << "TagLib could not open file" << filename;
+    qLog(Error) << "TagLib could not open file" << write_guard.working_filename();
     return TagReaderResult::ErrorCode::FileOpenError;
   }
 
@@ -1992,6 +2023,13 @@ TagReaderResult TagReaderTagLib::SaveSongPlaycount(const QString &filename, cons
   }
 
   const bool success = fileref->save();
+
+  fileref.reset();
+  stream.reset();
+  if (success && !write_guard.Commit()) {
+    qLog(Error) << "Failed to write edited file back to" << filename;
+    return TagReaderResult::ErrorCode::FileSaveError;
+  }
 
   return success ? TagReaderResult::ErrorCode::Success : TagReaderResult::ErrorCode::FileSaveError;
 
@@ -2058,10 +2096,15 @@ TagReaderResult TagReaderTagLib::SaveSongRating(const QString &filename, const f
     return TagReaderResult::ErrorCode::Success;
   }
 
-  ScopedPtr<TagLib::IOStream> stream(factory_->GetReadWriteStream(filename));
+  FileWriteGuard write_guard(filename);
+  if (!write_guard.Init()) {
+    return TagReaderResult::ErrorCode::FileOpenError;
+  }
+
+  ScopedPtr<TagLib::IOStream> stream(factory_->GetReadWriteStream(write_guard.working_filename()));
   ScopedPtr<TagLib::FileRef> fileref(factory_->GetFileRef(&*stream));
   if (!fileref || fileref->isNull()) {
-    qLog(Error) << "TagLib could not open file" << filename;
+    qLog(Error) << "TagLib could not open file" << write_guard.working_filename();
     return TagReaderResult::ErrorCode::FileOpenError;
   }
 
@@ -2117,7 +2160,14 @@ TagReaderResult TagReaderTagLib::SaveSongRating(const QString &filename, const f
 
   const bool success = fileref->save();
   if (!success) {
-    qLog(Error) << "TagLib hasn't been able to save file" << filename;
+    qLog(Error) << "TagLib hasn't been able to save file" << write_guard.working_filename();
+  }
+
+  fileref.reset();
+  stream.reset();
+  if (success && !write_guard.Commit()) {
+    qLog(Error) << "Failed to write edited file back to" << filename;
+    return TagReaderResult::ErrorCode::FileSaveError;
   }
 
   return success ? TagReaderResult::ErrorCode::Success : TagReaderResult::ErrorCode::FileSaveError;

--- a/src/utilities/fileutils.cpp
+++ b/src/utilities/fileutils.cpp
@@ -22,6 +22,15 @@
 
 #include <memory>
 
+#ifdef Q_OS_UNIX
+#  include <unistd.h>
+#  include <string.h>
+#endif
+
+#ifdef Q_OS_WIN32
+#  include <io.h>
+#endif
+
 #include <QByteArray>
 #include <QString>
 #include <QIODevice>
@@ -137,6 +146,77 @@ bool RemoveRecursive(const QString &path) {
   }
 
   return dir.rmdir(path);
+
+}
+
+// Whether the path is on a GVFS FUSE mount (GNOME's virtual filesystem, e.g. /run/user/<uid>/gvfs/... or the older ~/.gvfs/...).
+// Those mounts expose backends such as sftp, smb and mtp that do not support random, in-place writes; the whole file has to be rewritten instead.  Ordinary FUSE filesystems like sshfs do support in-place writes.
+bool FilenameOnGVFS(const QString &filename) {
+
+#ifdef Q_OS_UNIX
+  return filename.contains(QLatin1String("/gvfs/")) || filename.contains(QLatin1String("/.gvfs/"));
+#else
+  Q_UNUSED(filename)
+  return false;
+#endif  // Q_OS_UNIX
+
+}
+
+// Copies the contents of source over destination (truncating it), streaming in chunks so large files are not held in memory.
+// Unlike QFile::copy() this overwrites an existing destination, and it only writes sequentially from the start.
+bool CopyFileContents(const QString &source, const QString &destination) {
+
+  QFile source_file(source);
+  if (!source_file.open(QIODevice::ReadOnly)) {
+    qLog(Error) << "Failed to open" << source << "for reading:" << source_file.errorString();
+    return false;
+  }
+
+  QFile destination_file(destination);
+  if (!destination_file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+    qLog(Error) << "Failed to open" << destination << "for writing:" << destination_file.errorString();
+    return false;
+  }
+
+  constexpr qint64 kChunkSize = 64 * 1024;
+  for (;;) {
+    const QByteArray chunk = source_file.read(kChunkSize);
+    if (chunk.isEmpty()) break;
+    if (destination_file.write(chunk) != chunk.size()) {
+      qLog(Error) << "Failed to write to" << destination << ":" << destination_file.errorString();
+      return false;
+    }
+  }
+
+  if (source_file.error() != QFileDevice::NoError) {
+    qLog(Error) << "Failed to read from" << source << ":" << source_file.errorString();
+    return false;
+  }
+
+  // Flush and surface any error from closing (e.g. the remote write failing on commit).
+  if (!destination_file.flush()) {
+    qLog(Error) << "Failed to flush" << destination << ":" << destination_file.errorString();
+    return false;
+  }
+
+  // flush() only pushes the data into the OS; force it out to the underlying storage so that deferred write-back failures (common on network/FUSE-backed filesystems such as GVFS) are reported here rather than being silently lost when the file is closed.
+  const int handle = destination_file.handle();
+  if (handle != -1) {
+#ifdef Q_OS_UNIX
+    if (fsync(handle) != 0) {
+      qLog(Error) << "Failed to fsync" << destination << "to storage:" << strerror(errno);
+      return false;
+    }
+#endif
+#ifdef Q_OS_WIN32
+    if (_commit(handle) != 0) {
+      qLog(Error) << "Failed to commit" << destination << "to storage";
+      return false;
+    }
+#endif
+  }
+
+  return true;
 
 }
 

--- a/src/utilities/fileutils.h
+++ b/src/utilities/fileutils.h
@@ -31,6 +31,8 @@ QByteArray ReadDataFromFile(const QString &filename);
 bool Copy(QIODevice *source, QIODevice *destination);
 bool CopyRecursive(const QString &source, const QString &destination);
 bool RemoveRecursive(const QString &path);
+bool FilenameOnGVFS(const QString &filename);
+bool CopyFileContents(const QString &source, const QString &destination);
 
 }  // namespace Utilities
 


### PR DESCRIPTION
Fixes #1696

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved saving of edited music tags and artwork on GVFS/virtual file systems using a safer temporary-file workflow.
  * Added enhanced file-copy support to overwrite destinations reliably by streaming data and forcing persistence.

* **Bug Fixes**
  * Reduced the chance of corrupted or incomplete writes when updating tags, cover art, play counts, or ratings on mounted drives.
  * Save operations now more strictly validate that changes were fully written/committed before reporting success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->