### PR TITLE
BackendSettingsPage: Make sure exclusive mode is disabled unless suported

### DIFF
--- a/src/settings/backendsettingspage.cpp
+++ b/src/settings/backendsettingspage.cpp
@@ -483,7 +483,11 @@ void BackendSettingsPage::OutputChanged(const int index) {
   EngineBase::OutputDetails output = ui_->combobox_output->itemData(index).value<EngineBase::OutputDetails>();
 
 #ifdef Q_OS_WIN32
-  ui_->widget_exclusive_mode->setEnabled(player_->engine()->ExclusiveModeSupport(output.name));
+  const bool exclusive_mode_supported = player_->engine()->ExclusiveModeSupport(output.name);
+  ui_->widget_exclusive_mode->setEnabled(exclusive_mode_supported);
+  if (!exclusive_mode_supported && ui_->checkbox_exclusive_mode->isChecked()) {
+    ui_->checkbox_exclusive_mode->setChecked(false);
+  }
 #endif
 
   Load_Device(output.name, QVariant());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The exclusive mode option now updates more reliably on Windows.
  * If exclusive mode isn’t supported, the setting is disabled and any previously selected checkbox is automatically cleared to match the available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->