### PR TITLE
Enable native dark mode on macOS

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -248,15 +248,20 @@ int main(int argc, char *argv[]) {
     if (style != "default"_L1) {
       QApplication::setStyle(style);
     }
-#ifdef Q_OS_WIN32
-    // Native Windows styles (windowsvista, windows11) use Win32/UxTheme for rendering and only produce correct results with a dark palette when Windows itself is in dark mode for the process.
+    (void) dark_mode;
+#if defined(Q_OS_WIN32) || defined(Q_OS_MACOS)
     if (dark_mode && QApplication::style()) {
       const QString current_style = QApplication::style()->objectName();
-      if (current_style.compare(u"windowsvista"_s, Qt::CaseInsensitive) == 0 || current_style.compare(u"windows11"_s, Qt::CaseInsensitive) == 0) {
+#if defined(Q_OS_WIN32)
+      const bool is_native = current_style.compare(u"windowsvista"_s, Qt::CaseInsensitive) == 0 || current_style.compare(u"windows11"_s, Qt::CaseInsensitive) == 0;
+#elif defined(Q_OS_MACOS)
+      const bool is_native = current_style.compare(u"macos"_s, Qt::CaseInsensitive) == 0;
+#endif
+      if (is_native) {
         QGuiApplication::styleHints()->setColorScheme(Qt::ColorScheme::Dark);
       }
     }
-#endif  // Q_OS_WIN32
+#endif
     if (QApplication::style()) {
       qLog(Debug) << "Style:" << QApplication::style()->objectName();
     }

--- a/src/settings/appearancesettingspage.cpp
+++ b/src/settings/appearancesettingspage.cpp
@@ -258,7 +258,7 @@ void AppearanceSettingsPage::Save() {
   s.setValue(kSystemThemeIcons, ui_->checkbox_system_icons->isChecked());
 #endif
 
-  if (IsNativeWindowsStyle(ui_->combobox_style->currentData().toString())) {
+  if (IsNativeStyle(ui_->combobox_style->currentData().toString())) {
     s.setValue(kDarkMode, ui_->checkbox_dark_mode->isChecked());
     s.setValue(kUseCustomColorSet, false);
   }
@@ -337,7 +337,7 @@ void AppearanceSettingsPage::Save() {
 
 void AppearanceSettingsPage::Cancel() {
 
-#ifdef Q_OS_WIN32
+#if defined(Q_OS_WIN32) || defined(Q_OS_MACOS)
   QGuiApplication::styleHints()->setColorScheme(original_dark_mode_ ? Qt::ColorScheme::Dark : Qt::ColorScheme::Unknown);
 #endif
 
@@ -353,12 +353,12 @@ void AppearanceSettingsPage::Cancel() {
 void AppearanceSettingsPage::StyleChanged(const int index) {
 
   const QString style_name = ui_->combobox_style->itemData(index).toString();
-  const bool is_native = IsNativeWindowsStyle(style_name);
+  const bool is_native = IsNativeStyle(style_name);
 
   ui_->checkbox_dark_mode->setVisible(is_native);
   ui_->groupbox_colors->setEnabled(!is_native);
 
-#ifdef Q_OS_WIN32
+#if defined(Q_OS_WIN32) || defined(Q_OS_MACOS)
   if (is_native) {
     appearance_->ResetToSystemDefaultTheme();
     QGuiApplication::styleHints()->setColorScheme(ui_->checkbox_dark_mode->isChecked() ? Qt::ColorScheme::Dark : Qt::ColorScheme::Unknown);
@@ -372,7 +372,7 @@ void AppearanceSettingsPage::StyleChanged(const int index) {
       appearance_->ResetToSystemDefaultTheme();
     }
   }
-#endif  // Q_OS_WIN32
+#endif
 
   set_changed();
 
@@ -380,7 +380,7 @@ void AppearanceSettingsPage::StyleChanged(const int index) {
 
 void AppearanceSettingsPage::DarkModeToggled(const bool checked) {
 
-#if defined(Q_OS_WIN32)
+#if defined(Q_OS_WIN32) || defined(Q_OS_MACOS)
   QGuiApplication::styleHints()->setColorScheme(checked ? Qt::ColorScheme::Dark : Qt::ColorScheme::Unknown);
 #else
   Q_UNUSED(checked)
@@ -579,13 +579,15 @@ void AppearanceSettingsPage::PlaylistPlayingSongSelectColor() {
 
 }
 
-bool AppearanceSettingsPage::IsNativeWindowsStyle(const QString &style_name) {
+bool AppearanceSettingsPage::IsNativeStyle(const QString &style_name) {
 
-#ifdef Q_OS_WIN32
+#if defined(Q_OS_WIN32)
   return style_name.compare(u"default"_s, Qt::CaseInsensitive) == 0 || style_name.compare(u"windowsvista"_s, Qt::CaseInsensitive) == 0 || style_name.compare(u"windows11"_s, Qt::CaseInsensitive) == 0;
+#elif defined(Q_OS_MACOS)
+  return style_name.compare(u"default"_s, Qt::CaseInsensitive) == 0 || style_name.compare(u"macos"_s, Qt::CaseInsensitive) == 0;
 #else
   Q_UNUSED(style_name)
   return false;
-#endif  // Q_OS_WIN32
+#endif
 
 }

--- a/src/settings/appearancesettingspage.h
+++ b/src/settings/appearancesettingspage.h
@@ -81,7 +81,7 @@ class AppearanceSettingsPage : public SettingsPage {
   // Human-readable label for a palette color role.
   static QString ColorRoleLabel(const QPalette::ColorRole role);
 
-  static bool IsNativeWindowsStyle(const QString &style_name);
+  static bool IsNativeStyle(const QString &style_name);
 
   Ui_AppearanceSettingsPage *ui_;
   const SharedPtr<Appearance> appearance_;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dark mode color-scheme application on macOS to match Windows behavior.
  * Updated “native style” detection so appearance preferences are saved/restored consistently on both Windows and macOS.
  * Refined appearance behavior when switching styles, including correct dark mode UI state and restoring the right color scheme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->