### PR TITLE
RadioBrowserSearchView: Sort results by clicking column headers

### DIFF
--- a/src/radios/radiobrowsersearchview.cpp
+++ b/src/radios/radiobrowsersearchview.cpp
@@ -26,6 +26,7 @@
 #include <QMenu>
 #include <QAction>
 #include <QShowEvent>
+#include <QSortFilterProxyModel>
 
 #include "core/iconloader.h"
 #include "core/settings.h"
@@ -45,6 +46,7 @@ RadioBrowserSearchView::RadioBrowserSearchView(QWidget *parent)
       ui_(new Ui_RadioBrowserSearchView),
       service_(nullptr),
       model_(new RadioBrowserSearchModel(this)),
+      sort_model_(new QSortFilterProxyModel(this)),
       search_timer_(new QTimer(this)),
       context_menu_(nullptr),
       action_add_to_playlist_(nullptr),
@@ -56,7 +58,12 @@ RadioBrowserSearchView::RadioBrowserSearchView(QWidget *parent)
 
   ui_->setupUi(this);
 
-  ui_->results->setModel(model_);
+  // Client-side sorting of the loaded results by clicking a column header.
+  // Locale-aware so names/countries sort naturally, and dynamic so appended pages (Load more) stay sorted.
+  sort_model_->setSourceModel(model_);
+  sort_model_->setSortLocaleAware(true);
+  sort_model_->setDynamicSortFilter(true);
+  ui_->results->setModel(sort_model_);
 
   StretchHeaderView *header = new StretchHeaderView(Qt::Horizontal, this);
   ui_->results->setHeader(header);
@@ -65,6 +72,10 @@ RadioBrowserSearchView::RadioBrowserSearchView(QWidget *parent)
   header->SetColumnWidth(static_cast<int>(RadioBrowserSearchModel::Column::Country), 0.2);
   header->SetColumnWidth(static_cast<int>(RadioBrowserSearchModel::Column::Tags), 0.2);
   header->SetColumnWidth(static_cast<int>(RadioBrowserSearchModel::Column::Codec), 0.1);
+
+  // Start unsorted so the server-provided order (the "Sort" combo box) is what the user sees until they click a column header.
+  header->setSortIndicator(-1, Qt::AscendingOrder);
+  ui_->results->setSortingEnabled(true);
 
   ui_->search->setPlaceholderText(tr("Search radio stations..."));
 
@@ -231,7 +242,11 @@ void RadioBrowserSearchView::SortChanged(const int index) {
 
   Q_UNUSED(index)
 
-  if (service_) SearchTriggered();
+  if (!service_) return;
+
+  // Changing the server-side sort order clears any client-side column sort, otherwise the chosen order would stay hidden behind the column sort and the combo box would appear to do nothing.
+  ui_->results->header()->setSortIndicator(-1, Qt::AscendingOrder);
+  SearchTriggered();
 
 }
 
@@ -239,7 +254,7 @@ void RadioBrowserSearchView::ItemDoubleClicked(const QModelIndex &index) {
 
   if (!index.isValid()) return;
 
-  const RadioChannel channel = model_->ChannelForRow(index.row());
+  const RadioChannel channel = model_->ChannelForRow(sort_model_->mapToSource(index).row());
   if (channel.url.isEmpty()) return;
 
   RadioMimeData *mimedata = new RadioMimeData;
@@ -255,7 +270,7 @@ void RadioBrowserSearchView::AddSelectedToPlaylist() {
 
   RadioMimeData *mimedata = new RadioMimeData;
   for (const QModelIndex &idx : selected) {
-    const RadioChannel channel = model_->ChannelForRow(idx.row());
+    const RadioChannel channel = model_->ChannelForRow(sort_model_->mapToSource(idx).row());
     if (!channel.url.isEmpty()) {
       mimedata->songs << channel.ToSong();
     }

--- a/src/radios/radiobrowsersearchview.h
+++ b/src/radios/radiobrowsersearchview.h
@@ -32,6 +32,7 @@ class QMenu;
 class QAction;
 class QShowEvent;
 class QContextMenuEvent;
+class QSortFilterProxyModel;
 
 class RadioBrowserSearchModel;
 class RadioBrowserService;
@@ -72,6 +73,7 @@ class RadioBrowserSearchView : public QWidget {
   Ui_RadioBrowserSearchView *ui_;
   RadioBrowserService *service_;
   RadioBrowserSearchModel *model_;
+  QSortFilterProxyModel *sort_model_;
   QTimer *search_timer_;
   QMenu *context_menu_;
   QAction *action_add_to_playlist_;


### PR DESCRIPTION
Fixes #2200

The radio browser search results could not be sorted by clicking the column headers (`Name`, `Country`, `Tags`, `Codec`) — clicking a header did nothing.

### What this does

The results model is now wrapped in a `QSortFilterProxyModel` and sorting is enabled on the tree view, so clicking a column header sorts the loaded results. Sorting is locale-aware, and because the proxy uses `setDynamicSortFilter(true)`, pages appended via **Load more** are merged into the current sort instead of being tacked on at the end.

### Interaction with the existing "Sort" combo box

The combo box (`votes` / `clickcount` / `name` / `bitrate`) is **server-side** ordering — it decides which stations the API returns and in which order. The new column-header sorting is **client-side** and only reorders what is already loaded. To keep the two coherent:

- The sort indicator **starts cleared** (`setSortIndicator(-1, …)`), so right after a search the server-provided order from the combo box is what the user sees, until they explicitly click a column header.
- **Changing the combo box clears the column sort** again, otherwise a client-side column sort would stay layered on top of the freshly fetched results and the combo box would appear to do nothing.
- Text/country changes and **Load more** intentionally keep the user's chosen column sort — they refine or extend the result set rather than pick a new ordering.

### Notes

- No new class/file was added: the sort is plain string comparison over the existing columns, so `QSortFilterProxyModel` is used directly (locale-aware) rather than subclassing it à la `StreamingSearchSortModel`. Happy to extract a dedicated model if you'd prefer that for consistency.
- Double-click (append to playlist) and drag-and-drop now map through the proxy (`mapToSource`) so they still resolve to the correct channel after sorting.

### Testing

Built and installed locally (Qt 6, Linux). Verified: clicking each column sorts ascending, a second click reverses to descending; `Country`/`Tags`/`Codec` columns without a server-side equivalent sort correctly; combo box order is visible by default and after changing it; **Load more** keeps the active column sort; double-click and drag-and-drop add the correct station after sorting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now sort radio search results directly by clicking column headers.
  * Sorting is handled locally for faster browsing.

* **Bug Fixes**
  * Selecting or double-clicking a radio station now opens the correct item when results are sorted.
  * When the server-side sort option changes, any active column sort indicator is cleared so the displayed order matches the selected sort.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->