### PR TITLE
MacOsDeviceLister: Stop the run loop directly on exit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1630,6 +1630,7 @@ if(APPLE)
     "-framework DiskArbitration"
     "-framework IOKit"
     "-framework ScriptingBridge"
+    "-framework UserNotifications"
   )
   if(HAVE_SPARKLE)
     target_include_directories(strawberry_lib SYSTEM PRIVATE ${SPARKLE}/Headers)

--- a/src/core/mac_startup.mm
+++ b/src/core/mac_startup.mm
@@ -41,6 +41,8 @@
 
 #import <QuartzCore/CALayer.h>
 
+#import <UserNotifications/UserNotifications.h>
+
 //#import <SPMediaKeyTap.h>
 
 #include "config.h"
@@ -217,11 +219,16 @@ QDebug operator<<(QDebug dbg, NSObject *object) {
   return NSTerminateNow;
 }
 
-- (BOOL) userNotificationCenter: (id)center shouldPresentNotification: (id)notification {
+- (void) userNotificationCenter: (UNUserNotificationCenter*)center
+    willPresentNotification: (UNNotification*)notification
+    withCompletionHandler: (void (^)(UNNotificationPresentationOptions options))completionHandler {
+
   Q_UNUSED(center);
   Q_UNUSED(notification);
+
   // Always show notifications, even if Strawberry is in the foreground.
-  return YES;
+  completionHandler(UNNotificationPresentationOptionBanner | UNNotificationPresentationOptionList);
+
 }
 
 @end
@@ -257,15 +264,13 @@ QDebug operator<<(QDebug dbg, NSObject *object) {
   [delegate_ setShortcutHandler:shortcut_handler_];
   [self setDelegate:delegate_];
 
-  // FIXME
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-  [[NSUserNotificationCenter defaultUserNotificationCenter]setDelegate:delegate_];
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+  UNUserNotificationCenter *notification_center = [UNUserNotificationCenter currentNotificationCenter];
+  notification_center.delegate = delegate_;
+  [notification_center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionSound) completionHandler:^(BOOL granted, NSError *error) {
+    if (!granted) {
+      qLog(Warning) << "Notification authorization was not granted:" << (error ? QString::fromNSString(error.localizedDescription) : QStringLiteral("Unknown error"));
+    }
+  }];
 
 }
 

--- a/src/device/macosdevicelister.h
+++ b/src/device/macosdevicelister.h
@@ -2,7 +2,7 @@
  * Strawberry Music Player
  * This file was part of Clementine.
  * Copyright 2010, David Sansome <me@davidsansome.com>
- * Copyright 2018-2025, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2018-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,6 +27,8 @@
 #include <DiskArbitration/DADisk.h>
 #include <DiskArbitration/DADissenter.h>
 #include <IOKit/IOKitLib.h>
+
+#include <atomic>
 
 #include <QtGlobal>
 #include <QObject>
@@ -102,8 +104,8 @@ class MacOsDeviceLister : public DeviceLister {
 
   bool IsCDDevice(const QString &serial) const;
 
-  DASessionRef loop_session_;
-  CFRunLoopRef run_loop_;
+  DASessionRef loop_session_ = nullptr;
+  std::atomic<CFRunLoopRef> run_loop_ = nullptr;
 
   QMap<QString, QString> current_devices_;
 #ifdef HAVE_MTP

--- a/src/device/macosdevicelister.mm
+++ b/src/device/macosdevicelister.mm
@@ -2,7 +2,7 @@
  * Strawberry Music Player
  * This file was part of Clementine.
  * Copyright 2010, David Sansome <me@davidsansome.com>
- * Copyright 2018-2025, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2018-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -119,7 +119,11 @@ size_t qHash(const MacOsDeviceLister::MTPDevice &mtp_device) {
 
 MacOsDeviceLister::MacOsDeviceLister(QObject *parent) : DeviceLister(parent) {}
 
-MacOsDeviceLister::~MacOsDeviceLister() { CFRelease(loop_session_); }
+MacOsDeviceLister::~MacOsDeviceLister() {
+  if (loop_session_) {
+    CFRelease(loop_session_);
+  }
+}
 
 bool MacOsDeviceLister::Init() {
 
@@ -214,10 +218,27 @@ bool MacOsDeviceLister::Init() {
 }
 
 void MacOsDeviceLister::ExitAsync() {
+
+  // Init() blocks this object's thread in CFRunLoopRun() before that thread's Qt event loop ever starts, so a queued cross-thread call (like the base class's Exit()) never gets delivered and exit would hang.
+  // Stop the run loop directly instead, which is safe to call from any thread. Once CFRunLoopRun() returns, QThread::run() proceeds to call exec(), so also ask the thread to quit: QThread::quit() marks the thread as should-exit even if called before exec() starts, so exec() returns immediately once it is reached instead of running forever.
+  ShutDown();
+  if (thread_) {
+    thread_->quit();
+    thread_->wait();
+  }
   Q_EMIT ExitFinished();
+
 }
 
-void MacOsDeviceLister::ShutDown() { CFRunLoopStop(run_loop_); }
+void MacOsDeviceLister::ShutDown() {
+
+  // Init() may not have run yet (and set run_loop_) if the thread has only just been started, or hasn't started at all.
+  const CFRunLoopRef run_loop = run_loop_.load();
+  if (run_loop) {
+    CFRunLoopStop(run_loop);
+  }
+
+}
 
 // IOKit helpers.
 namespace {

--- a/src/includes/mac_delegate.h
+++ b/src/includes/mac_delegate.h
@@ -1,4 +1,5 @@
 #import <AppKit/NSApplication.h>
+#import <UserNotifications/UserNotifications.h>
 
 #include "config.h"
 #include "globalshortcuts/globalshortcutsbackend-macos.h"
@@ -6,7 +7,7 @@
 class PlatformInterface;
 //@class SPMediaKeyTap;
 
-@interface AppDelegate : NSObject<NSApplicationDelegate, NSUserNotificationCenterDelegate> {
+@interface AppDelegate : NSObject<NSApplicationDelegate, UNUserNotificationCenterDelegate> {
   PlatformInterface *application_handler_;
   NSMenu *dock_menu_;
   GlobalShortcutsBackendMacOS *shortcut_handler_;
@@ -22,9 +23,10 @@ class PlatformInterface;
 - (void)applicationDidFinishLaunching:(NSNotification*)aNotification;
 - (NSApplicationTerminateReply) applicationShouldTerminate:(NSApplication*)sender;
 
-// NSUserNotificationCenterDelegate
-- (BOOL) userNotificationCenter: (id)center
-    shouldPresentNotification: (id)notification;
+// UNUserNotificationCenterDelegate
+- (void) userNotificationCenter: (UNUserNotificationCenter*)center
+    willPresentNotification: (UNNotification*)notification
+    withCompletionHandler: (void (^)(UNNotificationPresentationOptions options))completionHandler;
 
 - (void) setDockMenu: (NSMenu*)menu;
 - (GlobalShortcutsBackendMacOS*) shortcut_handler;

--- a/src/osd/osdmac.h
+++ b/src/osd/osdmac.h
@@ -2,7 +2,7 @@
  * Strawberry Music Player
  * This file was part of Clementine.
  * Copyright 2010, David Sansome <me@davidsansome.com>
- * Copyright 2018-2021, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2018-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,8 +23,6 @@
 #define OSDMAC_H
 
 #include "config.h"
-
-#include <memory>
 
 #include <QtGlobal>
 #include <QObject>

--- a/src/osd/osdmac.mm
+++ b/src/osd/osdmac.mm
@@ -2,7 +2,7 @@
  * Strawberry Music Player
  * This file was part of Clementine.
  * Copyright 2010, David Sansome <me@davidsansome.com>
- * Copyright 2018-2021, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2018-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,6 +19,8 @@
  *
  */
 
+#import <UserNotifications/UserNotifications.h>
+
 #include "config.h"
 
 #include <memory>
@@ -26,28 +28,33 @@
 #include <QBuffer>
 #include <QByteArray>
 #include <QFile>
+#include <QString>
 
 #include "includes/scoped_nsobject.h"
+
+#include "core/logging.h"
 
 #include "osdmac.h"
 
 namespace {
 
 bool NotificationCenterSupported() {
-  return NSClassFromString(@"NSUserNotificationCenter");
+  return [UNUserNotificationCenter currentNotificationCenter] != nil;
 }
 
 void SendNotificationCenterMessage(NSString *title, NSString *subtitle) {
 
-  Class clazz = NSClassFromString(@"NSUserNotificationCenter");
-  id notification_center = [clazz defaultUserNotificationCenter];
+  scoped_nsobject<UNMutableNotificationContent> content([[UNMutableNotificationContent alloc] init]);
+  [content setTitle:title];
+  [content setSubtitle:subtitle];
 
-  Class user_notification_class = NSClassFromString(@"NSUserNotification");
-  id notification = [[user_notification_class alloc] init];
-  [notification setTitle:title];
-  [notification setSubtitle:subtitle];
+  UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:[[NSUUID UUID] UUIDString] content:content.get() trigger:nil];
 
-  [notification_center deliverNotification:notification];
+  [[UNUserNotificationCenter currentNotificationCenter] addNotificationRequest:request withCompletionHandler:^(NSError *error) {
+    if (error) {
+      qLog(Warning) << "Failed to deliver notification:" << QString::fromNSString(error.localizedDescription);
+    }
+  }];
 
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS device shutdown so the background worker thread and run loop stop cleanly before exit completes.
  * Prevented potential lingering background run loop activity when closing the app.
* **Improvements**
  * Updated macOS notifications to the modern UserNotifications framework for more reliable alert delivery.
  * Added proper delegate handling and notification authorization checks so supported notifications display consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->