### PR TITLE
Song: Set metadata from stream even if empty

### DIFF
--- a/src/core/song.cpp
+++ b/src/core/song.cpp
@@ -2032,15 +2032,16 @@ bool Song::MergeFromEngineMetadata(const EngineMetadata &engine_metadata) {
     if (lyrics().isEmpty() && !engine_metadata.lyrics.isEmpty()) set_lyrics(engine_metadata.lyrics);
   }
   else {
-    if (title() != engine_metadata.title && !engine_metadata.title.isEmpty()) {
+    const bool isradio = is_radio();
+    if ((isradio || !engine_metadata.title.isEmpty()) && title() != engine_metadata.title) {
       set_title(engine_metadata.title);
       minor = false;
     }
-    if (artist() != engine_metadata.artist && !engine_metadata.artist.isEmpty()) {
+    if ((isradio || !engine_metadata.artist.isEmpty()) && artist() != engine_metadata.artist) {
       set_artist(engine_metadata.artist);
       minor = false;
     }
-    if (album() != engine_metadata.album && !engine_metadata.album.isEmpty()) {
+    if ((isradio || !engine_metadata.album.isEmpty()) && album() != engine_metadata.album) {
       set_album(engine_metadata.album);
       minor = false;
     }


### PR DESCRIPTION
When streaming music, for the title, artist, and album tags, if one song has the metadata set and the next song in the same stream does not, the previous song's metadata was carried over.  For example, if song A had the album set, then song B did not, song B would keep song A's album, which would cause issues for lyric and cover look ups.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata refresh for radio/streamed tracks: title, artist, and album can now update correctly even when incoming values are empty, as long as the track is identified as radio/streamed.
  * Stream/radio details are more reliably kept in sync with the latest available metadata source, reducing stale or mismatched display information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->