### PR TITLE
WinSystemMediaTransportControls: Encode image to JPEG bytes in memory

### DIFF
--- a/src/core/winsystemmediatransportcontrols.cpp
+++ b/src/core/winsystemmediatransportcontrols.cpp
@@ -48,6 +48,7 @@ extern "C" HRESULT WINAPI CreateRandomAccessStreamOverStream(IStream *stream, BS
 #include <QImage>
 #include <QBuffer>
 #include <QUrl>
+#include <QTimer>
 
 #include "core/logging.h"
 #include "core/song.h"
@@ -77,10 +78,18 @@ WinSystemMediaTransportControls::WinSystemMediaTransportControls(SharedPtr<Playe
       player_(player),
       ro_initialized_(false),
       smtc_(nullptr),
+      smtc2_(nullptr),
       updater_(nullptr),
       button_handler_(nullptr),
       button_pressed_token_(0),
-      state_(EngineBase::State::Empty) {}
+      state_(EngineBase::State::Empty),
+      current_duration_nanosec_(0),
+      timeline_timer_(new QTimer(this)) {
+
+  timeline_timer_->setInterval(1000);
+  QObject::connect(timeline_timer_, &QTimer::timeout, this, &WinSystemMediaTransportControls::UpdateTimeline);
+
+}
 
 WinSystemMediaTransportControls::~WinSystemMediaTransportControls() {
 
@@ -100,6 +109,11 @@ WinSystemMediaTransportControls::~WinSystemMediaTransportControls() {
   if (updater_) {
     static_cast<ISystemMediaTransportControlsDisplayUpdater*>(updater_)->Release();
     updater_ = nullptr;
+  }
+
+  if (smtc2_) {
+    static_cast<ABI::Windows::Media::ISystemMediaTransportControls2*>(smtc2_)->Release();
+    smtc2_ = nullptr;
   }
 
   if (smtc) {
@@ -188,6 +202,14 @@ bool WinSystemMediaTransportControls::Initialize(const HWND hwnd) {
   smtc_ = smtc;
   updater_ = updater;
 
+  ABI::Windows::Media::ISystemMediaTransportControls2 *smtc2 = nullptr;
+  if (SUCCEEDED(smtc->QueryInterface(__uuidof(ABI::Windows::Media::ISystemMediaTransportControls2), reinterpret_cast<void**>(&smtc2)))) {
+    smtc2_ = smtc2;
+  }
+  else {
+    qLog(Warning) << "WinSystemMediaTransportControls: ISystemMediaTransportControls2 unavailable, timeline disabled";
+  }
+
   qLog(Info) << "WinSystemMediaTransportControls: Initialized";
 
   return true;
@@ -199,12 +221,22 @@ void WinSystemMediaTransportControls::EngineStateChanged(const EngineBase::State
   state_ = state;
   UpdatePlaybackStatus(state);
 
+  if (state == EngineBase::State::Playing) {
+    timeline_timer_->start();
+  }
+  else {
+    timeline_timer_->stop();
+    UpdateTimeline();
+  }
+
 }
 
 void WinSystemMediaTransportControls::CurrentSongChanged(const Song &song) {
 
   current_song_url_ = song.url();
+  current_duration_nanosec_ = song.length_nanosec();
   UpdateMetadata(song);
+  UpdateTimeline();
 
 }
 
@@ -218,6 +250,46 @@ void WinSystemMediaTransportControls::AlbumCoverLoaded(const Song &song, const A
   else {
     ClearThumbnail();
   }
+
+}
+
+void WinSystemMediaTransportControls::UpdateTimeline() {
+
+  if (!smtc2_) return;
+
+  ABI::Windows::Media::ISystemMediaTransportControls2 *smtc2 = static_cast<ABI::Windows::Media::ISystemMediaTransportControls2*>(smtc2_);
+
+  HSTRING h_class = nullptr;
+  static const wchar_t kClass[] = L"Windows.Media.SystemMediaTransportControlsTimelineProperties";
+  WindowsCreateString(kClass, static_cast<UINT32>(wcslen(kClass)), &h_class);
+
+  IInspectable *insp = nullptr;
+  const HRESULT hr = RoActivateInstance(h_class, &insp);
+  WindowsDeleteString(h_class);
+  if (FAILED(hr) || !insp) return;
+
+  ABI::Windows::Media::ISystemMediaTransportControlsTimelineProperties *props = nullptr;
+  if (FAILED(insp->QueryInterface(__uuidof(ABI::Windows::Media::ISystemMediaTransportControlsTimelineProperties), reinterpret_cast<void**>(&props))) || !props) {
+    insp->Release();
+    return;
+  }
+  insp->Release();
+
+  const qint64 pos_ns = player_->engine()->position_nanosec();
+  const qint64 dur_ns = current_duration_nanosec_ > 0 ? current_duration_nanosec_ : player_->engine()->length_nanosec();
+
+  ABI::Windows::Foundation::TimeSpan zero_ts = {};
+  ABI::Windows::Foundation::TimeSpan pos_ts = { pos_ns / 100 };
+  ABI::Windows::Foundation::TimeSpan dur_ts = { dur_ns / 100 };
+
+  props->put_StartTime(zero_ts);
+  props->put_EndTime(dur_ts);
+  props->put_MinSeekTime(zero_ts);
+  props->put_MaxSeekTime(dur_ts);
+  props->put_Position(pos_ts);
+
+  smtc2->UpdateTimelineProperties(props);
+  props->Release();
 
 }
 

--- a/src/core/winsystemmediatransportcontrols.cpp
+++ b/src/core/winsystemmediatransportcontrols.cpp
@@ -20,6 +20,7 @@
 #include "config.h"
 
 #include <windows.h>
+#include <objbase.h>
 #include <winstring.h>
 #include <roapi.h>
 #include <inspectable.h>
@@ -36,13 +37,17 @@
 
 #include <systemmediatransportcontrolsinterop.h>
 
+// robuffer.h may not be present in all SDK installs; declare the shcore.dll function manually.
+typedef enum BSOS_OPTIONS { BSOS_DEFAULT = 0, BSOS_PREFERDESTINATIONSTREAM = 1 } BSOS_OPTIONS;
+extern "C" HRESULT WINAPI CreateRandomAccessStreamOverStream(IStream *stream, BSOS_OPTIONS options, REFIID riid, void **ppv);
+#pragma comment(lib, "shcore.lib")
+
 #include <QObject>
 #include <QMetaObject>
 #include <QString>
 #include <QImage>
+#include <QBuffer>
 #include <QUrl>
-#include <QDir>
-#include <QFile>
 
 #include "core/logging.h"
 #include "core/song.h"
@@ -105,10 +110,6 @@ WinSystemMediaTransportControls::~WinSystemMediaTransportControls() {
 
   if (ro_initialized_) {
     RoUninitialize();
-  }
-
-  if (!temp_art_path_.isEmpty()) {
-    QFile::remove(temp_art_path_);
   }
 
 }
@@ -293,51 +294,53 @@ void WinSystemMediaTransportControls::UpdateMetadata(const Song &song) {
 
 void WinSystemMediaTransportControls::SetThumbnail(const QImage &image) {
 
-  if (temp_art_path_.isEmpty()) {
-    temp_art_path_ = QDir::tempPath() + QStringLiteral("/strawberry_smtc_art.jpg");
-  }
-
-  if (!image.save(temp_art_path_, "JPEG", 90)) {
-    qLog(Warning) << "WinSystemMediaTransportControls: Failed to save thumbnail";
-    ClearThumbnail();
-    return;
-  }
-
-  SetThumbnailFromFile(temp_art_path_);
-
-}
-
-void WinSystemMediaTransportControls::SetThumbnailFromFile(const QString &path) {
-
   if (!updater_) return;
 
   ISystemMediaTransportControlsDisplayUpdater *updater = static_cast<ISystemMediaTransportControlsDisplayUpdater*>(updater_);
 
-  const QString file_uri = QUrl::fromLocalFile(path).toString(QUrl::FullyEncoded);
+  // Encode image to JPEG bytes in memory
+  QByteArray jpeg_data;
+  {
+    QBuffer buf(&jpeg_data);
+    buf.open(QIODevice::WriteOnly);
+    if (!image.save(&buf, "JPEG", 90)) {
+      qLog(Warning) << "WinSystemMediaTransportControls: Failed to encode thumbnail";
+      ClearThumbnail();
+      return;
+    }
+  }
 
-  // Create WinRT Uri object
-  HSTRING h_uri_class = nullptr;
-  static const wchar_t kUriClass[] = L"Windows.Foundation.Uri";
-  WindowsCreateString(kUriClass, static_cast<UINT32>(wcslen(kUriClass)), &h_uri_class);
+  // Create a COM IStream over the JPEG bytes
+  HGLOBAL hg = GlobalAlloc(GMEM_MOVEABLE, static_cast<SIZE_T>(jpeg_data.size()));
+  if (!hg) {
+    ClearThumbnail();
+    return;
+  }
+  void *ptr = GlobalLock(hg);
+  if (!ptr) {
+    GlobalFree(hg);
+    ClearThumbnail(); return;
+  }
+  memcpy(ptr, jpeg_data.constData(), static_cast<size_t>(jpeg_data.size()));
+  GlobalUnlock(hg);
 
-  IUriRuntimeClassFactory *uri_factory = nullptr;
-  HRESULT hr = RoGetActivationFactory(h_uri_class, __uuidof(IUriRuntimeClassFactory), reinterpret_cast<void**>(&uri_factory));
-  WindowsDeleteString(h_uri_class);
+  IStream *stream = nullptr;
+  if (FAILED(CreateStreamOnHGlobal(hg, TRUE, &stream)) || !stream) {
+    GlobalFree(hg);
+    ClearThumbnail();
+    return;
+  }
 
-  if (FAILED(hr) || !uri_factory) return;
+  // Wrap as a WinRT IRandomAccessStream
+  IRandomAccessStream *ra_stream = nullptr;
+  HRESULT hr = CreateRandomAccessStreamOverStream(stream, BSOS_DEFAULT, __uuidof(IRandomAccessStream), reinterpret_cast<void**>(&ra_stream));
+  stream->Release();
+  if (FAILED(hr) || !ra_stream) {
+    ClearThumbnail();
+    return;
+  }
 
-  HSTRING h_uri = nullptr;
-  const std::wstring w_uri = file_uri.toStdWString();
-  WindowsCreateString(w_uri.c_str(), static_cast<UINT32>(w_uri.size()), &h_uri);
-
-  IUriRuntimeClass *uri = nullptr;
-  hr = uri_factory->CreateUri(h_uri, &uri);
-  WindowsDeleteString(h_uri);
-  uri_factory->Release();
-
-  if (FAILED(hr) || !uri) return;
-
-  // Create RandomAccessStreamReference from the file URI
+  // Create a RandomAccessStreamReference from the stream
   HSTRING h_stream_class = nullptr;
   static const wchar_t kStreamRefClass[] = L"Windows.Storage.Streams.RandomAccessStreamReference";
   WindowsCreateString(kStreamRefClass, static_cast<UINT32>(wcslen(kStreamRefClass)), &h_stream_class);
@@ -345,18 +348,20 @@ void WinSystemMediaTransportControls::SetThumbnailFromFile(const QString &path) 
   IRandomAccessStreamReferenceStatics *stream_statics = nullptr;
   hr = RoGetActivationFactory(h_stream_class, __uuidof(IRandomAccessStreamReferenceStatics), reinterpret_cast<void**>(&stream_statics));
   WindowsDeleteString(h_stream_class);
-
   if (FAILED(hr) || !stream_statics) {
-    uri->Release();
+    ra_stream->Release();
+    ClearThumbnail();
     return;
   }
 
   IRandomAccessStreamReference *stream_ref = nullptr;
-  hr = stream_statics->CreateFromUri(uri, &stream_ref);
-  uri->Release();
+  hr = stream_statics->CreateFromStream(ra_stream, &stream_ref);
+  ra_stream->Release();
   stream_statics->Release();
-
-  if (FAILED(hr) || !stream_ref) return;
+  if (FAILED(hr) || !stream_ref) {
+    ClearThumbnail();
+    return;
+  }
 
   updater->put_Thumbnail(stream_ref);
   stream_ref->Release();

--- a/src/core/winsystemmediatransportcontrols.cpp
+++ b/src/core/winsystemmediatransportcontrols.cpp
@@ -20,7 +20,6 @@
 #include "config.h"
 
 #include <windows.h>
-#include <objbase.h>
 #include <winstring.h>
 #include <roapi.h>
 #include <inspectable.h>
@@ -36,11 +35,6 @@
 #endif
 
 #include <systemmediatransportcontrolsinterop.h>
-
-// robuffer.h may not be present in all SDK installs; declare the shcore.dll function manually.
-typedef enum BSOS_OPTIONS { BSOS_DEFAULT = 0, BSOS_PREFERDESTINATIONSTREAM = 1 } BSOS_OPTIONS;
-extern "C" HRESULT WINAPI CreateRandomAccessStreamOverStream(IStream *stream, BSOS_OPTIONS options, REFIID riid, void **ppv);
-#pragma comment(lib, "shcore.lib")
 
 #include <QObject>
 #include <QMetaObject>
@@ -382,55 +376,108 @@ void WinSystemMediaTransportControls::SetThumbnail(const QImage &image) {
     }
   }
 
-  // Create a COM IStream over the JPEG bytes
-  HGLOBAL hg = GlobalAlloc(GMEM_MOVEABLE, static_cast<SIZE_T>(jpeg_data.size()));
-  if (!hg) {
-    ClearThumbnail();
-    return;
-  }
-  void *ptr = GlobalLock(hg);
-  if (!ptr) {
-    GlobalFree(hg);
-    ClearThumbnail(); return;
-  }
-  memcpy(ptr, jpeg_data.constData(), static_cast<size_t>(jpeg_data.size()));
-  GlobalUnlock(hg);
-
-  IStream *stream = nullptr;
-  if (FAILED(CreateStreamOnHGlobal(hg, TRUE, &stream)) || !stream) {
-    GlobalFree(hg);
-    ClearThumbnail();
-    return;
-  }
-
-  // Wrap as a WinRT IRandomAccessStream
+  // Create InMemoryRandomAccessStream — an agile (free-threaded) WinRT type.
+  // Unlike CreateRandomAccessStreamOverStream, it has no STA affinity, so the SMTC background MTA thread can call OpenReadAsync without marshaling back to the GUI STA.
   IRandomAccessStream *ra_stream = nullptr;
-  HRESULT hr = CreateRandomAccessStreamOverStream(stream, BSOS_DEFAULT, __uuidof(IRandomAccessStream), reinterpret_cast<void**>(&ra_stream));
-  stream->Release();
-  if (FAILED(hr) || !ra_stream) {
+  {
+    HSTRING h = nullptr;
+    static const wchar_t kImsClass[] = L"Windows.Storage.Streams.InMemoryRandomAccessStream";
+    WindowsCreateString(kImsClass, static_cast<UINT32>(wcslen(kImsClass)), &h);
+    IInspectable *insp = nullptr;
+    const HRESULT hr = RoActivateInstance(h, &insp);
+    WindowsDeleteString(h);
+    if (FAILED(hr) || !insp) {
+      ClearThumbnail();
+      return;
+    }
+    insp->QueryInterface(__uuidof(IRandomAccessStream), reinterpret_cast<void**>(&ra_stream));
+    insp->Release();
+  }
+  if (!ra_stream) {
     ClearThumbnail();
     return;
   }
 
-  // Create a RandomAccessStreamReference from the stream
-  HSTRING h_stream_class = nullptr;
-  static const wchar_t kStreamRefClass[] = L"Windows.Storage.Streams.RandomAccessStreamReference";
-  WindowsCreateString(kStreamRefClass, static_cast<UINT32>(wcslen(kStreamRefClass)), &h_stream_class);
+  // Write JPEG bytes into the stream via DataWriter
+  {
+    IOutputStream *out = nullptr;
+    ra_stream->GetOutputStreamAt(0, &out);
+    if (!out) {
+      ra_stream->Release();
+      ClearThumbnail();
+      return;
+    }
 
-  IRandomAccessStreamReferenceStatics *stream_statics = nullptr;
-  hr = RoGetActivationFactory(h_stream_class, __uuidof(IRandomAccessStreamReferenceStatics), reinterpret_cast<void**>(&stream_statics));
-  WindowsDeleteString(h_stream_class);
-  if (FAILED(hr) || !stream_statics) {
-    ra_stream->Release();
-    ClearThumbnail();
-    return;
+    IDataWriterFactory *dwf = nullptr;
+    {
+      HSTRING h = nullptr;
+      static const wchar_t kDwClass[] = L"Windows.Storage.Streams.DataWriter";
+      WindowsCreateString(kDwClass, static_cast<UINT32>(wcslen(kDwClass)), &h);
+      RoGetActivationFactory(h, __uuidof(IDataWriterFactory), reinterpret_cast<void**>(&dwf));
+      WindowsDeleteString(h);
+    }
+    if (!dwf) {
+      out->Release();
+      ra_stream->Release();
+      ClearThumbnail();
+      return;
+    }
+
+    IDataWriter *dw = nullptr;
+    dwf->CreateDataWriter(out, &dw);
+    dwf->Release();
+    out->Release();
+    if (!dw) {
+      ra_stream->Release();
+      ClearThumbnail();
+      return;
+    }
+
+    // WriteBytes buffers data synchronously into DataWriter's internal buffer
+    dw->WriteBytes(static_cast<UINT32>(jpeg_data.size()), reinterpret_cast<BYTE*>(const_cast<char*>(jpeg_data.constData())));
+
+    // StoreAsync flushes to the InMemoryRandomAccessStream.
+    // The completion callback runs on an MTA thread pool thread — no STA marshal, so WaitForSingleObject from the GUI STA thread cannot deadlock here.
+    using StoreOp = __FIAsyncOperation_1_UINT32_t;
+    using StoreHandler = __FIAsyncOperationCompletedHandler_1_UINT32_t;
+    StoreOp *store_op = nullptr;
+    dw->StoreAsync(&store_op);
+    if (store_op) {
+      HANDLE ev = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+      if (ev) {
+        auto cb = Microsoft::WRL::Callback<StoreHandler>([ev](StoreOp *, AsyncStatus) -> HRESULT {
+          SetEvent(ev);
+          return S_OK;
+        });
+        store_op->put_Completed(cb.Get());
+        WaitForSingleObject(ev, 5000);
+        CloseHandle(ev);
+      }
+      store_op->Release();
+    }
+
+    IOutputStream *detached = nullptr;
+    dw->DetachStream(&detached);
+    if (detached) detached->Release();
+    dw->Release();
   }
 
+  // Create a RandomAccessStreamReference from the agile stream
   IRandomAccessStreamReference *stream_ref = nullptr;
-  hr = stream_statics->CreateFromStream(ra_stream, &stream_ref);
+  {
+    HSTRING h = nullptr;
+    static const wchar_t kSrClass[] = L"Windows.Storage.Streams.RandomAccessStreamReference";
+    WindowsCreateString(kSrClass, static_cast<UINT32>(wcslen(kSrClass)), &h);
+    IRandomAccessStreamReferenceStatics *statics = nullptr;
+    RoGetActivationFactory(h, __uuidof(IRandomAccessStreamReferenceStatics), reinterpret_cast<void**>(&statics));
+    WindowsDeleteString(h);
+    if (statics) {
+      statics->CreateFromStream(ra_stream, &stream_ref);
+      statics->Release();
+    }
+  }
   ra_stream->Release();
-  stream_statics->Release();
-  if (FAILED(hr) || !stream_ref) {
+  if (!stream_ref) {
     ClearThumbnail();
     return;
   }

--- a/src/core/winsystemmediatransportcontrols.h
+++ b/src/core/winsystemmediatransportcontrols.h
@@ -32,6 +32,8 @@
 #include "includes/shared_ptr.h"
 #include "engine/enginebase.h"
 
+class QTimer;
+
 class Player;
 class Song;
 class AlbumCoverLoaderResult;
@@ -56,6 +58,7 @@ class WinSystemMediaTransportControls : public QObject {
  private:
   void UpdatePlaybackStatus(EngineBase::State state);
   void UpdateMetadata(const Song &song);
+  void UpdateTimeline();
   void SetThumbnail(const QImage &image);
   void ClearThumbnail();
 
@@ -63,12 +66,15 @@ class WinSystemMediaTransportControls : public QObject {
 
   bool ro_initialized_;
   void *smtc_;           // ABI::Windows::Media::ISystemMediaTransportControls*
+  void *smtc2_;          // ABI::Windows::Media::ISystemMediaTransportControls2*
   void *updater_;        // ABI::Windows::Media::ISystemMediaTransportControlsDisplayUpdater*
   void *button_handler_; // IUnknown* (WRL handler, kept alive for unregistration)
   qint64 button_pressed_token_;
 
   EngineBase::State state_;
   QUrl current_song_url_;
+  qint64 current_duration_nanosec_;
+  QTimer *timeline_timer_;
 };
 
 #endif  // WINSYSTEMMEDIATRANSPORTCONTROLS_H

--- a/src/core/winsystemmediatransportcontrols.h
+++ b/src/core/winsystemmediatransportcontrols.h
@@ -58,7 +58,6 @@ class WinSystemMediaTransportControls : public QObject {
   void UpdateMetadata(const Song &song);
   void SetThumbnail(const QImage &image);
   void ClearThumbnail();
-  void SetThumbnailFromFile(const QString &path);
 
   SharedPtr<Player> player_;
 
@@ -70,7 +69,6 @@ class WinSystemMediaTransportControls : public QObject {
 
   EngineBase::State state_;
   QUrl current_song_url_;
-  QString temp_art_path_;
 };
 
 #endif  // WINSYSTEMMEDIATRANSPORTCONTROLS_H


### PR DESCRIPTION
Addresses #2208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Windows media controls with SMTC2-aware timeline updates that refresh during playback and on track changes.

* **Bug Fixes**
  * Improved thumbnail handling by updating from in-memory JPEG data instead of temporary disk artifacts.
  * Added more robust failure handling to clear the thumbnail when updates can’t be completed.

* **Chores**
  * Removed the file-based thumbnail workflow and related temporary thumbnail artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->