### PR TITLE
mac_startup: Move requestAuthorizationWithOptions

### DIFF
--- a/src/core/mac_startup.h
+++ b/src/core/mac_startup.h
@@ -2,7 +2,7 @@
  * Strawberry Music Player
  * This file was part of Clementine.
  * Copyright 2010, David Sansome <me@davidsansome.com>
- * Copyright 2018-2021, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2018-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/core/mac_startup.mm
+++ b/src/core/mac_startup.mm
@@ -147,6 +147,15 @@ QDebug operator<<(QDebug dbg, NSObject *object) {
 
   [[NSAppleEventManager sharedAppleEventManager] setEventHandler:self andSelector:@selector(handleURLEvent:withReplyEvent:) forEventClass:kInternetEventClass andEventID:kAEGetURL];
 
+  // Requesting authorization before the app has finished launching (e.g. from SetApplicationHandler:, which runs before QApplication::exec() starts the run loop) is rejected outright by the notification daemon, regardless of code signing.
+  UNUserNotificationCenter *notification_center = [UNUserNotificationCenter currentNotificationCenter];
+  notification_center.delegate = self;
+  [notification_center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionSound) completionHandler:^(BOOL granted, NSError *error) {
+    if (!granted) {
+      qLog(Warning) << "Notification authorization was not granted:" << (error ? QString::fromNSString(error.localizedDescription) : QStringLiteral("Unknown error"));
+    }
+  }];
+
   // key_tap_ = [[SPMediaKeyTap alloc] initWithDelegate:self];
   // if ([SPMediaKeyTap usesGlobalMediaKeyTap]) {
   //   if ([key_tap_ startWatchingMediaKeys]) {
@@ -263,14 +272,6 @@ QDebug operator<<(QDebug dbg, NSObject *object) {
   // this makes sure the delegate's shortcut_handler is set
   [delegate_ setShortcutHandler:shortcut_handler_];
   [self setDelegate:delegate_];
-
-  UNUserNotificationCenter *notification_center = [UNUserNotificationCenter currentNotificationCenter];
-  notification_center.delegate = delegate_;
-  [notification_center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionSound) completionHandler:^(BOOL granted, NSError *error) {
-    if (!granted) {
-      qLog(Warning) << "Notification authorization was not granted:" << (error ? QString::fromNSString(error.localizedDescription) : QStringLiteral("Unknown error"));
-    }
-  }];
 
 }
 

--- a/src/core/mac_startup.mm
+++ b/src/core/mac_startup.mm
@@ -2,7 +2,7 @@
  * Strawberry Music Player
  * This file was part of Clementine.
  * Copyright 2010, David Sansome <me@davidsansome.com>
- * Copyright 2018-2021, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2018-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -43,8 +43,6 @@
 
 #import <UserNotifications/UserNotifications.h>
 
-//#import <SPMediaKeyTap.h>
-
 #include "config.h"
 
 #include <QApplication>
@@ -70,9 +68,6 @@ QDebug operator<<(QDebug dbg, NSObject *object) {
   return dbg.space();
 
 }
-
-// Capture global media keys on Mac (Cocoa only!)
-// See: http://www.rogueamoeba.com/utm/2007/09/29/apple-keyboard-media-key-event-handling/
 
 @interface MacApplication : NSApplication {
 
@@ -156,19 +151,6 @@ QDebug operator<<(QDebug dbg, NSObject *object) {
     }
   }];
 
-  // key_tap_ = [[SPMediaKeyTap alloc] initWithDelegate:self];
-  // if ([SPMediaKeyTap usesGlobalMediaKeyTap]) {
-  //   if ([key_tap_ startWatchingMediaKeys]) {
-  //       qLog(Debug) << "Media key monitoring started";
-  //   }
-  //   else {
-  //       qLog(Warning) << "Failed to start media key monitoring";
-  //   }
-  // }
-  // else {
-  //   qLog(Warning) << "Media key monitoring disabled";
-  // }
-
 }
 
 - (BOOL)application:(NSApplication*)app openFile:(NSString*)filename {
@@ -202,11 +184,6 @@ QDebug operator<<(QDebug dbg, NSObject *object) {
   application_handler_->LoadUrl(QString::fromNSString(url));
 
 }
-
-// - (void) mediaKeyTap: (SPMediaKeyTap*)keyTap receivedMediaKeyEvent:(NSEvent*)event {
-//   #pragma unused(keyTap)
-//   [self handleMediaEvent:event];
-// }
 
 - (BOOL) handleMediaEvent:(NSEvent*)event {
   // if it is not a media key event, then ignore

--- a/src/includes/mac_delegate.h
+++ b/src/includes/mac_delegate.h
@@ -5,14 +5,11 @@
 #include "globalshortcuts/globalshortcutsbackend-macos.h"
 
 class PlatformInterface;
-//@class SPMediaKeyTap;
 
 @interface AppDelegate : NSObject<NSApplicationDelegate, UNUserNotificationCenterDelegate> {
   PlatformInterface *application_handler_;
   NSMenu *dock_menu_;
   GlobalShortcutsBackendMacOS *shortcut_handler_;
-  //SPMediaKeyTap *key_tap_;
-
 }
 
 - (id) initWithHandler: (PlatformInterface*)handler;
@@ -31,5 +28,4 @@ class PlatformInterface;
 - (void) setDockMenu: (NSMenu*)menu;
 - (GlobalShortcutsBackendMacOS*) shortcut_handler;
 - (void) setShortcutHandler: (GlobalShortcutsBackendMacOS*)backend;
-//- (void) mediaKeyTap: (SPMediaKeyTap*)keyTap receivedMediaKeyEvent:(NSEvent*)event;
 @end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The app now requests notification permission during startup so users can enable alerts right away.
* **Bug Fixes**
  * Notification permission handling has been streamlined to prevent duplicate prompts and initialize settings consistently.
  * If permission isn’t granted, the app logs a warning to aid diagnosis.
* **Chores**
  * Updated internal header comments/formatting and removed unused commented-out media-key related code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->