### PR TITLE
Add F64LE support for analyzer

### DIFF
--- a/src/engine/gstengine.cpp
+++ b/src/engine/gstengine.cpp
@@ -1088,7 +1088,8 @@ void GstEngine::UpdateScope(const int chunk_length) {
       buffer_format_.startsWith("S24LE"_L1) ||
       buffer_format_.startsWith("S24_32LE"_L1) ||
       buffer_format_.startsWith("S32LE"_L1) ||
-      buffer_format_.startsWith("F32LE"_L1)) {
+      buffer_format_.startsWith("F32LE"_L1) ||
+      buffer_format_.startsWith("F64LE"_L1)) {
     memcpy(dest, source, bytes);
   }
   else {

--- a/src/engine/gstenginepipeline.cpp
+++ b/src/engine/gstenginepipeline.cpp
@@ -1448,6 +1448,26 @@ GstPadProbeReturn GstEnginePipeline::BufferProbeCallback(GstPad *pad, GstPadProb
     }
     instance->logged_unsupported_analyzer_format_ = false;
   }
+  else if (format.startsWith("F64LE"_L1)) {
+    GstMapInfo map_info;
+    if (gst_buffer_map(buf, &map_info, GST_MAP_READ)) {
+      double *s = reinterpret_cast<double*>(map_info.data);
+      int samples = static_cast<int>((map_info.size / sizeof(double)) / channels);
+      int buf16_size = samples * static_cast<int>(sizeof(int16_t)) * channels;
+      int16_t *d = static_cast<int16_t*>(g_malloc(static_cast<gsize>(buf16_size)));
+      memset(d, 0, static_cast<size_t>(buf16_size));
+      for (int i = 0; i < (samples * channels); ++i) {
+        // Clamp before casting - samples can exceed [-1.0, 1.0) (ReplayGain/intersample peaks, and this probe is pre-volume/pre-EQ), which would otherwise wrap on the int16 cast.
+        const float sample_float = qBound(-32768.0F, s[i] * 32768.0F, 32767.0F);
+        d[i] = static_cast<int16_t>(sample_float);
+      }
+      gst_buffer_unmap(buf, &map_info);
+      buf16 = gst_buffer_new_wrapped(d, static_cast<gsize>(buf16_size));
+      GST_BUFFER_DURATION(buf16) = GST_FRAMES_TO_CLOCK_TIME(static_cast<guint64>(samples), static_cast<guint64>(rate));
+      buf = buf16;
+    }
+    instance->logged_unsupported_analyzer_format_ = false;
+  }
   else if (!instance->logged_unsupported_analyzer_format_) {
     instance->logged_unsupported_analyzer_format_ = true;
     qLog(Error) << "Unsupported audio format for the analyzer" << format;


### PR DESCRIPTION
Fix bug where analyzers don't work for F64LE encoded songs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio handling for 64-bit floating-point streams.
  * Ensured 64-bit float audio is correctly processed for analyzer output.
  * Prevented 64-bit floating-point samples from being incorrectly replaced with silence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->