### PR TITLE
Remove pragma GCC diagnostic ignored "-Warray-bounds"

### DIFF
--- a/src/equalizer/equalizer.cpp
+++ b/src/equalizer/equalizer.cpp
@@ -117,14 +117,7 @@ void Equalizer::ReloadSettings() {
   const int count = s.beginReadArray(kPresets);
   for (int i = 0; i < count; ++i) {
     s.setArrayIndex(i);
-#ifdef __GNUC__
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Warray-bounds"
-#endif
     AddPreset(s.value(kName).toString(), s.value(kParams).value<Equalizer::Params>());
-#ifdef __GNUC__
-#  pragma GCC diagnostic pop
-#endif
   }
   s.endArray();
 

--- a/src/mpris2/mpris2.cpp
+++ b/src/mpris2/mpris2.cpp
@@ -57,19 +57,10 @@
 #include "covermanager/currentalbumcoverloader.h"
 #include "covermanager/albumcoverloaderresult.h"
 
-#ifdef __GNUC__
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Warray-bounds"
-#endif
-
 #include "mpris2_player.h"
 #include "mpris2_playlists.h"
 #include "mpris2_root.h"
 #include "mpris2_tracklist.h"
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic pop
-#endif
 
 using namespace Qt::Literals::StringLiterals;
 

--- a/src/mpris2/mpris2.h
+++ b/src/mpris2/mpris2.h
@@ -62,20 +62,11 @@ using MprisPlaylistList = QList<MprisPlaylist>;
 Q_DECLARE_METATYPE(MprisPlaylist)
 Q_DECLARE_METATYPE(MprisPlaylistList)
 
-#ifdef __GNUC__
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Warray-bounds"
-#endif
-
 struct MaybePlaylist {
   bool valid{};
   MprisPlaylist playlist;
 };
 Q_DECLARE_METATYPE(MaybePlaylist)
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic pop
-#endif
 
 QDBusArgument &operator<<(QDBusArgument &arg, const MprisPlaylist &playlist);
 const QDBusArgument &operator>>(const QDBusArgument &arg, MprisPlaylist &playlist);

--- a/src/settings/backendsettingspage.cpp
+++ b/src/settings/backendsettingspage.cpp
@@ -72,11 +72,6 @@ static const QRegularExpression kRegex_ALSA_PCM_Dev(u"^.*:.*DEV=.*"_s);
 #endif
 }  // namespace
 
-#ifdef __GNUC__
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Warray-bounds"
-#endif
-
 BackendSettingsPage::BackendSettingsPage(SettingsDialog *dialog, const SharedPtr<Player> player, const SharedPtr<DeviceFinders> device_finders, QWidget *parent)
     : SettingsPage(dialog, parent),
       ui_(new Ui_BackendSettingsPage),
@@ -776,6 +771,3 @@ void BackendSettingsPage::BufferDefaults() {
 
 }
 
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif

--- a/src/transcoder/transcodedialog.cpp
+++ b/src/transcoder/transcodedialog.cpp
@@ -78,11 +78,6 @@ constexpr char kLastOutputFormat[] = "last_output_format";
 constexpr char kGeometry[] = "geometry";
 }  // namespace
 
-#ifdef __GNUC__
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Warray-bounds"
-#endif
-
 static bool ComparePresetsByName(const TranscoderPreset &left, const TranscoderPreset &right) {
   return left.name_ < right.name_;
 }
@@ -503,6 +498,3 @@ QString TranscodeDialog::GetOutputFileName(const QString &input_filepath, const 
 
 }
 
-#ifdef __GNUC__
-#  pragma GCC diagnostic pop
-#endif


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up compiler warning suppression in several areas of the app.
  * No user-facing behavior or settings were changed.
  * Internal code paths were simplified without affecting playback, transcoding, or settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->