### PR TITLE
Refactor appearance settings and apply style immediately

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -502,6 +502,7 @@ set(SOURCES
   src/utilities/coverutils.cpp
   src/utilities/screenutils.cpp
   src/utilities/textencodingutils.cpp
+  src/utilities/styleutils.cpp
   src/utilities/coveroptions.cpp
   src/utilities/musixmatchprovider.cpp
 

--- a/src/constants/appearancesettings.h
+++ b/src/constants/appearancesettings.h
@@ -41,8 +41,8 @@ enum class BackgroundImagePosition {
 };
 
 constexpr char kStyle[] = "style";
-constexpr char kDarkMode[] = "dark_mode";
 constexpr char kSystemThemeIcons[] = "system_icons";
+constexpr char kDarkMode[] = "dark_mode";
 constexpr char kUseCustomColorSet[] = "use-custom-color-set";
 
 // Per-QPalette-role custom colors (the "central roles" from https://doc.qt.io/qt-6/qpalette.html).
@@ -62,6 +62,8 @@ constexpr char kTabBarSystemColor[] = "tab_system_color";
 constexpr char kTabBarGradient[] = "tab_gradient";
 constexpr char kTabBarColor[] = "tab_color";
 
+constexpr char kPlaylistPlayingSongColor[] = "playlist_playing_song_color";
+
 constexpr char kBackgroundImageType[] = "background_image_type";
 constexpr char kBackgroundImageFilename[] = "background_image_file";
 constexpr char kBackgroundImagePosition[] = "background_image_position";
@@ -70,8 +72,8 @@ constexpr char kBackgroundImageStretch[] = "background_image_stretch";
 constexpr char kBackgroundImageDoNotCut[] = "background_image_do_not_cut";
 constexpr char kBackgroundImageKeepAspectRatio[] = "background_image_keep_aspect_ratio";
 
-constexpr char kBlurRadius[] = "blur_radius";
-constexpr char kOpacityLevel[] = "opacity_level";
+constexpr char kBackgroundImageBlurRadius[] = "blur_radius";
+constexpr char kBackgroundImageOpacityLevel[] = "opacity_level";
 
 constexpr char kIconSizeTabbarSmallMode[] = "icon_size_tabbar_small_mode";
 constexpr char kIconSizeTabbarLargeMode[] = "icon_size_tabbar_large_mode";
@@ -80,21 +82,20 @@ constexpr char kIconSizePlaylistButtons[] = "icon_size_playlist_buttons";
 constexpr char kIconSizeLeftPanelButtons[] = "icon_size_left_panel_buttons";
 constexpr char kIconSizeConfigureButtons[] = "icon_size_configure_buttons";
 
-constexpr char kPlaylistPlayingSongColor[] = "playlist_playing_song_color";
-
 constexpr bool kDefaultDarkMode = false;
-constexpr bool kDefaultSystemThemeIcons = false;
+constexpr bool kDefaultSystemIcons = false;
 constexpr bool kDefaultUseCustomColorSet = false;
 constexpr bool kDefaultTabBarSystemColor = false;
 constexpr bool kDefaultTabBarGradient = true;
+
 constexpr BackgroundImageType kDefaultBackgroundImageType = BackgroundImageType::Default;
 constexpr BackgroundImagePosition kDefaultBackgroundImagePosition = BackgroundImagePosition::BottomRight;
 constexpr int kDefaultBackgroundImageMaxSize = 0;
 constexpr bool kDefaultBackgroundImageStretch = false;
 constexpr bool kDefaultBackgroundImageDoNotCut = true;
 constexpr bool kDefaultBackgroundImageKeepAspectRatio = true;
-constexpr int kDefaultBlurRadius = 0;
-constexpr int kDefaultOpacityLevel = 40;
+constexpr int kDefaultBackgroundImageBlurRadius = 0;
+constexpr int kDefaultBackgroundImageOpacityLevel = 40;
 
 constexpr int kDefaultIconSizeTabbarSmallMode = 32;
 constexpr int kDefaultIconSizeTabbarLargeMode = 40;

--- a/src/core/appearance.cpp
+++ b/src/core/appearance.cpp
@@ -21,6 +21,7 @@
 
 #include <QApplication>
 #include <QObject>
+#include <QThread>
 #include <QList>
 #include <QMap>
 #include <QPalette>
@@ -32,6 +33,36 @@
 
 Appearance::Appearance(QObject *parent) : QObject(parent), system_palette_(QApplication::palette()) {}
 
+namespace {
+
+bool IsTextColorRole(const QPalette::ColorRole color_role) {
+
+  return color_role == QPalette::WindowText || color_role == QPalette::Text || color_role == QPalette::ButtonText || color_role == QPalette::BrightText || color_role == QPalette::PlaceholderText;
+
+}
+
+QPalette::ColorRole BackgroundRoleForTextRole(const QPalette::ColorRole color_role) {
+
+  switch (color_role) {
+    case QPalette::Text:
+    case QPalette::PlaceholderText:
+      return QPalette::Base;
+    case QPalette::ButtonText:
+      return QPalette::Button;
+    default:
+      return QPalette::Window;
+  }
+
+}
+
+QColor DimmedTextColor(const QColor &text_color, const QColor &background_color) {
+
+  return QColor((text_color.red() + background_color.red()) / 2, (text_color.green() + background_color.green()) / 2, (text_color.blue() + background_color.blue()) / 2);
+
+}
+
+}  // namespace
+
 const QList<Appearance::ColorRole> &Appearance::ColorRoles() {
 
   static const QList<ColorRole> color_roles = {
@@ -39,76 +70,84 @@ const QList<Appearance::ColorRole> &Appearance::ColorRoles() {
     { QPalette::WindowText, QLatin1String(AppearanceSettings::kColorWindowText) },
     { QPalette::Base, QLatin1String(AppearanceSettings::kColorBase) },
     { QPalette::AlternateBase, QLatin1String(AppearanceSettings::kColorAlternateBase) },
-    { QPalette::ToolTipBase, QLatin1String(AppearanceSettings::kColorToolTipBase) },
-    { QPalette::ToolTipText, QLatin1String(AppearanceSettings::kColorToolTipText) },
     { QPalette::Text, QLatin1String(AppearanceSettings::kColorText) },
     { QPalette::Button, QLatin1String(AppearanceSettings::kColorButton) },
     { QPalette::ButtonText, QLatin1String(AppearanceSettings::kColorButtonText) },
     { QPalette::BrightText, QLatin1String(AppearanceSettings::kColorBrightText) },
-    { QPalette::PlaceholderText, QLatin1String(AppearanceSettings::kColorPlaceholderText) }
+    { QPalette::PlaceholderText, QLatin1String(AppearanceSettings::kColorPlaceholderText) },
+    { QPalette::ToolTipBase, QLatin1String(AppearanceSettings::kColorToolTipBase) },
+    { QPalette::ToolTipText, QLatin1String(AppearanceSettings::kColorToolTipText) }
   };
 
   return color_roles;
 
 }
 
-QMap<QPalette::ColorRole, QColor> Appearance::DarkColors() {
+const QMap<QPalette::ColorRole, QColor> &Appearance::DarkColors() {
 
-  return QMap<QPalette::ColorRole, QColor>{
+  static const QMap<QPalette::ColorRole, QColor> dark_colors = {
     { QPalette::Window, QColor(53, 53, 53) },
     { QPalette::WindowText, QColor(240, 240, 240) },
     { QPalette::Base, QColor(35, 35, 35) },
     { QPalette::AlternateBase, QColor(53, 53, 53) },
-    { QPalette::ToolTipBase, QColor(53, 53, 53) },
-    { QPalette::ToolTipText, QColor(240, 240, 240) },
     { QPalette::Text, QColor(240, 240, 240) },
     { QPalette::Button, QColor(53, 53, 53) },
     { QPalette::ButtonText, QColor(240, 240, 240) },
     { QPalette::BrightText, QColor(255, 80, 80) },
-    { QPalette::PlaceholderText, QColor(140, 140, 140) }
+    { QPalette::PlaceholderText, QColor(140, 140, 140) },
+    { QPalette::ToolTipBase, QColor(53, 53, 53) },
+    { QPalette::ToolTipText, QColor(240, 240, 240) }
   };
+
+  return dark_colors;
 
 }
 
-void Appearance::LoadUserTheme() {
+void Appearance::LoadCustomPaletteColors() {
 
   Settings s;
   s.beginGroup(AppearanceSettings::kSettingsGroup);
   const bool use_custom_color_set = s.value(AppearanceSettings::kUseCustomColorSet).toBool();
 
-  if (!use_custom_color_set) {
-    s.endGroup();
-    return;
-  }
-
-  QMap<QPalette::ColorRole, QColor> colors;
-  for (const ColorRole &color_role : ColorRoles()) {
-    const QVariant value = s.value(color_role.settings_key);
-    if (value.isValid()) {
-      const QColor color = value.value<QColor>();
-      if (color.isValid()) {
-        colors.insert(color_role.role, color);
+  if (use_custom_color_set) {
+    QMap<QPalette::ColorRole, QColor> colors;
+    for (const ColorRole &color_role : ColorRoles()) {
+      const QVariant value = s.value(color_role.settings_key);
+      if (value.isValid()) {
+        const QColor color = value.value<QColor>();
+        if (color.isValid()) {
+          colors.insert(color_role.role, color);
+        }
       }
     }
+    SetCustomPaletteColors(colors);
   }
 
   s.endGroup();
 
-  ChangeColors(colors);
-
 }
 
-void Appearance::ResetToSystemDefaultTheme() {
-  QApplication::setPalette(system_palette_);
-}
+void Appearance::SetCustomPaletteColors(const QMap<QPalette::ColorRole, QColor> &colors) {
 
-void Appearance::ChangeColors(const QMap<QPalette::ColorRole, QColor> &colors) {
+  Q_ASSERT(QThread::currentThread() == qApp->thread());
 
+  // Only set the active and inactive color groups here, the disabled color group is handled below so that disabled widgets still look greyed out with a custom color set.
   QPalette palette = QApplication::palette();
-
   for (QMap<QPalette::ColorRole, QColor>::const_iterator it = colors.constBegin(); it != colors.constEnd(); ++it) {
     if (it.value().isValid()) {
-      palette.setColor(it.key(), it.value());
+      palette.setColor(QPalette::Active, it.key(), it.value());
+      palette.setColor(QPalette::Inactive, it.key(), it.value());
+      if (!IsTextColorRole(it.key())) {
+        palette.setColor(QPalette::Disabled, it.key(), it.value());
+      }
+    }
+  }
+
+  // Dim the text roles for the disabled color group by blending them with the corresponding background color.
+  for (QMap<QPalette::ColorRole, QColor>::const_iterator it = colors.constBegin(); it != colors.constEnd(); ++it) {
+    if (it.value().isValid() && IsTextColorRole(it.key())) {
+      const QColor background_color = palette.color(QPalette::Disabled, BackgroundRoleForTextRole(it.key()));
+      palette.setColor(QPalette::Disabled, it.key(), DimmedTextColor(it.value(), background_color));
     }
   }
 

--- a/src/core/appearance.h
+++ b/src/core/appearance.h
@@ -31,6 +31,7 @@
 
 class Appearance : public QObject {
   Q_OBJECT
+  Q_DISABLE_COPY_MOVE(Appearance)
 
  public:
   explicit Appearance(QObject *parent = nullptr);
@@ -45,19 +46,23 @@ class Appearance : public QObject {
   static const QList<ColorRole> &ColorRoles();
 
   // A suitable set of colors for a dark theme, keyed by palette role (covers all of ColorRoles()).
-  static QMap<QPalette::ColorRole, QColor> DarkColors();
+  static const QMap<QPalette::ColorRole, QColor> &DarkColors();
+  
+  // The default style, captured before any user theme is applied so it can be restored later.
+  const QString &default_style() const { return default_style_; }
+  void set_default_style(const QString &style) { default_style_ = style; }
 
   // The system's default palette, captured before any user theme is applied so it can be restored later.
   const QPalette &system_palette() const { return system_palette_; }
   void set_system_palette(const QPalette &palette) { system_palette_ = palette; }
 
-  void LoadUserTheme();
-  void ResetToSystemDefaultTheme();
+  void LoadCustomPaletteColors();
 
   // Applies the given per-role colors on top of the current application palette.
-  static void ChangeColors(const QMap<QPalette::ColorRole, QColor> &colors);
+  static void SetCustomPaletteColors(const QMap<QPalette::ColorRole, QColor> &colors);
 
  private:
+  QString default_style_;
   QPalette system_palette_;
 };
 

--- a/src/core/iconloader.cpp
+++ b/src/core/iconloader.cpp
@@ -49,7 +49,7 @@ void IconLoader::Init() {
 #if !defined(Q_OS_MACOS) && !defined(Q_OS_WIN32)
   Settings s;
   s.beginGroup(AppearanceSettings::kSettingsGroup);
-  system_icons_ = s.value(AppearanceSettings::kSystemThemeIcons, AppearanceSettings::kDefaultSystemThemeIcons).toBool();
+  system_icons_ = s.value(AppearanceSettings::kSystemThemeIcons, AppearanceSettings::kDefaultSystemIcons).toBool();
   s.endGroup();
 #endif
 

--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -299,6 +299,7 @@ MainWindow::MainWindow(Application *app,
                        DiscordRichPresence *discord_rich_presence,
 #endif
                        const CommandlineOptions &options,
+                       const QString &default_style,
                        QWidget *parent)
     : QMainWindow(parent),
       ui_(new Ui_MainWindow),
@@ -994,8 +995,9 @@ MainWindow::MainWindow(Application *app,
 
   // Load theme
   // We need to save the default/system palette now, before loading user preferred theme (which will override it), to be able to restore it later
+  appearance_->set_default_style(default_style);
   appearance_->set_system_palette(QApplication::palette());
-  appearance_->LoadUserTheme();
+  appearance_->LoadCustomPaletteColors();
   StyleSheetLoader *css_loader = new StyleSheetLoader(this);
   css_loader->SetStyleSheet(this, u":/style/strawberry.css"_s);
 

--- a/src/core/mainwindow.h
+++ b/src/core/mainwindow.h
@@ -118,6 +118,7 @@ class MainWindow : public QMainWindow, public PlatformInterface {
                       DiscordRichPresence *discord_rich_presence,
 #endif
                       const CommandlineOptions &options,
+                      const QString &default_style,
                       QWidget *parent = nullptr);
   ~MainWindow() override;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,6 +75,7 @@
 #include "core/settings.h"
 
 #include "utilities/envutils.h"
+#include "utilities/styleutils.h"
 
 #include <kdsingleapplication.h>
 
@@ -235,33 +236,30 @@ int main(int argc, char *argv[]) {
   // Gnome on Ubuntu has menu icons disabled by default.  I think that's a bad idea, and makes some menus in Strawberry look confusing.
   QCoreApplication::setAttribute(Qt::AA_DontShowIconsInMenus, false);
 
+  const QString default_style = QApplication::style() ? QApplication::style()->objectName() : QString();
   {
     Settings s;
     s.beginGroup(AppearanceSettings::kSettingsGroup);
-    QString style = s.value(AppearanceSettings::kStyle).toString();
-    if (style.isEmpty()) {
-      style = "default"_L1;
-      s.setValue(AppearanceSettings::kStyle, style);
-    }
+    const QString style_name = s.value(AppearanceSettings::kStyle).toString();
     const bool dark_mode = s.value(AppearanceSettings::kDarkMode, false).toBool();
     s.endGroup();
-    if (style != "default"_L1) {
-      QApplication::setStyle(style);
-    }
-    (void) dark_mode;
-#if defined(Q_OS_WIN32) || defined(Q_OS_MACOS)
-    if (dark_mode && QApplication::style()) {
-      const QString current_style = QApplication::style()->objectName();
-#if defined(Q_OS_WIN32)
-      const bool is_native = current_style.compare(u"windowsvista"_s, Qt::CaseInsensitive) == 0 || current_style.compare(u"windows11"_s, Qt::CaseInsensitive) == 0;
-#elif defined(Q_OS_MACOS)
-      const bool is_native = current_style.compare(u"macos"_s, Qt::CaseInsensitive) == 0;
-#endif
-      if (is_native) {
-        QGuiApplication::styleHints()->setColorScheme(Qt::ColorScheme::Dark);
+    if (!style_name.isEmpty() && style_name.compare("default"_L1, Qt::CaseInsensitive) != 0) {
+      if (!QApplication::setStyle(style_name)) {
+        qLog(Error) << "Could not set style" << style_name << "- falling back to default style" << default_style;
+        if (!QApplication::setStyle(default_style)) {
+          qLog(Error) << "Could not set default style" << default_style;
+        }
       }
     }
+    if (dark_mode && QApplication::style()) {
+      const QString current_style = QApplication::style() ? QApplication::style()->objectName() : QString();
+      const bool dark_mode_supported = Utilities::StyleHasDarkModeSupport(current_style);
+      if (dark_mode_supported) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+        QGuiApplication::styleHints()->setColorScheme(Qt::ColorScheme::Dark);
 #endif
+      }
+    }
     if (QApplication::style()) {
       qLog(Debug) << "Style:" << QApplication::style()->objectName();
     }
@@ -396,7 +394,8 @@ int main(int argc, char *argv[]) {
 #ifdef HAVE_DISCORD_RPC
                &discord_rich_presence,
 #endif
-               options);
+               options,
+               default_style);
 
 #ifdef Q_OS_UNIX
   UnixSignalWatcher unix_signal_watcher;

--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -101,8 +101,8 @@ PlaylistView::PlaylistView(QWidget *parent)
       background_image_stretch_(false),
       background_image_do_not_cut_(true),
       background_image_keep_aspect_ratio_(true),
-      blur_radius_(AppearanceSettings::kDefaultBlurRadius),
-      opacity_level_(AppearanceSettings::kDefaultOpacityLevel),
+      blur_radius_(AppearanceSettings::kDefaultBackgroundImageBlurRadius),
+      opacity_level_(AppearanceSettings::kDefaultBackgroundImageOpacityLevel),
       background_initialized_(false),
       set_initial_header_layout_(false),
       header_state_loaded_(false),
@@ -1233,8 +1233,8 @@ void PlaylistView::ReloadSettings() {
   bool background_image_stretch = s.value(AppearanceSettings::kBackgroundImageStretch, AppearanceSettings::kDefaultBackgroundImageStretch).toBool();
   bool background_image_do_not_cut = s.value(AppearanceSettings::kBackgroundImageDoNotCut, AppearanceSettings::kDefaultBackgroundImageDoNotCut).toBool();
   bool background_image_keep_aspect_ratio = s.value(AppearanceSettings::kBackgroundImageKeepAspectRatio, AppearanceSettings::kDefaultBackgroundImageKeepAspectRatio).toBool();
-  int blur_radius = s.value(AppearanceSettings::kBlurRadius, AppearanceSettings::kDefaultBlurRadius).toInt();
-  int opacity_level = s.value(AppearanceSettings::kOpacityLevel, AppearanceSettings::kDefaultOpacityLevel).toInt();
+  int blur_radius = s.value(AppearanceSettings::kBackgroundImageBlurRadius, AppearanceSettings::kDefaultBackgroundImageBlurRadius).toInt();
+  int opacity_level = s.value(AppearanceSettings::kBackgroundImageOpacityLevel, AppearanceSettings::kDefaultBackgroundImageOpacityLevel).toInt();
   QColor playlist_playing_song_color = s.value(AppearanceSettings::kPlaylistPlayingSongColor).value<QColor>();
   if (playlist_playing_song_color != playlist_playing_song_color_) {
     row_height_ = -1;

--- a/src/settings/appearancesettingspage.cpp
+++ b/src/settings/appearancesettingspage.cpp
@@ -38,6 +38,7 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
+#include <QPointer>
 #include <QRadioButton>
 #include <QSlider>
 #include <QBoxLayout>
@@ -50,6 +51,7 @@
 #include "appearancesettingspage.h"
 #include "constants/appearancesettings.h"
 #include "constants/filefilterconstants.h"
+#include "utilities/styleutils.h"
 #include "core/iconloader.h"
 #include "core/stylehelper.h"
 #include "core/settings.h"
@@ -66,6 +68,8 @@ AppearanceSettingsPage::AppearanceSettingsPage(SettingsDialog *dialog, SharedPtr
     : SettingsPage(dialog, parent),
       ui_(new Ui_AppearanceSettingsPage),
       appearance_(appearance),
+      original_style_(QApplication::style() ? QApplication::style()->objectName() : QString()),
+      system_palette_(QApplication::palette()),
       original_dark_mode_(false),
       original_use_custom_color_set_(false),
       background_image_type_(BackgroundImageType::Default) {
@@ -79,29 +83,32 @@ AppearanceSettingsPage::AppearanceSettingsPage(SettingsDialog *dialog, SharedPtr
     ui_->combobox_style->addItem(style, style);
   }
 
-  ui_->combobox_backgroundimageposition->setItemData(0, static_cast<int>(BackgroundImagePosition::UpperLeft));
-  ui_->combobox_backgroundimageposition->setItemData(1, static_cast<int>(BackgroundImagePosition::UpperRight));
-  ui_->combobox_backgroundimageposition->setItemData(2, static_cast<int>(BackgroundImagePosition::Middle));
-  ui_->combobox_backgroundimageposition->setItemData(3, static_cast<int>(BackgroundImagePosition::BottomLeft));
-  ui_->combobox_backgroundimageposition->setItemData(4, static_cast<int>(BackgroundImagePosition::BottomRight));
+  CreateColorSelectors();
+
+  ui_->combobox_background_image_position->setItemData(0, static_cast<int>(BackgroundImagePosition::UpperLeft));
+  ui_->combobox_background_image_position->setItemData(1, static_cast<int>(BackgroundImagePosition::UpperRight));
+  ui_->combobox_background_image_position->setItemData(2, static_cast<int>(BackgroundImagePosition::Middle));
+  ui_->combobox_background_image_position->setItemData(3, static_cast<int>(BackgroundImagePosition::BottomLeft));
+  ui_->combobox_background_image_position->setItemData(4, static_cast<int>(BackgroundImagePosition::BottomRight));
 
   QObject::connect(ui_->checkbox_dark_mode, &QCheckBox::toggled, this, &AppearanceSettingsPage::DarkModeToggled);
-
-  QObject::connect(ui_->blur_slider, &QSlider::valueChanged, this, &AppearanceSettingsPage::BlurLevelChanged);
-  QObject::connect(ui_->opacity_slider, &QSlider::valueChanged, this, &AppearanceSettingsPage::OpacityLevelChanged);
 
   QObject::connect(ui_->use_custom_color_set, &QRadioButton::toggled, this, &AppearanceSettingsPage::UseCustomColorSetOptionChanged);
   QObject::connect(ui_->use_custom_color_set, &QRadioButton::toggled, ui_->widget_custom_colors, &QWidget::setEnabled);
   QObject::connect(ui_->button_dark_colors, &QPushButton::pressed, this, &AppearanceSettingsPage::SetDarkColors);
   QObject::connect(ui_->button_reset_colors, &QPushButton::pressed, this, &AppearanceSettingsPage::ResetToDefaultColors);
 
-  CreateColorSelectors();
+  QObject::connect(ui_->select_tabbar_color, &QPushButton::pressed, this, &AppearanceSettingsPage::TabBarSelectBGColor);
+  QObject::connect(ui_->tabbar_system_color, &QRadioButton::toggled, this, &AppearanceSettingsPage::TabBarSystemColor);
 
-  QObject::connect(ui_->use_default_background, &QRadioButton::toggled, ui_->widget_custom_background_image_options, &AppearanceSettingsPage::setDisabled);
-  QObject::connect(ui_->use_no_background, &QRadioButton::toggled, ui_->widget_custom_background_image_options, &AppearanceSettingsPage::setDisabled);
-  QObject::connect(ui_->use_album_cover_background, &QRadioButton::toggled, ui_->widget_custom_background_image_options, &AppearanceSettingsPage::setEnabled);
-  QObject::connect(ui_->use_strawbs_background, &QRadioButton::toggled, ui_->widget_custom_background_image_options, &AppearanceSettingsPage::setDisabled);
-  QObject::connect(ui_->use_custom_background_image, &QRadioButton::toggled, ui_->widget_custom_background_image_options, &AppearanceSettingsPage::setEnabled);
+  QObject::connect(ui_->select_playlist_playing_song_color, &QPushButton::pressed, this, &AppearanceSettingsPage::PlaylistPlayingSongSelectColor);
+  QObject::connect(ui_->playlist_playing_song_color_system, &QRadioButton::toggled, this, &AppearanceSettingsPage::PlaylistPlayingSongColorSystem);
+
+  QObject::connect(ui_->use_default_background, &QRadioButton::toggled, ui_->widget_background_image_options, &AppearanceSettingsPage::setDisabled);
+  QObject::connect(ui_->use_no_background, &QRadioButton::toggled, ui_->widget_background_image_options, &AppearanceSettingsPage::setDisabled);
+  QObject::connect(ui_->use_album_cover_background, &QRadioButton::toggled, ui_->widget_background_image_options, &AppearanceSettingsPage::setEnabled);
+  QObject::connect(ui_->use_strawbs_background, &QRadioButton::toggled, ui_->widget_background_image_options, &AppearanceSettingsPage::setDisabled);
+  QObject::connect(ui_->use_custom_background_image, &QRadioButton::toggled, ui_->widget_background_image_options, &AppearanceSettingsPage::setEnabled);
 
   QObject::connect(ui_->select_background_image_filename_button, &QPushButton::pressed, this, &AppearanceSettingsPage::SelectBackgroundImage);
   QObject::connect(ui_->use_custom_background_image, &QRadioButton::toggled, ui_->background_image_filename, &AppearanceSettingsPage::setEnabled);
@@ -113,23 +120,20 @@ AppearanceSettingsPage::AppearanceSettingsPage(SettingsDialog *dialog, SharedPtr
 
   QObject::connect(ui_->checkbox_background_image_keep_aspect_ratio, &QCheckBox::toggled, ui_->checkbox_background_image_do_not_cut, &AppearanceSettingsPage::setEnabled);
 
-  QObject::connect(ui_->select_tabbar_color, &QPushButton::pressed, this, &AppearanceSettingsPage::TabBarSelectBGColor);
-  QObject::connect(ui_->tabbar_system_color, &QRadioButton::toggled, this, &AppearanceSettingsPage::TabBarSystemColor);
-
-  QObject::connect(ui_->select_playlist_playing_song_color, &QPushButton::pressed, this, &AppearanceSettingsPage::PlaylistPlayingSongSelectColor);
-  QObject::connect(ui_->playlist_playing_song_color_system, &QRadioButton::toggled, this, &AppearanceSettingsPage::PlaylistPlayingSongColorSystem);
+  QObject::connect(ui_->slider_background_image_blur, &QSlider::valueChanged, this, &AppearanceSettingsPage::BackgroundImageBlurLevelChanged);
+  QObject::connect(ui_->slider_background_image_opacity, &QSlider::valueChanged, this, &AppearanceSettingsPage::BackgroundImageOpacityLevelChanged);
 
 #if defined(Q_OS_MACOS) || defined(Q_OS_WIN32)
-  ui_->checkbox_system_icons->hide();
+  ui_->checkbox_system_icons->setEnabled(false);
+#else
+  ui_->checkbox_system_icons->setEnabled(true);
 #endif
 
   AppearanceSettingsPage::Load();
 
 }
 
-AppearanceSettingsPage::~AppearanceSettingsPage() {
-  delete ui_;
-}
+AppearanceSettingsPage::~AppearanceSettingsPage() = default;
 
 void AppearanceSettingsPage::Load() {
 
@@ -139,13 +143,19 @@ void AppearanceSettingsPage::Load() {
   Settings s;
   s.beginGroup(kSettingsGroup);
 
+  // Style
+  original_style_ = QApplication::style() ? QApplication::style()->objectName() : QString();
   ComboBoxLoadFromSettings(s, ui_->combobox_style, QLatin1String(kStyle), u"default"_s);
 
 #if !defined(Q_OS_MACOS) && !defined(Q_OS_WIN32)
-  ui_->checkbox_system_icons->setChecked(s.value(kSystemThemeIcons, kDefaultSystemThemeIcons).toBool());
+  ui_->checkbox_system_icons->setChecked(s.value(kSystemThemeIcons, kDefaultSystemIcons).toBool());
 #endif
 
-  const QPalette p = QApplication::palette();
+  original_dark_mode_ = s.value(kDarkMode, kDefaultDarkMode).toBool();
+  ui_->checkbox_dark_mode->setChecked(original_dark_mode_);
+
+  // Colors
+  const QPalette palette = QApplication::palette();
 
   // Keep in mind originals colors, in case the user clicks on Cancel, to be able to restore colors
   original_use_custom_color_set_ = s.value(kUseCustomColorSet, kDefaultUseCustomColorSet).toBool();
@@ -155,7 +165,7 @@ void AppearanceSettingsPage::Load() {
     const QVariant value = s.value(color_role.settings_key);
     QColor color = value.isValid() ? value.value<QColor>() : QColor();
     if (!color.isValid()) {
-      color = p.color(color_role.role);
+      color = palette.color(color_role.role);
     }
     current_colors_.insert(color_role.role, color);
   }
@@ -164,7 +174,7 @@ void AppearanceSettingsPage::Load() {
 
   UpdateColorSelectorsColors();
 
-  // Tab widget BG color settings.
+  // Tabbar background color
   bool tabbar_system_color = s.value(kTabBarSystemColor, kDefaultTabBarSystemColor).toBool();
   ui_->tabbar_gradient->setChecked(s.value(kTabBarGradient, kDefaultTabBarGradient).toBool());
   ui_->tabbar_system_color->setChecked(tabbar_system_color);
@@ -175,8 +185,23 @@ void AppearanceSettingsPage::Load() {
   UpdateColorSelectorColor(ui_->select_tabbar_color, current_tabbar_bg_color_);
   TabBarSystemColor(ui_->tabbar_system_color->isChecked());
 
-  // Playlist settings
-  background_image_type_ = static_cast<BackgroundImageType>(s.value(kBackgroundImageType, static_cast<int>(kDefaultBackgroundImageType)).toInt());
+  // Currently playing song color
+  current_playlist_playing_song_color_ = s.value(kPlaylistPlayingSongColor).value<QColor>();
+  if (current_playlist_playing_song_color_.isValid()) {
+    ui_->playlist_playing_song_color_custom->setChecked(true);
+  }
+  else {
+    ui_->playlist_playing_song_color_system->setChecked(true);
+    current_playlist_playing_song_color_ = StyleHelper::highlightColor();
+  }
+  UpdateColorSelectorColor(ui_->select_playlist_playing_song_color, current_playlist_playing_song_color_);
+  PlaylistPlayingSongColorSystem(ui_->playlist_playing_song_color_system->isChecked());
+
+  // Playlist background image
+  {
+    const int v = s.value(kBackgroundImageType, static_cast<int>(kDefaultBackgroundImageType)).toInt();
+    background_image_type_ = (v >= static_cast<int>(BackgroundImageType::Default) && v <= static_cast<int>(BackgroundImageType::Strawbs)) ? static_cast<BackgroundImageType>(v) : kDefaultBackgroundImageType;
+  }
   background_image_filename_ = s.value(kBackgroundImageFilename).toString();
 
   ui_->use_system_color_set->setChecked(!original_use_custom_color_set_);
@@ -190,29 +215,36 @@ void AppearanceSettingsPage::Load() {
     case BackgroundImageType::None:
       ui_->use_no_background->setChecked(true);
       break;
+    case BackgroundImageType::Custom:
+      ui_->use_custom_background_image->setChecked(true);
+      break;
     case BackgroundImageType::Album:
       ui_->use_album_cover_background->setChecked(true);
       break;
     case BackgroundImageType::Strawbs:
       ui_->use_strawbs_background->setChecked(true);
       break;
-    case BackgroundImageType::Custom:
-      ui_->use_custom_background_image->setChecked(true);
-      break;
   }
   ui_->background_image_filename->setText(background_image_filename_);
 
-  ui_->combobox_backgroundimageposition->setCurrentIndex(ui_->combobox_backgroundimageposition->findData(s.value(kBackgroundImagePosition, static_cast<int>(kDefaultBackgroundImagePosition)).toInt()));
+  const int background_image_position = s.value(kBackgroundImagePosition, static_cast<int>(kDefaultBackgroundImagePosition)).toInt();
+  int background_image_position_index = ui_->combobox_background_image_position->findData(background_image_position);
+  if (background_image_position_index < 0) {
+    background_image_position_index = ui_->combobox_background_image_position->findData(static_cast<int>(kDefaultBackgroundImagePosition));
+  }
+  ui_->combobox_background_image_position->setCurrentIndex(background_image_position_index);
+
   ui_->spinbox_background_image_maxsize->setValue(s.value(kBackgroundImageMaxSize, kDefaultBackgroundImageMaxSize).toInt());
   ui_->checkbox_background_image_stretch->setChecked(s.value(kBackgroundImageStretch, kDefaultBackgroundImageStretch).toBool());
   ui_->checkbox_background_image_do_not_cut->setChecked(s.value(kBackgroundImageDoNotCut, kDefaultBackgroundImageDoNotCut).toBool());
   ui_->checkbox_background_image_keep_aspect_ratio->setChecked(s.value(kBackgroundImageKeepAspectRatio, kDefaultBackgroundImageKeepAspectRatio).toBool());
-  ui_->blur_slider->setValue(s.value(kBlurRadius, kDefaultBlurRadius).toInt());
-  ui_->opacity_slider->setValue(s.value(kOpacityLevel, kDefaultOpacityLevel).toInt());
+  ui_->slider_background_image_blur->setValue(s.value(kBackgroundImageBlurRadius, kDefaultBackgroundImageBlurRadius).toInt());
+  ui_->slider_background_image_opacity->setValue(s.value(kBackgroundImageOpacityLevel, kDefaultBackgroundImageOpacityLevel).toInt());
 
   ui_->checkbox_background_image_keep_aspect_ratio->setEnabled(ui_->checkbox_background_image_stretch->isChecked());
   ui_->checkbox_background_image_do_not_cut->setEnabled(ui_->checkbox_background_image_stretch->isChecked() && ui_->checkbox_background_image_keep_aspect_ratio->isChecked());
 
+  // Button sizes
   ui_->spinbox_icon_size_tabbar_small_mode->setValue(s.value(kIconSizeTabbarSmallMode, kDefaultIconSizeTabbarSmallMode).toInt());
   ui_->spinbox_icon_size_tabbar_large_mode->setValue(s.value(kIconSizeTabbarLargeMode, kDefaultIconSizeTabbarLargeMode).toInt());
   ui_->spinbox_icon_size_play_control_buttons->setValue(s.value(kIconSizePlayControlButtons, kDefaultIconSizePlayControlButtons).toInt());
@@ -220,19 +252,9 @@ void AppearanceSettingsPage::Load() {
   ui_->spinbox_icon_size_left_panel_buttons->setValue(s.value(kIconSizeLeftPanelButtons, kDefaultIconSizeLeftPanelButtons).toInt());
   ui_->spinbox_icon_size_configure_buttons->setValue(s.value(kIconSizeConfigureButtons, kDefaultIconSizeConfigureButtons).toInt());
 
-  current_playlist_playing_song_color_ = s.value(kPlaylistPlayingSongColor).value<QColor>();
-  if (current_playlist_playing_song_color_.isValid()) {
-    ui_->playlist_playing_song_color_custom->setChecked(true);
-  }
-  else {
-    ui_->playlist_playing_song_color_system->setChecked(true);
-    current_playlist_playing_song_color_ = StyleHelper::highlightColor();
-  }
-  UpdateColorSelectorColor(ui_->select_playlist_playing_song_color, current_playlist_playing_song_color_);
-  PlaylistPlayingSongColorSystem(ui_->playlist_playing_song_color_system->isChecked());
-
-  original_dark_mode_ = s.value(kDarkMode, kDefaultDarkMode).toBool();
-  ui_->checkbox_dark_mode->setChecked(original_dark_mode_);
+  original_tabbar_bg_color_ = current_tabbar_bg_color_;
+  original_background_image_filename_ = background_image_filename_;
+  original_playlist_playing_song_color_ = current_playlist_playing_song_color_;
 
   s.endGroup();
 
@@ -241,7 +263,7 @@ void AppearanceSettingsPage::Load() {
   if (!Settings().childGroups().contains(QLatin1String(kSettingsGroup))) set_changed();
 
   QObject::connect(ui_->combobox_style, &QComboBox::currentIndexChanged, this, &AppearanceSettingsPage::StyleChanged);
-  StyleChanged(ui_->combobox_style->currentIndex());
+  InitStyle(ui_->combobox_style->currentIndex());
 
 }
 
@@ -250,7 +272,13 @@ void AppearanceSettingsPage::Save() {
   Settings s;
   s.beginGroup(kSettingsGroup);
 
+  // Style
   s.setValue(kStyle, ui_->combobox_style->currentText());
+
+  QString selected_style = ui_->combobox_style->currentData().toString();
+  if (selected_style.compare(u"default"_s, Qt::CaseInsensitive) == 0) {
+    selected_style = appearance_->default_style();
+  }
 
 #if defined(Q_OS_MACOS) || defined(Q_OS_WIN32)
   s.setValue(kSystemThemeIcons, false);
@@ -258,31 +286,37 @@ void AppearanceSettingsPage::Save() {
   s.setValue(kSystemThemeIcons, ui_->checkbox_system_icons->isChecked());
 #endif
 
-  if (IsNativeStyle(ui_->combobox_style->currentData().toString())) {
-    s.setValue(kDarkMode, ui_->checkbox_dark_mode->isChecked());
-    s.setValue(kUseCustomColorSet, false);
-  }
-  else if (IsBreezeStyle()) {
-    s.setValue(kDarkMode, false);
-    s.setValue(kUseCustomColorSet, false);
+  s.setValue(kDarkMode, Utilities::StyleHasDarkModeSupport(selected_style) ? ui_->checkbox_dark_mode->isChecked() : false);
+
+  // Colors
+  const bool use_custom_color_set = Utilities::StyleHasCustomPaletteColorsSupport(selected_style) && ui_->use_custom_color_set->isChecked();
+  s.setValue(kUseCustomColorSet, use_custom_color_set);
+  if (use_custom_color_set) {
+    for (const Appearance::ColorRole &color_role : Appearance::ColorRoles()) {
+      s.setValue(color_role.settings_key, current_colors_.value(color_role.role));
+    }
   }
   else {
-    s.setValue(kDarkMode, false);
-    const bool use_custom_color_set = ui_->use_custom_color_set->isChecked();
-    s.setValue(kUseCustomColorSet, use_custom_color_set);
-    if (use_custom_color_set) {
-      for (const Appearance::ColorRole &color_role : Appearance::ColorRoles()) {
-        s.setValue(color_role.settings_key, current_colors_.value(color_role.role));
-      }
-    }
-    else {
-      appearance_->ResetToSystemDefaultTheme();
-      for (const Appearance::ColorRole &color_role : Appearance::ColorRoles()) {
-        s.remove(color_role.settings_key);
-      }
+    QApplication::setPalette(system_palette_);
+    for (const Appearance::ColorRole &color_role : Appearance::ColorRoles()) {
+      s.remove(color_role.settings_key);
     }
   }
 
+  // Tabbar background color
+  s.setValue(kTabBarSystemColor, ui_->tabbar_system_color->isChecked());
+  s.setValue(kTabBarGradient, ui_->tabbar_gradient->isChecked());
+  s.setValue(kTabBarColor, current_tabbar_bg_color_);
+
+  // Currently playing song color
+  if (ui_->playlist_playing_song_color_system->isChecked()) {
+    s.setValue(kPlaylistPlayingSongColor, QColor());
+  }
+  else {
+    s.setValue(kPlaylistPlayingSongColor, current_playlist_playing_song_color_);
+  }
+
+  // Playlist background image
   background_image_filename_ = ui_->background_image_filename->text();
   if (ui_->use_default_background->isChecked()) {
     background_image_type_ = BackgroundImageType::Default;
@@ -309,18 +343,15 @@ void AppearanceSettingsPage::Save() {
   }
 
   s.setValue(kBackgroundImageMaxSize, ui_->spinbox_background_image_maxsize->value());
-  s.setValue(kBackgroundImagePosition, ui_->combobox_backgroundimageposition->currentData().toInt());
+  s.setValue(kBackgroundImagePosition, ui_->combobox_background_image_position->currentData().toInt());
   s.setValue(kBackgroundImageStretch, ui_->checkbox_background_image_stretch->isChecked());
   s.setValue(kBackgroundImageDoNotCut, ui_->checkbox_background_image_do_not_cut->isChecked());
   s.setValue(kBackgroundImageKeepAspectRatio, ui_->checkbox_background_image_keep_aspect_ratio->isChecked());
 
-  s.setValue(kBlurRadius, ui_->blur_slider->value());
-  s.setValue(kOpacityLevel, ui_->opacity_slider->value());
+  s.setValue(kBackgroundImageBlurRadius, ui_->slider_background_image_blur->value());
+  s.setValue(kBackgroundImageOpacityLevel, ui_->slider_background_image_opacity->value());
 
-  s.setValue(kTabBarSystemColor, ui_->tabbar_system_color->isChecked());
-  s.setValue(kTabBarGradient, ui_->tabbar_gradient->isChecked());
-  s.setValue(kTabBarColor, current_tabbar_bg_color_);
-
+  // Button sizes
   s.setValue(kIconSizeTabbarSmallMode, ui_->spinbox_icon_size_tabbar_small_mode->value());
   s.setValue(kIconSizeTabbarLargeMode, ui_->spinbox_icon_size_tabbar_large_mode->value());
   s.setValue(kIconSizePlayControlButtons, ui_->spinbox_icon_size_play_control_buttons->value());
@@ -328,71 +359,121 @@ void AppearanceSettingsPage::Save() {
   s.setValue(kIconSizeLeftPanelButtons, ui_->spinbox_icon_size_left_panel_buttons->value());
   s.setValue(kIconSizeConfigureButtons, ui_->spinbox_icon_size_configure_buttons->value());
 
-  if (ui_->playlist_playing_song_color_system->isChecked()) {
-    s.setValue(kPlaylistPlayingSongColor, QColor());
-  }
-  else {
-    s.setValue(kPlaylistPlayingSongColor, current_playlist_playing_song_color_);
-  }
-
   s.endGroup();
+
+  appearance_->set_system_palette(system_palette_);
 
 }
 
 void AppearanceSettingsPage::Cancel() {
 
-#if defined(Q_OS_WIN32) || defined(Q_OS_MACOS)
+  const QString current_style = QApplication::style() ? QApplication::style()->objectName() : QString();
+  if (original_style_.compare(current_style, Qt::CaseInsensitive) != 0) {
+    ApplyStyle(current_style, original_style_);
+  }
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
   QGuiApplication::styleHints()->setColorScheme(original_dark_mode_ ? Qt::ColorScheme::Dark : Qt::ColorScheme::Unknown);
 #endif
 
   if (original_use_custom_color_set_) {
-    Appearance::ChangeColors(original_colors_);
+    Appearance::SetCustomPaletteColors(original_colors_);
   }
   else {
-    appearance_->ResetToSystemDefaultTheme();
+    QApplication::setPalette(system_palette_);
   }
+
+  background_image_filename_ = original_background_image_filename_;
+  current_tabbar_bg_color_ = original_tabbar_bg_color_;
+  current_playlist_playing_song_color_ = original_playlist_playing_song_color_;
+
+}
+
+void AppearanceSettingsPage::InitStyle(const int index) {
+
+  SetStyle(index, false);
 
 }
 
 void AppearanceSettingsPage::StyleChanged(const int index) {
 
+  SetStyle(index, true);
+
+}
+
+void AppearanceSettingsPage::SetStyle(const int index, const bool apply) {
+
   const QString style_name = ui_->combobox_style->itemData(index).toString();
-  const bool is_native = IsNativeStyle(style_name);
-  const bool is_breeze = IsBreezeStyle();
+  SetStyle(style_name, apply);
 
-  ui_->checkbox_dark_mode->setVisible(is_native);
-  ui_->groupbox_colors->setEnabled(!is_native && !is_breeze);
-  ui_->groupbox_colors->setToolTip(is_breeze ? tr("Custom colors are not supported with the Breeze style, because Breeze colors the menubar and toolbars from the KDE color scheme instead of the application palette.") : QString());
+}
 
-#if defined(Q_OS_WIN32) || defined(Q_OS_MACOS)
-  if (is_native) {
-    appearance_->ResetToSystemDefaultTheme();
-    QGuiApplication::styleHints()->setColorScheme(ui_->checkbox_dark_mode->isChecked() ? Qt::ColorScheme::Dark : Qt::ColorScheme::Unknown);
+void AppearanceSettingsPage::SetStyle(const QString &new_style, const bool apply) {
+
+  QString current_style = QApplication::style() ? QApplication::style()->objectName() : QString();
+
+  bool style_changed = false;
+  if (apply) {
+    style_changed = ApplyStyle(current_style, new_style);
+    current_style = QApplication::style() ? QApplication::style()->objectName() : QString();
   }
-  else {
-    QGuiApplication::styleHints()->setColorScheme(Qt::ColorScheme::Unknown);
+
+  const QString style_for_caps = apply ? current_style : (new_style.compare("default"_L1, Qt::CaseInsensitive) == 0 ? appearance_->default_style() : new_style);
+  const bool custom_palette_colors_support = Utilities::StyleHasCustomPaletteColorsSupport(style_for_caps);
+  const bool dark_mode_support = Utilities::StyleHasDarkModeSupport(style_for_caps);
+
+  if (!dark_mode_support && ui_->checkbox_dark_mode->isChecked()) {
+    ui_->checkbox_dark_mode->setChecked(false);
+  }
+
+  if (!custom_palette_colors_support && !ui_->use_system_color_set->isChecked()) {
+    ui_->use_system_color_set->setChecked(true);
+  }
+
+  ui_->checkbox_dark_mode->setEnabled(dark_mode_support);
+  ui_->groupbox_colors->setEnabled(custom_palette_colors_support);
+
+  if (style_changed) {
+    QApplication::setPalette(QPalette());
+    system_palette_ = QApplication::palette();
     if (ui_->use_custom_color_set->isChecked()) {
       ApplyCustomColors();
     }
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+    QGuiApplication::styleHints()->setColorScheme(dark_mode_support && ui_->checkbox_dark_mode->isChecked() ? Qt::ColorScheme::Dark : Qt::ColorScheme::Unknown);
+#endif
+  }
+
+}
+
+bool AppearanceSettingsPage::ApplyStyle(const QString &current_style, const QString &new_style) {
+
+  QString effective_new_style = new_style;
+  if (new_style.compare("default"_L1, Qt::CaseInsensitive) == 0) {
+    effective_new_style = appearance_->default_style();
+  }
+  if (current_style.compare(effective_new_style, Qt::CaseInsensitive) != 0) {
+    qLog(Debug) << "Changing style from" << current_style << "to" << effective_new_style;
+    if (QApplication::setStyle(effective_new_style)) {
+      qLog(Debug) << "Style is set to" << effective_new_style;
+      return true;
+    }
     else {
-      appearance_->ResetToSystemDefaultTheme();
+      qLog(Warning) << "Could not set style" << effective_new_style;
     }
   }
-#endif
 
-  set_changed();
+  return false;
 
 }
 
 void AppearanceSettingsPage::DarkModeToggled(const bool checked) {
 
-#if defined(Q_OS_WIN32) || defined(Q_OS_MACOS)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
   QGuiApplication::styleHints()->setColorScheme(checked ? Qt::ColorScheme::Dark : Qt::ColorScheme::Unknown);
 #else
   Q_UNUSED(checked)
 #endif
-
-  set_changed();
 
 }
 
@@ -410,7 +491,7 @@ QString AppearanceSettingsPage::ColorRoleLabel(const QPalette::ColorRole color_r
     case QPalette::Button:          return tr("Button");
     case QPalette::ButtonText:      return tr("Button text");
     case QPalette::BrightText:      return tr("Bright text");
-    default:                        return QString();
+    default: return QString();
   }
 
 }
@@ -418,7 +499,6 @@ QString AppearanceSettingsPage::ColorRoleLabel(const QPalette::ColorRole color_r
 void AppearanceSettingsPage::CreateColorSelectors() {
 
   QFormLayout *layout = ui_->layout_custom_colors;
-
   for (const Appearance::ColorRole &color_role : Appearance::ColorRoles()) {
     QPushButton *button = new QPushButton(ui_->widget_custom_colors);
     button->setToolTip(tr("Select color"));
@@ -437,8 +517,9 @@ void AppearanceSettingsPage::SelectColor(const QPalette::ColorRole role) {
 
   current_colors_[role] = color_selected;
 
-  if (color_selectors_.contains(role)) {
-    UpdateColorSelectorColor(color_selectors_.value(role), color_selected);
+  const auto it = color_selectors_.constFind(role);
+  if (it != color_selectors_.constEnd() && it.value()) {
+    UpdateColorSelectorColor(it.value(), color_selected);
   }
 
   ApplyCustomColors();
@@ -448,7 +529,7 @@ void AppearanceSettingsPage::SelectColor(const QPalette::ColorRole role) {
 }
 
 void AppearanceSettingsPage::ApplyCustomColors() {
-  Appearance::ChangeColors(current_colors_);
+  Appearance::SetCustomPaletteColors(current_colors_);
 }
 
 void AppearanceSettingsPage::SetDarkColors() {
@@ -456,12 +537,9 @@ void AppearanceSettingsPage::SetDarkColors() {
   // Switch to a custom color set and fill it with colors suitable for a dark theme.
   ui_->use_custom_color_set->setChecked(true);
 
-  const QMap<QPalette::ColorRole, QColor> dark_colors = Appearance::DarkColors();
+  const QMap<QPalette::ColorRole, QColor> &dark_colors = Appearance::DarkColors();
   for (const Appearance::ColorRole &color_role : Appearance::ColorRoles()) {
-    const QPalette::ColorRole color_role_role = color_role.role;
-    if (dark_colors.contains(color_role_role)) {
-      current_colors_[color_role_role] = dark_colors.value(color_role_role);
-    }
+    current_colors_[color_role.role] = dark_colors.value(color_role.role);
   }
 
   UpdateColorSelectorsColors();
@@ -471,14 +549,13 @@ void AppearanceSettingsPage::SetDarkColors() {
 
 }
 
-void AppearanceSettingsPage::UseCustomColorSetOptionChanged(bool checked) {
+void AppearanceSettingsPage::UseCustomColorSetOptionChanged(const bool checked) {
 
   if (checked) {
     ApplyCustomColors();
   }
   else {
-    // Only restore the system palette for the preview; keep the user's custom picks in current_colors_ so they are not lost when switching back to a custom color set.
-    appearance_->ResetToSystemDefaultTheme();
+    QApplication::setPalette(system_palette_);
   }
 
 }
@@ -486,7 +563,7 @@ void AppearanceSettingsPage::UseCustomColorSetOptionChanged(bool checked) {
 void AppearanceSettingsPage::ResetToDefaultColors() {
 
   // Reset the custom color set back to the system default colors.
-  const QPalette p = appearance_->system_palette();
+  const QPalette &p = system_palette_;
   for (const Appearance::ColorRole &color_role : Appearance::ColorRoles()) {
     current_colors_[color_role.role] = p.color(color_role.role);
   }
@@ -501,18 +578,22 @@ void AppearanceSettingsPage::ResetToDefaultColors() {
 
 }
 
-void AppearanceSettingsPage::UpdateColorSelectorsColors() {
+void AppearanceSettingsPage::UpdateColorSelectorsColors() const {
 
-  for (QMap<QPalette::ColorRole, QPushButton*>::const_iterator it = color_selectors_.constBegin(); it != color_selectors_.constEnd(); ++it) {
-    UpdateColorSelectorColor(it.value(), current_colors_.value(it.key()));
+  for (auto it = color_selectors_.constBegin(); it != color_selectors_.constEnd(); ++it) {
+    if (it.value()) {
+      UpdateColorSelectorColor(it.value(), current_colors_.value(it.key()));
+    }
   }
 
 }
 
 void AppearanceSettingsPage::UpdateColorSelectorColor(QWidget *color_selector, const QColor &color) {
 
-  QString css = QStringLiteral("background-color: rgb(%1, %2, %3); color: rgb(255, 255, 255); border: 1px dotted black;").arg(color.red()).arg(color.green()).arg(color.blue());
-  color_selector->setStyleSheet(css);
+  const QString css = QStringLiteral("background-color: rgb(%1, %2, %3); color: rgb(255, 255, 255); border: 1px dotted black;").arg(color.red()).arg(color.green()).arg(color.blue());
+  if (color_selector->styleSheet() != css) {
+    color_selector->setStyleSheet(css);
+  }
 
 }
 
@@ -525,12 +606,12 @@ void AppearanceSettingsPage::SelectBackgroundImage() {
 
 }
 
-void AppearanceSettingsPage::BlurLevelChanged(const int value) {
-  ui_->background_blur_radius_label->setText(QStringLiteral("%1px").arg(value));
+void AppearanceSettingsPage::BackgroundImageBlurLevelChanged(const int value) {
+  ui_->label_background_image_blur_radius->setText(QStringLiteral("%1px").arg(value));
 }
 
-void AppearanceSettingsPage::OpacityLevelChanged(const int percent) {
-  ui_->background_opacity_label->setText(QStringLiteral("%1%").arg(percent));
+void AppearanceSettingsPage::BackgroundImageOpacityLevelChanged(const int percent) {
+  ui_->label_background_image_opacity->setText(QStringLiteral("%1%").arg(percent));
 }
 
 void AppearanceSettingsPage::TabBarSystemColor(const bool checked) {
@@ -541,8 +622,6 @@ void AppearanceSettingsPage::TabBarSystemColor(const bool checked) {
   }
   ui_->layout_tabbar_color->setEnabled(!checked);
   ui_->select_tabbar_color->setEnabled(!checked);
-
-  set_changed();
 
 }
 
@@ -568,8 +647,6 @@ void AppearanceSettingsPage::PlaylistPlayingSongColorSystem(const bool checked) 
   ui_->layout_playlist_playing_song_color_custom->setEnabled(!checked);
   ui_->select_playlist_playing_song_color->setEnabled(!checked);
 
-  set_changed();
-
 }
 
 void AppearanceSettingsPage::PlaylistPlayingSongSelectColor() {
@@ -582,26 +659,5 @@ void AppearanceSettingsPage::PlaylistPlayingSongSelectColor() {
   UpdateColorSelectorColor(ui_->select_playlist_playing_song_color, current_playlist_playing_song_color_);
 
   set_changed();
-
-}
-
-bool AppearanceSettingsPage::IsNativeStyle(const QString &style_name) {
-
-#if defined(Q_OS_WIN32)
-  return style_name.compare(u"default"_s, Qt::CaseInsensitive) == 0 || style_name.compare(u"windowsvista"_s, Qt::CaseInsensitive) == 0 || style_name.compare(u"windows11"_s, Qt::CaseInsensitive) == 0;
-#elif defined(Q_OS_MACOS)
-  return style_name.compare(u"default"_s, Qt::CaseInsensitive) == 0 || style_name.compare(u"macos"_s, Qt::CaseInsensitive) == 0;
-#else
-  Q_UNUSED(style_name)
-  return false;
-#endif
-
-}
-
-bool AppearanceSettingsPage::IsBreezeStyle() {
-
-  // Breeze colors the menubar and toolbars ("Tools Area") from the Header color set of the KDE color scheme and applies it directly to the widgets, so a custom application palette is never fully in effect with Breeze.
-  // This checks the active style, not the selected style, because style changes take effect on restart while palette colors apply to the running application.
-  return QApplication::style() && QApplication::style()->objectName().startsWith(u"breeze"_s, Qt::CaseInsensitive);
 
 }

--- a/src/settings/appearancesettingspage.h
+++ b/src/settings/appearancesettingspage.h
@@ -26,10 +26,12 @@
 
 #include <QObject>
 #include <QMap>
+#include <QPointer>
 #include <QString>
 #include <QColor>
 #include <QPalette>
 
+#include "includes/scoped_ptr.h"
 #include "includes/shared_ptr.h"
 #include "settingspage.h"
 #include "constants/appearancesettings.h"
@@ -43,6 +45,7 @@ class Appearance;
 
 class AppearanceSettingsPage : public SettingsPage {
   Q_OBJECT
+  Q_DISABLE_COPY_MOVE(AppearanceSettingsPage)
 
  public:
   explicit AppearanceSettingsPage(SettingsDialog *dialog, SharedPtr<Appearance> appearance, QWidget *parent = nullptr);
@@ -58,8 +61,8 @@ class AppearanceSettingsPage : public SettingsPage {
   void SetDarkColors();
   void ResetToDefaultColors();
   void SelectBackgroundImage();
-  void BlurLevelChanged(const int value);
-  void OpacityLevelChanged(const int percent);
+  void BackgroundImageBlurLevelChanged(const int value);
+  void BackgroundImageOpacityLevelChanged(const int percent);
   void TabBarSystemColor(const bool checked);
   void TabBarSelectBGColor();
   void PlaylistPlayingSongColorSystem(const bool checked);
@@ -67,13 +70,17 @@ class AppearanceSettingsPage : public SettingsPage {
 
  private:
   void Cancel() override;
+  void InitStyle(const int index);
+  void SetStyle(const int index, const bool apply);
+  void SetStyle(const QString &new_style, const bool apply);
+  bool ApplyStyle(const QString &current_style, const QString &new_style);
 
   // Set the widget's background to new_color
   static void UpdateColorSelectorColor(QWidget *color_selector, const QColor &new_color);
   // Create a color selector button for each palette role in the custom colors layout.
   void CreateColorSelectors();
   // Refresh all custom color selector buttons from current_colors_.
-  void UpdateColorSelectorsColors();
+  void UpdateColorSelectorsColors() const;
   // Open a color dialog for the given palette role and apply the result.
   void SelectColor(const QPalette::ColorRole role);
   // Apply current_colors_ to the application palette (live preview).
@@ -81,21 +88,23 @@ class AppearanceSettingsPage : public SettingsPage {
   // Human-readable label for a palette color role.
   static QString ColorRoleLabel(const QPalette::ColorRole role);
 
-  static bool IsNativeStyle(const QString &style_name);
-  static bool IsBreezeStyle();
-
-  Ui_AppearanceSettingsPage *ui_;
+  ScopedPtr<Ui_AppearanceSettingsPage> ui_;
   const SharedPtr<Appearance> appearance_;
 
+  QString original_style_;
+  QPalette system_palette_;
   bool original_dark_mode_;
   bool original_use_custom_color_set_;
   QMap<QPalette::ColorRole, QColor> original_colors_;
   QMap<QPalette::ColorRole, QColor> current_colors_;
-  QMap<QPalette::ColorRole, QPushButton*> color_selectors_;
+  QMap<QPalette::ColorRole, QPointer<QPushButton>> color_selectors_;
   QColor current_tabbar_bg_color_;
+  QColor original_tabbar_bg_color_;
   AppearanceSettings::BackgroundImageType background_image_type_;
   QString background_image_filename_;
+  QString original_background_image_filename_;
   QColor current_playlist_playing_song_color_;
+  QColor original_playlist_playing_song_color_;
 };
 
 #endif  // APPEARANCESETTINGSPAGE_H

--- a/src/settings/appearancesettingspage.ui
+++ b/src/settings/appearancesettingspage.ui
@@ -32,7 +32,7 @@
         <item>
          <widget class="QComboBox" name="combobox_style">
           <property name="toolTip">
-           <string>You need to restart Strawberry for this setting to take affect.</string>
+           <string>You might need to restart Strawberry for this setting to fully apply</string>
           </property>
          </widget>
         </item>
@@ -44,9 +44,19 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="checkbox_system_icons">
+          <property name="toolTip">
+           <string>You need to restart Strawberry for this setting to take affect</string>
+          </property>
+          <property name="text">
+           <string>System icons</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <spacer name="spacer_style">
           <property name="orientation">
-           <enum>Qt::Orientation::Horizontal</enum>
+           <enum>Qt::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -58,21 +68,14 @@
         </item>
        </layout>
       </item>
-      <item>
-       <widget class="QCheckBox" name="checkbox_system_icons">
-        <property name="toolTip">
-         <string>You need to restart Strawberry for this setting to take affect.</string>
-        </property>
-        <property name="text">
-         <string>Use system theme icons</string>
-        </property>
-       </widget>
-      </item>
      </layout>
     </widget>
    </item>
    <item>
     <widget class="QGroupBox" name="groupbox_colors">
+     <property name="toolTip">
+      <string>Changing colors is only supported with some styles</string>
+     </property>
      <property name="title">
       <string>Colors</string>
      </property>
@@ -104,7 +107,7 @@
            <string>Set a custom color set suitable for a dark theme</string>
           </property>
           <property name="text">
-           <string>Dark mode</string>
+           <string>Dark colors</string>
           </property>
          </widget>
         </item>
@@ -191,6 +194,47 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="playlist_playing_song_color">
+     <property name="title">
+      <string>Playlist playing song color</string>
+     </property>
+     <layout class="QVBoxLayout" name="layout_playlist_playing_song_color">
+      <item>
+       <widget class="QRadioButton" name="playlist_playing_song_color_system">
+        <property name="text">
+         <string>System highlight color</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="playlist_playing_song_color_custom">
+        <property name="text">
+         <string>Custom color</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="layout_playlist_playing_song_color_custom">
+        <item>
+         <widget class="QLabel" name="label_select_playlist_playing_song_color">
+          <property name="text">
+           <string>Select playlist playing song color:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="select_playlist_playing_song_color">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupbox_background_image">
      <property name="title">
       <string>Background image</string>
@@ -259,7 +303,7 @@
        </layout>
       </item>
       <item>
-       <widget class="QWidget" name="widget_custom_background_image_options" native="true">
+       <widget class="QWidget" name="widget_background_image_options" native="true">
         <layout class="QVBoxLayout" name="layout_custom_background_image_options">
          <property name="leftMargin">
           <number>0</number>
@@ -274,7 +318,7 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QWidget" name="widget_custom_position" native="true">
+          <widget class="QWidget" name="widget_background_image_custom_position" native="true">
            <layout class="QHBoxLayout" name="layout_custom_position">
             <property name="leftMargin">
              <number>0</number>
@@ -289,14 +333,14 @@
              <number>0</number>
             </property>
             <item>
-             <widget class="QLabel" name="label_position">
+             <widget class="QLabel" name="label_background_image_position">
               <property name="text">
                <string>Position</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QComboBox" name="combobox_backgroundimageposition">
+             <widget class="QComboBox" name="combobox_background_image_position">
               <item>
                <property name="text">
                 <string>Upper Left</string>
@@ -325,7 +369,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QLabel" name="label">
+             <widget class="QLabel" name="label_background_image_max_cover_size">
               <property name="text">
                <string>Max cover size</string>
               </property>
@@ -333,15 +377,18 @@
             </item>
             <item>
              <widget class="QSpinBox" name="spinbox_background_image_maxsize">
+              <property name="minimum">
+               <number>0</number>
+              </property>
               <property name="maximum">
                <number>9000</number>
               </property>
              </widget>
             </item>
             <item>
-             <spacer name="spacer_position">
+             <spacer name="spacer_background_image_position">
               <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
+               <enum>Qt::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -393,7 +440,7 @@
             <item>
              <spacer name="spacer_background_image_stretch">
               <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
+               <enum>Qt::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -407,9 +454,9 @@
           </widget>
          </item>
          <item>
-          <layout class="QGridLayout" name="layout_blur_opacity">
+          <layout class="QGridLayout" name="layout_background_image_blur_opacity">
            <item row="0" column="0">
-            <widget class="QLabel" name="select_background_blur_label">
+            <widget class="QLabel" name="label_background_image_blur">
              <property name="enabled">
               <bool>true</bool>
              </property>
@@ -419,7 +466,7 @@
             </widget>
            </item>
            <item row="0" column="1">
-            <widget class="QSlider" name="blur_slider">
+            <widget class="QSlider" name="slider_background_image_blur">
              <property name="minimum">
               <number>0</number>
              </property>
@@ -427,10 +474,10 @@
               <number>100</number>
              </property>
              <property name="orientation">
-              <enum>Qt::Orientation::Horizontal</enum>
+              <enum>Qt::Horizontal</enum>
              </property>
              <property name="tickPosition">
-              <enum>QSlider::TickPosition::TicksBelow</enum>
+              <enum>QSlider::TicksBelow</enum>
              </property>
              <property name="tickInterval">
               <number>10</number>
@@ -438,7 +485,7 @@
             </widget>
            </item>
            <item row="0" column="2">
-            <widget class="QLabel" name="background_blur_radius_label">
+            <widget class="QLabel" name="label_background_image_blur_radius">
              <property name="enabled">
               <bool>true</bool>
              </property>
@@ -448,14 +495,14 @@
             </widget>
            </item>
            <item row="1" column="0">
-            <widget class="QLabel" name="select_opacity_level_label">
+            <widget class="QLabel" name="label_background_image_opacity">
              <property name="text">
               <string>Opacity</string>
              </property>
             </widget>
            </item>
            <item row="1" column="1">
-            <widget class="QSlider" name="opacity_slider">
+            <widget class="QSlider" name="slider_background_image_opacity">
              <property name="maximum">
               <number>100</number>
              </property>
@@ -463,10 +510,10 @@
               <number>10</number>
              </property>
              <property name="orientation">
-              <enum>Qt::Orientation::Horizontal</enum>
+              <enum>Qt::Horizontal</enum>
              </property>
              <property name="tickPosition">
-              <enum>QSlider::TickPosition::TicksBelow</enum>
+              <enum>QSlider::TicksBelow</enum>
              </property>
              <property name="tickInterval">
               <number>10</number>
@@ -474,7 +521,7 @@
             </widget>
            </item>
            <item row="1" column="2">
-            <widget class="QLabel" name="background_opacity_label">
+            <widget class="QLabel" name="label_background_image_opacity_2">
              <property name="text">
               <string>40%</string>
              </property>
@@ -603,7 +650,7 @@
       <item>
        <spacer name="spacer_icon_sizes">
         <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
+         <enum>Qt::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -617,50 +664,9 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="playlist_playing_song_color">
-     <property name="title">
-      <string>Playlist playing song color</string>
-     </property>
-     <layout class="QVBoxLayout" name="layout_playlist_playing_song_color">
-      <item>
-       <widget class="QRadioButton" name="playlist_playing_song_color_system">
-        <property name="text">
-         <string>System highlight color</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="playlist_playing_song_color_custom">
-        <property name="text">
-         <string>Custom color</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="layout_playlist_playing_song_color_custom">
-        <item>
-         <widget class="QLabel" name="label_select_playlist_playing_song_color">
-          <property name="text">
-           <string>Select playlist playing song color:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="select_playlist_playing_song_color">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
     <spacer name="spacer_bottom">
      <property name="orientation">
-      <enum>Qt::Orientation::Vertical</enum>
+      <enum>Qt::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -684,6 +690,9 @@
   <tabstop>tabbar_custom_color</tabstop>
   <tabstop>tabbar_gradient</tabstop>
   <tabstop>select_tabbar_color</tabstop>
+  <tabstop>playlist_playing_song_color_system</tabstop>
+  <tabstop>playlist_playing_song_color_custom</tabstop>
+  <tabstop>select_playlist_playing_song_color</tabstop>
   <tabstop>use_default_background</tabstop>
   <tabstop>use_no_background</tabstop>
   <tabstop>use_album_cover_background</tabstop>
@@ -691,22 +700,19 @@
   <tabstop>use_custom_background_image</tabstop>
   <tabstop>background_image_filename</tabstop>
   <tabstop>select_background_image_filename_button</tabstop>
-  <tabstop>combobox_backgroundimageposition</tabstop>
+  <tabstop>combobox_background_image_position</tabstop>
   <tabstop>spinbox_background_image_maxsize</tabstop>
   <tabstop>checkbox_background_image_stretch</tabstop>
   <tabstop>checkbox_background_image_keep_aspect_ratio</tabstop>
   <tabstop>checkbox_background_image_do_not_cut</tabstop>
-  <tabstop>blur_slider</tabstop>
-  <tabstop>opacity_slider</tabstop>
+  <tabstop>slider_background_image_blur</tabstop>
+  <tabstop>slider_background_image_opacity</tabstop>
   <tabstop>spinbox_icon_size_tabbar_small_mode</tabstop>
   <tabstop>spinbox_icon_size_tabbar_large_mode</tabstop>
   <tabstop>spinbox_icon_size_play_control_buttons</tabstop>
   <tabstop>spinbox_icon_size_playlist_buttons</tabstop>
   <tabstop>spinbox_icon_size_left_panel_buttons</tabstop>
   <tabstop>spinbox_icon_size_configure_buttons</tabstop>
-  <tabstop>playlist_playing_song_color_system</tabstop>
-  <tabstop>playlist_playing_song_color_custom</tabstop>
-  <tabstop>select_playlist_playing_song_color</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/utilities/styleutils.cpp
+++ b/src/utilities/styleutils.cpp
@@ -1,0 +1,54 @@
+/*
+ * Strawberry Music Player
+ * Copyright 2026, Jonas Kvinge <jonas@jkvinge.net>
+ *
+ * Strawberry is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Strawberry is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Strawberry.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <QtGlobal>
+#include <QString>
+
+#include "styleutils.h"
+
+using namespace Qt::StringLiterals;
+
+namespace Utilities {
+
+bool StyleHasCustomPaletteColorsSupport(const QString &style_name) {
+
+#if defined(Q_OS_WIN32)
+  return style_name.compare(u"windows"_s, Qt::CaseInsensitive) != 0 && style_name.compare(u"windowsvista"_s, Qt::CaseInsensitive) != 0 && style_name.compare(u"windows11"_s, Qt::CaseInsensitive) != 0;
+#elif defined(Q_OS_MACOS)
+  return style_name.compare(u"macos"_s, Qt::CaseInsensitive) != 0;
+#else
+  return style_name.compare(u"breeze"_s, Qt::CaseInsensitive) != 0;
+#endif
+
+}
+
+bool StyleHasDarkModeSupport(const QString &style_name) {
+
+#if defined(Q_OS_WIN32)
+  return style_name.compare(u"windows"_s, Qt::CaseInsensitive) == 0 || style_name.compare(u"windows11"_s, Qt::CaseInsensitive) == 0;
+#elif defined(Q_OS_MACOS)
+  return style_name.compare(u"macos"_s, Qt::CaseInsensitive) == 0;
+#else
+  Q_UNUSED(style_name)
+  return false;
+#endif
+
+}
+
+}  // namespace Utilities

--- a/src/utilities/styleutils.h
+++ b/src/utilities/styleutils.h
@@ -1,0 +1,32 @@
+/*
+ * Strawberry Music Player
+ * Copyright 2026, Jonas Kvinge <jonas@jkvinge.net>
+ *
+ * Strawberry is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Strawberry is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Strawberry.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef STYLEUTILS_H
+#define STYLEUTILS_H
+
+#include <QString>
+
+namespace Utilities {
+
+bool StyleHasCustomPaletteColorsSupport(const QString &style_name);
+bool StyleHasDarkModeSupport(const QString &style_name);
+
+}  // namespace Utilities
+
+#endif  // STYLEUTILS_H


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/relocated “currently playing song color” controls (system highlight vs custom).
  * Added a “System icons” appearance option with updated restart messaging.

* **Improvements**
  * Theme/style switching now preserves and restores the selected Qt style and palette more reliably, including custom per-role colors when supported.
  * Dark colors and custom palette options are available only for compatible styles.
  * Refreshed playlist background image controls (including blur/opacity defaults and restoration).

* **Bug Fixes**
  * Empty/“default” style selections no longer write unintended values; if applying a style fails, the previous style is restored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->