### PR TITLE
Add more color options under appearance settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,6 +478,7 @@ set(SOURCES
   src/core/httpbaserequest.cpp
   src/core/jsonbaserequest.cpp
   src/core/oauthenticator.cpp
+  src/core/appearance.cpp
 
   src/utilities/strutils.cpp
   src/utilities/envutils.cpp
@@ -875,6 +876,7 @@ set(HEADERS
   src/core/httpbaserequest.h
   src/core/jsonbaserequest.h
   src/core/oauthenticator.h
+  src/core/appearance.h
 
   src/tagreader/tagreaderclient.h
   src/tagreader/tagreaderreply.h

--- a/src/constants/appearancesettings.h
+++ b/src/constants/appearancesettings.h
@@ -1,6 +1,6 @@
 /*
  * Strawberry Music Player
- * Copyright 2024, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2024-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,6 +26,21 @@ constexpr char kSettingsGroup[] = "Appearance";
 
 constexpr char kStyle[] = "style";
 constexpr char kSystemThemeIcons[] = "system_icons";
+
+constexpr char kUseCustomColorSet[] = "use-custom-color-set";
+
+// Per-QPalette-role custom colors (the "central roles" from https://doc.qt.io/qt-6/qpalette.html).
+constexpr char kColorWindow[] = "color-window";
+constexpr char kColorWindowText[] = "color-window-text";
+constexpr char kColorBase[] = "color-base";
+constexpr char kColorAlternateBase[] = "color-alternate-base";
+constexpr char kColorToolTipBase[] = "color-tooltip-base";
+constexpr char kColorToolTipText[] = "color-tooltip-text";
+constexpr char kColorText[] = "color-text";
+constexpr char kColorButton[] = "color-button";
+constexpr char kColorButtonText[] = "color-button-text";
+constexpr char kColorBrightText[] = "color-bright-text";
+constexpr char kColorPlaceholderText[] = "color-placeholder-text";
 
 constexpr char kBackgroundImageType[] = "background_image_type";
 constexpr char kBackgroundImageFilename[] = "background_image_file";

--- a/src/core/appearance.cpp
+++ b/src/core/appearance.cpp
@@ -1,0 +1,117 @@
+/*
+ * Strawberry Music Player
+ * Copyright 2026, Jonas Kvinge <jonas@jkvinge.net>
+ *
+ * Strawberry is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Strawberry is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Strawberry.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "config.h"
+
+#include <QApplication>
+#include <QObject>
+#include <QList>
+#include <QMap>
+#include <QPalette>
+#include <QColor>
+
+#include "settings.h"
+#include "appearance.h"
+#include "constants/appearancesettings.h"
+
+Appearance::Appearance(QObject *parent) : QObject(parent), system_palette_(QApplication::palette()) {}
+
+const QList<Appearance::ColorRole> &Appearance::ColorRoles() {
+
+  static const QList<ColorRole> color_roles = {
+    { QPalette::Window, QLatin1String(AppearanceSettings::kColorWindow) },
+    { QPalette::WindowText, QLatin1String(AppearanceSettings::kColorWindowText) },
+    { QPalette::Base, QLatin1String(AppearanceSettings::kColorBase) },
+    { QPalette::AlternateBase, QLatin1String(AppearanceSettings::kColorAlternateBase) },
+    { QPalette::ToolTipBase, QLatin1String(AppearanceSettings::kColorToolTipBase) },
+    { QPalette::ToolTipText, QLatin1String(AppearanceSettings::kColorToolTipText) },
+    { QPalette::Text, QLatin1String(AppearanceSettings::kColorText) },
+    { QPalette::Button, QLatin1String(AppearanceSettings::kColorButton) },
+    { QPalette::ButtonText, QLatin1String(AppearanceSettings::kColorButtonText) },
+    { QPalette::BrightText, QLatin1String(AppearanceSettings::kColorBrightText) },
+    { QPalette::PlaceholderText, QLatin1String(AppearanceSettings::kColorPlaceholderText) }
+  };
+
+  return color_roles;
+
+}
+
+QMap<QPalette::ColorRole, QColor> Appearance::DarkColors() {
+
+  return QMap<QPalette::ColorRole, QColor>{
+    { QPalette::Window, QColor(53, 53, 53) },
+    { QPalette::WindowText, QColor(240, 240, 240) },
+    { QPalette::Base, QColor(35, 35, 35) },
+    { QPalette::AlternateBase, QColor(53, 53, 53) },
+    { QPalette::ToolTipBase, QColor(53, 53, 53) },
+    { QPalette::ToolTipText, QColor(240, 240, 240) },
+    { QPalette::Text, QColor(240, 240, 240) },
+    { QPalette::Button, QColor(53, 53, 53) },
+    { QPalette::ButtonText, QColor(240, 240, 240) },
+    { QPalette::BrightText, QColor(255, 80, 80) },
+    { QPalette::PlaceholderText, QColor(140, 140, 140) }
+  };
+
+}
+
+void Appearance::LoadUserTheme() {
+
+  Settings s;
+  s.beginGroup(AppearanceSettings::kSettingsGroup);
+  const bool use_custom_color_set = s.value(AppearanceSettings::kUseCustomColorSet).toBool();
+
+  if (!use_custom_color_set) {
+    s.endGroup();
+    return;
+  }
+
+  QMap<QPalette::ColorRole, QColor> colors;
+  for (const ColorRole &color_role : ColorRoles()) {
+    const QVariant value = s.value(color_role.settings_key);
+    if (value.isValid()) {
+      const QColor color = value.value<QColor>();
+      if (color.isValid()) {
+        colors.insert(color_role.role, color);
+      }
+    }
+  }
+
+  s.endGroup();
+
+  ChangeColors(colors);
+
+}
+
+void Appearance::ResetToSystemDefaultTheme() {
+  QApplication::setPalette(system_palette_);
+}
+
+void Appearance::ChangeColors(const QMap<QPalette::ColorRole, QColor> &colors) {
+
+  QPalette palette = QApplication::palette();
+
+  for (QMap<QPalette::ColorRole, QColor>::const_iterator it = colors.constBegin(); it != colors.constEnd(); ++it) {
+    if (it.value().isValid()) {
+      palette.setColor(it.key(), it.value());
+    }
+  }
+
+  QApplication::setPalette(palette);
+
+}

--- a/src/core/appearance.h
+++ b/src/core/appearance.h
@@ -1,0 +1,64 @@
+/*
+ * Strawberry Music Player
+ * Copyright 2026, Jonas Kvinge <jonas@jkvinge.net>
+ *
+ * Strawberry is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Strawberry is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Strawberry.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef APPEARANCE_H
+#define APPEARANCE_H
+
+#include "config.h"
+
+#include <QObject>
+#include <QList>
+#include <QMap>
+#include <QString>
+#include <QColor>
+#include <QPalette>
+
+class Appearance : public QObject {
+  Q_OBJECT
+
+ public:
+  explicit Appearance(QObject *parent = nullptr);
+
+  // A configurable QPalette color role and the settings key its custom color is stored under.
+  struct ColorRole {
+    QPalette::ColorRole role;
+    QString settings_key;
+  };
+
+  // The "central roles" from https://doc.qt.io/qt-6/qpalette.html, in the order shown in the settings page.
+  static const QList<ColorRole> &ColorRoles();
+
+  // A suitable set of colors for a dark theme, keyed by palette role (covers all of ColorRoles()).
+  static QMap<QPalette::ColorRole, QColor> DarkColors();
+
+  // The system's default palette, captured before any user theme is applied so it can be restored later.
+  const QPalette &system_palette() const { return system_palette_; }
+  void set_system_palette(const QPalette &palette) { system_palette_ = palette; }
+
+  void LoadUserTheme();
+  void ResetToSystemDefaultTheme();
+
+  // Applies the given per-role colors on top of the current application palette.
+  static void ChangeColors(const QMap<QPalette::ColorRole, QColor> &colors);
+
+ private:
+  QPalette system_palette_;
+};
+
+#endif  // APPEARANCE_H

--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -103,6 +103,7 @@
 #include "core/deletefiles.h"
 #include "core/settings.h"
 #include "core/player.h"
+#include "core/appearance.h"
 #include "utilities/envutils.h"
 #include "utilities/filemanagerutils.h"
 #include "utilities/screenutils.h"
@@ -308,6 +309,7 @@ MainWindow::MainWindow(Application *app,
       smtc_(new WinSystemMediaTransportControls(app->player(), this)),
 #endif
       app_(app),
+      appearance_(make_shared<Appearance>()),
       systemtrayicon_(systemtrayicon),
       osd_(osd),
 #ifdef HAVE_DISCORD_RPC
@@ -990,6 +992,10 @@ MainWindow::MainWindow(Application *app,
   QObject::connect(ui_->action_console, &QAction::triggered, this, &MainWindow::ShowConsole);
   PlayingWidgetPositionChanged(ui_->widget_playing->show_above_status_bar());
 
+  // Load theme
+  // We need to save the default/system palette now, before loading user preferred theme (which will override it), to be able to restore it later
+  appearance_->set_system_palette(QApplication::palette());
+  appearance_->LoadUserTheme();
   StyleSheetLoader *css_loader = new StyleSheetLoader(this);
   css_loader->SetStyleSheet(this, u":/style/strawberry.css"_s);
 
@@ -3044,6 +3050,7 @@ SettingsDialog *MainWindow::CreateSettingsDialog() {
                                                        app_->lyrics_providers(),
                                                        app_->scrobbler(),
                                                        app_->streaming_services(),
+                                                       appearance_,
 #ifdef HAVE_GLOBALSHORTCUTS
                                                        globalshortcuts_manager_,
 #endif

--- a/src/core/mainwindow.h
+++ b/src/core/mainwindow.h
@@ -62,6 +62,7 @@
 #include "covermanager/albumcoverimageresult.h"
 
 class About;
+class Appearance;
 class Console;
 class AlbumCoverManager;
 class Application;
@@ -316,6 +317,7 @@ class MainWindow : public QMainWindow, public PlatformInterface {
 #endif
 
   Application *app_;
+  SharedPtr<Appearance> appearance_;
   SharedPtr<SystemTrayIcon> systemtrayicon_;
   OSDBase *osd_;
 #ifdef HAVE_DISCORD_RPC

--- a/src/settings/appearancesettingspage.cpp
+++ b/src/settings/appearancesettingspage.cpp
@@ -2,7 +2,7 @@
  * Strawberry Music Player
  * This file was part of Clementine.
  * Copyright 2012, David Sansome <me@davidsansome.com>
- * Copyright 2018-2021, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2018-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,7 +27,9 @@
 #include <QWidget>
 #include <QStyleFactory>
 #include <QVariant>
+#include <QMap>
 #include <QString>
+#include <QColor>
 #include <QPalette>
 #include <QColorDialog>
 #include <QFileDialog>
@@ -37,6 +39,7 @@
 #include <QRadioButton>
 #include <QSlider>
 #include <QBoxLayout>
+#include <QFormLayout>
 #include <QCheckBox>
 #include <QComboBox>
 #include <QSpinBox>
@@ -48,6 +51,7 @@
 #include "core/iconloader.h"
 #include "core/stylehelper.h"
 #include "core/settings.h"
+#include "core/appearance.h"
 #include "widgets/fancytabwidget.h"
 #include "settingspage.h"
 #include "settingsdialog.h"
@@ -56,9 +60,11 @@
 using namespace Qt::Literals::StringLiterals;
 using namespace AppearanceSettings;
 
-AppearanceSettingsPage::AppearanceSettingsPage(SettingsDialog *dialog, QWidget *parent)
+AppearanceSettingsPage::AppearanceSettingsPage(SettingsDialog *dialog, SharedPtr<Appearance> appearance, QWidget *parent)
     : SettingsPage(dialog, parent),
       ui_(new Ui_AppearanceSettingsPage),
+      appearance_(appearance),
+      original_use_custom_color_set_(false),
       background_image_type_(BackgroundImageType::Default) {
 
   ui_->setupUi(this);
@@ -78,6 +84,13 @@ AppearanceSettingsPage::AppearanceSettingsPage(SettingsDialog *dialog, QWidget *
 
   QObject::connect(ui_->blur_slider, &QSlider::valueChanged, this, &AppearanceSettingsPage::BlurLevelChanged);
   QObject::connect(ui_->opacity_slider, &QSlider::valueChanged, this, &AppearanceSettingsPage::OpacityLevelChanged);
+
+  QObject::connect(ui_->use_custom_color_set, &QRadioButton::toggled, this, &AppearanceSettingsPage::UseCustomColorSetOptionChanged);
+  QObject::connect(ui_->use_custom_color_set, &QRadioButton::toggled, ui_->widget_custom_colors, &QWidget::setEnabled);
+  QObject::connect(ui_->button_dark_colors, &QPushButton::pressed, this, &AppearanceSettingsPage::SetDarkColors);
+  QObject::connect(ui_->button_reset_colors, &QPushButton::pressed, this, &AppearanceSettingsPage::ResetToDefaultColors);
+
+  CreateColorSelectors();
 
   QObject::connect(ui_->use_default_background, &QRadioButton::toggled, ui_->widget_custom_background_image_options, &AppearanceSettingsPage::setDisabled);
   QObject::connect(ui_->use_no_background, &QRadioButton::toggled, ui_->widget_custom_background_image_options, &AppearanceSettingsPage::setDisabled);
@@ -124,6 +137,25 @@ void AppearanceSettingsPage::Load() {
   ui_->checkbox_system_icons->setChecked(s.value(kSystemThemeIcons, false).toBool());
 #endif
 
+  const QPalette p = QApplication::palette();
+
+  // Keep in mind originals colors, in case the user clicks on Cancel, to be able to restore colors
+  original_use_custom_color_set_ = s.value(kUseCustomColorSet, false).toBool();
+
+  current_colors_.clear();
+  for (const Appearance::ColorRole &color_role : Appearance::ColorRoles()) {
+    const QVariant value = s.value(color_role.settings_key);
+    QColor color = value.isValid() ? value.value<QColor>() : QColor();
+    if (!color.isValid()) {
+      color = p.color(color_role.role);
+    }
+    current_colors_.insert(color_role.role, color);
+  }
+
+  original_colors_ = current_colors_;
+
+  UpdateColorSelectorsColors();
+
   // Tab widget BG color settings.
   bool tabbar_system_color = s.value(kTabBarSystemColor, true).toBool();
   ui_->tabbar_gradient->setChecked(s.value(kTabBarGradient, true).toBool());
@@ -138,6 +170,10 @@ void AppearanceSettingsPage::Load() {
   // Playlist settings
   background_image_type_ = static_cast<BackgroundImageType>(s.value(kBackgroundImageType, static_cast<int>(BackgroundImageType::Default)).toInt());
   background_image_filename_ = s.value(kBackgroundImageFilename).toString();
+
+  ui_->use_system_color_set->setChecked(!original_use_custom_color_set_);
+  ui_->use_custom_color_set->setChecked(original_use_custom_color_set_);
+  ui_->widget_custom_colors->setEnabled(original_use_custom_color_set_);
 
   switch (background_image_type_) {
     case BackgroundImageType::Default:
@@ -208,6 +244,20 @@ void AppearanceSettingsPage::Save() {
   s.setValue(kSystemThemeIcons, ui_->checkbox_system_icons->isChecked());
 #endif
 
+  bool use_custom_color_set = ui_->use_custom_color_set->isChecked();
+  s.setValue(kUseCustomColorSet, use_custom_color_set);
+  if (use_custom_color_set) {
+    for (const Appearance::ColorRole &color_role : Appearance::ColorRoles()) {
+      s.setValue(color_role.settings_key, current_colors_.value(color_role.role));
+    }
+  }
+  else {
+    appearance_->ResetToSystemDefaultTheme();
+    for (const Appearance::ColorRole &color_role : Appearance::ColorRoles()) {
+      s.remove(color_role.settings_key);
+    }
+  }
+
   background_image_filename_ = ui_->background_image_filename->text();
   if (ui_->use_default_background->isChecked()) {
     background_image_type_ = BackgroundImageType::Default;
@@ -261,6 +311,129 @@ void AppearanceSettingsPage::Save() {
   }
 
   s.endGroup();
+
+}
+
+void AppearanceSettingsPage::Cancel() {
+
+  if (original_use_custom_color_set_) {
+    Appearance::ChangeColors(original_colors_);
+  }
+  else {
+    appearance_->ResetToSystemDefaultTheme();
+  }
+
+}
+
+QString AppearanceSettingsPage::ColorRoleLabel(const QPalette::ColorRole role) {
+
+  switch (role) {
+    case QPalette::Window:          return tr("Window");
+    case QPalette::WindowText:      return tr("Window text");
+    case QPalette::Base:            return tr("Base");
+    case QPalette::AlternateBase:   return tr("Alternate base");
+    case QPalette::ToolTipBase:     return tr("Tooltip base");
+    case QPalette::ToolTipText:     return tr("Tooltip text");
+    case QPalette::PlaceholderText: return tr("Placeholder text");
+    case QPalette::Text:            return tr("Text");
+    case QPalette::Button:          return tr("Button");
+    case QPalette::ButtonText:      return tr("Button text");
+    case QPalette::BrightText:      return tr("Bright text");
+    default:                        return QString();
+  }
+
+}
+
+void AppearanceSettingsPage::CreateColorSelectors() {
+
+  QFormLayout *layout = ui_->layout_custom_colors;
+
+  for (const Appearance::ColorRole &color_role : Appearance::ColorRoles()) {
+    QPushButton *button = new QPushButton(ui_->widget_custom_colors);
+    button->setToolTip(tr("Select color"));
+    const QPalette::ColorRole role = color_role.role;
+    QObject::connect(button, &QPushButton::pressed, this, [this, role]() { SelectColor(role); });
+    layout->addRow(ColorRoleLabel(role) + u':', button);
+    color_selectors_.insert(role, button);
+  }
+
+}
+
+void AppearanceSettingsPage::SelectColor(const QPalette::ColorRole role) {
+
+  const QColor color_selected = QColorDialog::getColor(current_colors_.value(role));
+  if (!color_selected.isValid()) return;
+
+  current_colors_[role] = color_selected;
+
+  if (color_selectors_.contains(role)) {
+    UpdateColorSelectorColor(color_selectors_.value(role), color_selected);
+  }
+
+  ApplyCustomColors();
+
+  set_changed();
+
+}
+
+void AppearanceSettingsPage::ApplyCustomColors() {
+  Appearance::ChangeColors(current_colors_);
+}
+
+void AppearanceSettingsPage::SetDarkColors() {
+
+  // Switch to a custom color set and fill it with colors suitable for a dark theme.
+  ui_->use_custom_color_set->setChecked(true);
+
+  const QMap<QPalette::ColorRole, QColor> dark_colors = Appearance::DarkColors();
+  for (const Appearance::ColorRole &color_role : Appearance::ColorRoles()) {
+    if (dark_colors.contains(color_role.role)) {
+      current_colors_[color_role.role] = dark_colors.value(color_role.role);
+    }
+  }
+
+  UpdateColorSelectorsColors();
+  ApplyCustomColors();
+
+  set_changed();
+
+}
+
+void AppearanceSettingsPage::UseCustomColorSetOptionChanged(bool checked) {
+
+  if (checked) {
+    ApplyCustomColors();
+  }
+  else {
+    // Only restore the system palette for the preview; keep the user's custom picks in current_colors_ so they are not lost when switching back to a custom color set.
+    appearance_->ResetToSystemDefaultTheme();
+  }
+
+}
+
+void AppearanceSettingsPage::ResetToDefaultColors() {
+
+  // Reset the custom color set back to the system default colors.
+  const QPalette p = appearance_->system_palette();
+  for (const Appearance::ColorRole &color_role : Appearance::ColorRoles()) {
+    current_colors_[color_role.role] = p.color(color_role.role);
+  }
+
+  UpdateColorSelectorsColors();
+
+  if (ui_->use_custom_color_set->isChecked()) {
+    ApplyCustomColors();
+  }
+
+  set_changed();
+
+}
+
+void AppearanceSettingsPage::UpdateColorSelectorsColors() {
+
+  for (QMap<QPalette::ColorRole, QPushButton*>::const_iterator it = color_selectors_.constBegin(); it != color_selectors_.constEnd(); ++it) {
+    UpdateColorSelectorColor(it.value(), current_colors_.value(it.key()));
+  }
 
 }
 

--- a/src/settings/appearancesettingspage.h
+++ b/src/settings/appearancesettingspage.h
@@ -2,7 +2,7 @@
  * Strawberry Music Player
  * This file was part of Clementine.
  * Copyright 2012, David Sansome <me@davidsansome.com>
- * Copyright 2018-2021, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2018-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,28 +25,36 @@
 #include "config.h"
 
 #include <QObject>
+#include <QMap>
 #include <QString>
 #include <QColor>
+#include <QPalette>
 
+#include "includes/shared_ptr.h"
 #include "settingspage.h"
 #include "constants/appearancesettings.h"
 
 class QWidget;
+class QPushButton;
 
 class SettingsDialog;
 class Ui_AppearanceSettingsPage;
+class Appearance;
 
 class AppearanceSettingsPage : public SettingsPage {
   Q_OBJECT
 
  public:
-  explicit AppearanceSettingsPage(SettingsDialog *dialog, QWidget *parent = nullptr);
+  explicit AppearanceSettingsPage(SettingsDialog *dialog, SharedPtr<Appearance> appearance, QWidget *parent = nullptr);
   ~AppearanceSettingsPage() override;
 
   void Load() override;
   void Save() override;
 
  private Q_SLOTS:
+  void UseCustomColorSetOptionChanged(bool);
+  void SetDarkColors();
+  void ResetToDefaultColors();
   void SelectBackgroundImage();
   void BlurLevelChanged(int);
   void OpacityLevelChanged(int);
@@ -56,11 +64,28 @@ class AppearanceSettingsPage : public SettingsPage {
   void PlaylistPlayingSongSelectColor();
 
  private:
+  void Cancel() override;
+
   // Set the widget's background to new_color
   static void UpdateColorSelectorColor(QWidget *color_selector, const QColor &new_color);
+  // Create a color selector button for each palette role in the custom colors layout.
+  void CreateColorSelectors();
+  // Refresh all custom color selector buttons from current_colors_.
+  void UpdateColorSelectorsColors();
+  // Open a color dialog for the given palette role and apply the result.
+  void SelectColor(const QPalette::ColorRole role);
+  // Apply current_colors_ to the application palette (live preview).
+  void ApplyCustomColors();
+  // Human-readable label for a palette color role.
+  static QString ColorRoleLabel(const QPalette::ColorRole role);
 
   Ui_AppearanceSettingsPage *ui_;
+  const SharedPtr<Appearance> appearance_;
 
+  bool original_use_custom_color_set_;
+  QMap<QPalette::ColorRole, QColor> original_colors_;
+  QMap<QPalette::ColorRole, QColor> current_colors_;
+  QMap<QPalette::ColorRole, QPushButton*> color_selectors_;
   QColor current_tabbar_bg_color_;
   AppearanceSettings::BackgroundImageType background_image_type_;
   QString background_image_filename_;

--- a/src/settings/appearancesettingspage.ui
+++ b/src/settings/appearancesettingspage.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>612</width>
-    <height>1186</height>
+    <height>1166</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -60,6 +60,71 @@
          <string>Use system theme icons</string>
         </property>
        </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupbox_colors">
+     <property name="title">
+      <string>Colors</string>
+     </property>
+     <layout class="QVBoxLayout" name="layout_colors">
+      <item>
+       <widget class="QRadioButton" name="use_system_color_set">
+        <property name="text">
+         <string>&amp;Use the system default color set</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="use_custom_color_set">
+        <property name="text">
+         <string>Use a custom color set</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="widget_custom_colors" native="true">
+        <layout class="QFormLayout" name="layout_custom_colors"/>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="layout_color_presets">
+        <item>
+         <widget class="QPushButton" name="button_dark_colors">
+          <property name="toolTip">
+           <string>Set a custom color set suitable for a dark theme</string>
+          </property>
+          <property name="text">
+           <string>Dark mode</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="button_reset_colors">
+          <property name="toolTip">
+           <string>Reset the custom color set to the system default colors</string>
+          </property>
+          <property name="text">
+           <string>Reset to default</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="spacer_color_presets">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -601,6 +666,8 @@
   </layout>
  </widget>
  <tabstops>
+  <tabstop>use_system_color_set</tabstop>
+  <tabstop>use_custom_color_set</tabstop>
   <tabstop>tabbar_system_color</tabstop>
   <tabstop>tabbar_custom_color</tabstop>
   <tabstop>tabbar_gradient</tabstop>

--- a/src/settings/settingsdialog.cpp
+++ b/src/settings/settingsdialog.cpp
@@ -49,6 +49,7 @@
 
 #include "core/settings.h"
 #include "core/player.h"
+#include "core/appearance.h"
 #include "utilities/screenutils.h"
 #include "widgets/groupediconview.h"
 #include "collection/collectionlibrary.h"
@@ -111,6 +112,7 @@ SettingsDialog::SettingsDialog(const SharedPtr<Player> player,
                                const SharedPtr<LyricsProviders> lyrics_providers,
                                const SharedPtr<AudioScrobbler> scrobbler,
                                const SharedPtr<StreamingServices> streaming_services,
+                               const SharedPtr<Appearance> appearance,
 #ifdef HAVE_GLOBALSHORTCUTS
                                GlobalShortcutsManager *global_shortcuts_manager,
 #endif
@@ -137,7 +139,7 @@ SettingsDialog::SettingsDialog(const SharedPtr<Player> player,
   AddPage(Page::Proxy, new NetworkProxySettingsPage(this, this), general);
 
   QTreeWidgetItem *iface = AddCategory(tr("User interface"));
-  AddPage(Page::Appearance, new AppearanceSettingsPage(this, this), iface);
+  AddPage(Page::Appearance, new AppearanceSettingsPage(this, appearance, this), iface);
   AddPage(Page::Context, new ContextSettingsPage(this, this), iface);
   AddPage(Page::Notifications, new NotificationsSettingsPage(this, osd, this), iface);
 

--- a/src/settings/settingsdialog.h
+++ b/src/settings/settingsdialog.h
@@ -49,6 +49,7 @@ class CoverProviders;
 class LyricsProviders;
 class AudioScrobbler;
 class StreamingServices;
+class Appearance;
 class GlobalShortcutsManager;
 class SettingsPage;
 
@@ -65,6 +66,7 @@ class SettingsDialog : public QDialog {
                           const SharedPtr<LyricsProviders> lyrics_providers,
                           const SharedPtr<AudioScrobbler> scrobbler,
                           const SharedPtr<StreamingServices> streaming_services,
+                          const SharedPtr<Appearance> appearance,
 #ifdef HAVE_GLOBALSHORTCUTS
                           GlobalShortcutsManager *global_shortcuts_manager,
 #endif


### PR DESCRIPTION
Fixes #2063

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added appearance customization in Settings, including choosing between system default and custom colors.
  * Added a dark color preset and a one-click reset to default colors.
  * Theme selections now persist between app launches.

* **Bug Fixes**
  * Improved theme handling so custom colors are applied consistently and invalid color values are ignored.
  * Canceling appearance changes now restores the previous theme state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->