### PR TITLE
Playlist context menu

### DIFF
--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -707,7 +707,7 @@ MainWindow::MainWindow(Application *app,
   QObject::connect(ui_->playlist->view(), &PlaylistView::doubleClicked, this, &MainWindow::PlaylistDoubleClick);
   QObject::connect(ui_->playlist->view(), &PlaylistView::PlayItem, this, &MainWindow::PlayIndex);
   QObject::connect(ui_->playlist->view(), &PlaylistView::PlayPause, &*app_->player(), &Player::PlayPause);
-  QObject::connect(ui_->playlist->view(), &PlaylistView::RightClicked, this, &MainWindow::PlaylistRightClick);
+  QObject::connect(ui_->playlist->view(), &PlaylistView::ShowPlaylistContextMenu, this, &MainWindow::ShowPlaylistContextMenu);
   QObject::connect(ui_->playlist->view(), &PlaylistView::SeekForward, &*app_->player(), &Player::SeekForward);
   QObject::connect(ui_->playlist->view(), &PlaylistView::SeekBackward, &*app_->player(), &Player::SeekBackward);
   QObject::connect(ui_->playlist->view(), &PlaylistView::BackgroundPropertyChanged, this, &MainWindow::RefreshStyleSheet);
@@ -2014,7 +2014,7 @@ void MainWindow::PlaylistMenuHidden() {
 
 }
 
-void MainWindow::PlaylistRightClick(const QPoint global_pos, const QModelIndex &index) {
+void MainWindow::ShowPlaylistContextMenu(const QPoint global_pos, const QModelIndex &index) {
 
   QModelIndex source_index = index;
   if (index.model() == app_->playlist_manager()->current()->filter()) {

--- a/src/core/mainwindow.h
+++ b/src/core/mainwindow.h
@@ -158,7 +158,7 @@ class MainWindow : public QMainWindow, public PlatformInterface {
   void ForceShowOSD(const Song &song, const bool toggle);
 
   void PlaylistMenuHidden();
-  void PlaylistRightClick(const QPoint global_pos, const QModelIndex &index);
+  void ShowPlaylistContextMenu(const QPoint global_pos, const QModelIndex &index);
   void PlaylistCurrentChanged(const QModelIndex &current);
   void PlaylistViewSelectionModelChanged();
   void PlaylistPlay();

--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -748,7 +748,7 @@ void PlaylistView::contextMenuEvent(QContextMenuEvent *e) {
     index = indexAt(e->pos());
   }
 
-  Q_EMIT RightClicked(global_pos, index);
+  Q_EMIT ShowPlaylistContextMenu(global_pos, index);
   e->accept();
 
 }

--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -735,8 +735,22 @@ void PlaylistView::keyPressEvent(QKeyEvent *event) {
 }
 
 void PlaylistView::contextMenuEvent(QContextMenuEvent *e) {
-  Q_EMIT RightClicked(e->globalPos(), indexAt(e->pos()));
+
+  QModelIndex index;
+  QPoint global_pos = e->globalPos();
+  if (e->reason() == QContextMenuEvent::Keyboard) {
+    index = currentIndex();
+    if (index.isValid()) {
+      global_pos = viewport()->mapToGlobal(visualRect(index).center());
+    }
+  }
+  else {
+    index = indexAt(e->pos());
+  }
+
+  Q_EMIT RightClicked(global_pos, index);
   e->accept();
+
 }
 
 void PlaylistView::RemoveSelected() {

--- a/src/playlist/playlistview.h
+++ b/src/playlist/playlistview.h
@@ -120,7 +120,7 @@ class PlaylistView : public QTreeView {
  Q_SIGNALS:
   void PlayItem(const QModelIndex idx, const Playlist::AutoScroll autoscroll);
   void PlayPause(const quint64 offset_nanosec = 0, const Playlist::AutoScroll autoscroll = Playlist::AutoScroll::Never);
-  void RightClicked(const QPoint global_pos, const QModelIndex idx);
+  void ShowPlaylistContextMenu(const QPoint global_pos, const QModelIndex idx);
   void SeekForward();
   void SeekBackward();
   void FocusOnFilterSignal(QKeyEvent *event);

--- a/src/smartplaylists/smartplaylistsview.cpp
+++ b/src/smartplaylists/smartplaylistsview.cpp
@@ -47,7 +47,19 @@ void SmartPlaylistsView::selectionChanged(const QItemSelection &selected, const 
 
 void SmartPlaylistsView::contextMenuEvent(QContextMenuEvent *e) {
 
-  Q_EMIT ShowSmartPlaylistContextMenu(e->globalPos(), indexAt(e->pos()));
+  QModelIndex index;
+  QPoint global_pos = e->globalPos();
+  if (e->reason() == QContextMenuEvent::Keyboard) {
+    index = currentIndex();
+    if (index.isValid()) {
+      global_pos = viewport()->mapToGlobal(visualRect(index).center());
+    }
+  }
+  else {
+    index = indexAt(e->pos());
+  }
+
+  Q_EMIT ShowSmartPlaylistContextMenu(global_pos, index);
   e->accept();
 
 }

--- a/src/smartplaylists/smartplaylistsview.cpp
+++ b/src/smartplaylists/smartplaylistsview.cpp
@@ -47,7 +47,7 @@ void SmartPlaylistsView::selectionChanged(const QItemSelection &selected, const 
 
 void SmartPlaylistsView::contextMenuEvent(QContextMenuEvent *e) {
 
-  Q_EMIT RightClicked(e->globalPos(), indexAt(e->pos()));
+  Q_EMIT ShowSmartPlaylistContextMenu(e->globalPos(), indexAt(e->pos()));
   e->accept();
 
 }

--- a/src/smartplaylists/smartplaylistsview.h
+++ b/src/smartplaylists/smartplaylistsview.h
@@ -40,7 +40,7 @@ class SmartPlaylistsView : public QListView {
 
  Q_SIGNALS:
   void ItemsSelectedChanged();
-  void RightClicked(const QPoint global_pos, const QModelIndex idx);
+  void ShowSmartPlaylistContextMenu(const QPoint global_pos, const QModelIndex idx);
 };
 
 #endif  // SMARTPLAYLISTSVIEW_H

--- a/src/smartplaylists/smartplaylistsviewcontainer.cpp
+++ b/src/smartplaylists/smartplaylistsviewcontainer.cpp
@@ -106,7 +106,7 @@ SmartPlaylistsViewContainer::SmartPlaylistsViewContainer(const SharedPtr<Player>
 
   QObject::connect(ui_->view, &SmartPlaylistsView::ItemsSelectedChanged, this, &SmartPlaylistsViewContainer::ItemsSelectedChanged);
   QObject::connect(ui_->view, &SmartPlaylistsView::doubleClicked, this, &SmartPlaylistsViewContainer::ItemDoubleClicked);
-  QObject::connect(ui_->view, &SmartPlaylistsView::RightClicked, this, &SmartPlaylistsViewContainer::RightClicked);
+  QObject::connect(ui_->view, &SmartPlaylistsView::ShowSmartPlaylistContextMenu, this, &SmartPlaylistsViewContainer::ShowSmartPlaylistContextMenu);
 
   ReloadSettings();
 
@@ -147,7 +147,7 @@ void SmartPlaylistsViewContainer::ItemsSelectedChanged() {
 
 }
 
-void SmartPlaylistsViewContainer::RightClicked(const QPoint global_pos, const QModelIndex &idx) {
+void SmartPlaylistsViewContainer::ShowSmartPlaylistContextMenu(const QPoint global_pos, const QModelIndex &idx) {
 
   context_menu_index_ = idx;
   if (context_menu_index_.isValid()) {

--- a/src/smartplaylists/smartplaylistsviewcontainer.h
+++ b/src/smartplaylists/smartplaylistsviewcontainer.h
@@ -70,7 +70,7 @@ class SmartPlaylistsViewContainer : public QWidget {
   void ItemsSelectedChanged();
   void ItemDoubleClicked(const QModelIndex &idx);
 
-  void RightClicked(const QPoint global_pos, const QModelIndex &idx);
+  void ShowSmartPlaylistContextMenu(const QPoint global_pos, const QModelIndex &idx);
 
   void AppendToPlaylist();
   void ReplaceCurrentPlaylist();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved context-menu behavior for playlist and smart playlist views.
  - Keyboard-triggered context menus now open at the correct screen position and target the intended item.
  - Context-menu actions continue to reflect the current selection state.
- **Refactor**
  - Updated the context-menu event flow by renaming the related signals and handlers for both playlist and smart playlist views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->