### PR TITLE
FHT: Fix Division by zero [clang-analyzer-core.DivideZero]

### DIFF
--- a/src/analyzer/fht.cpp
+++ b/src/analyzer/fht.cpp
@@ -182,8 +182,11 @@ void FHT::transform8(float *p) {
 
 void FHT::_transform(float *p, int n, int k) {
 
-  if (n == 8) {
-    transform8(p + k);
+  // n <= 8 also covers the degenerate num_ == 0 case (constructed with n < 3), which would otherwise recurse infinitely and divide by zero below.
+  if (n <= 8) {
+    if (n == 8) {
+      transform8(p + k);
+    }
     return;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of very small input sizes in the transform routine.
  * Prevents invalid recursive processing for inputs smaller than 8, avoiding potential crashes or infinite loops in edge cases.
  * Preserves the existing optimized path for inputs of exactly 8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->