### PR TITLE
Set automatic redirect

### DIFF
--- a/src/engine/gstengine.cpp
+++ b/src/engine/gstengine.cpp
@@ -280,7 +280,7 @@ bool GstEngine::Play(const bool pause, const quint64 offset_nanosec) {
   if (current_pipeline_->state() == GstState::GST_STATE_PLAYING) {
     if (offset_nanosec != 0 || beginning_offset_nanosec_ != 0) {
       Seek(offset_nanosec);
-      PlayDone(GST_STATE_CHANGE_SUCCESS, false, offset_nanosec, current_pipeline_->id());
+      PlayDone(GST_STATE_CHANGE_SUCCESS, false, current_pipeline_->id());
     }
     return true;
   }
@@ -303,10 +303,10 @@ bool GstEngine::Play(const bool pause, const quint64 offset_nanosec) {
 
   QFutureWatcher<GstStateChangeReturn> *watcher = new QFutureWatcher<GstStateChangeReturn>();
   const int pipeline_id = current_pipeline_->id();
-  QObject::connect(watcher, &QFutureWatcher<GstStateChangeReturn>::finished, this, [this, watcher, pipeline_id, pause, offset_nanosec]() {
+  QObject::connect(watcher, &QFutureWatcher<GstStateChangeReturn>::finished, this, [this, watcher, pipeline_id, pause]() {
     const GstStateChangeReturn ret = watcher->result();
     watcher->deleteLater();
-    PlayDone(ret, pause, offset_nanosec, pipeline_id);
+    PlayDone(ret, pause, pipeline_id);
   });
   QFuture<GstStateChangeReturn> future = current_pipeline_->Play(pause, beginning_offset_nanosec_ + offset_nanosec);
   watcher->setFuture(future);
@@ -742,48 +742,14 @@ void GstEngine::SeekNow() {
 
 }
 
-void GstEngine::PlayDone(const GstStateChangeReturn ret, const bool pause, const quint64 offset_nanosec, const int pipeline_id) {
+void GstEngine::PlayDone(const GstStateChangeReturn state_change_return, const bool pause, const int pipeline_id) {
 
   if (!current_pipeline_ || pipeline_id != current_pipeline_->id()) {
     return;
   }
 
-  if (ret == GST_STATE_CHANGE_FAILURE) {
-
-    // Failure, but we might have gotten a redirection URL - try loading that instead.
-    // Read redirect_url_/gst_url_ off current_pipeline_ directly and don't touch current_pipeline_ itself yet: unless we actually have a redirect to retry, we want to leave it exactly as it is (see the comment below).
-    QByteArray redirect_url;
-    {
-      QMutexLocker l(current_pipeline_->mutex_redirect_url());
-      redirect_url = current_pipeline_->redirect_url();
-      redirect_url.detach();
-    }
-    QByteArray gst_url;
-    {
-      QMutexLocker l(current_pipeline_->mutex_url());
-      gst_url = current_pipeline_->gst_url();
-      gst_url.detach();
-    }
-
-    if (!redirect_url.isEmpty() && redirect_url != gst_url) {
-      qLog(Info) << "Redirecting to" << redirect_url;
-      GstEnginePipelinePtr old_pipeline = current_pipeline_;
-      QUrl media_url;
-      QUrl stream_url;
-      {
-        QMutexLocker l(old_pipeline->mutex_url());
-        media_url = old_pipeline->media_url();
-        media_url.detach();
-        stream_url = old_pipeline->stream_url();
-        stream_url.detach();
-      }
-      current_pipeline_ = CreatePipeline(media_url, stream_url, redirect_url, static_cast<qint64>(beginning_offset_nanosec_), end_offset_nanosec_, old_pipeline->ebur128_loudness_normalizing_gain_db());
-      FinishPipeline(old_pipeline);
-      Play(pause, offset_nanosec);
-      return;
-    }
-
-    // No redirect to fall back to. Don't tear the pipeline down or emit anything here: GStreamer guarantees that an element which fails a state change also posts a GST_MESSAGE_ERROR on the bus explaining why, and that message is still on its way to ErrorMessageReceived()/HandlePipelineError() via the normal bus watch.
+  if (state_change_return == GST_STATE_CHANGE_FAILURE) {
+    // Don't tear the pipeline down or emit anything here: GStreamer guarantees that an element which fails a state change also posts a GST_MESSAGE_ERROR on the bus explaining why, and that message is still on its way to ErrorMessageReceived()/HandlePipelineError() via the normal bus watch.
     // Leaving current_pipeline_ (and its signal connections) untouched means that when it arrives, HandlePipelineError() finds current_pipeline_->id() == pipeline_id and does the full, correct job - FinishPipeline(), StateChanged(Error), InvalidSongRequested()/FatalError() - using the real GStreamer error text instead of a generic one synthesized here, and without racing FinishPipeline()'s QObject::disconnect() against that still-pending bus message.
     qLog(Warning) << "Could not set pipeline" << pipeline_id << "to" << (pause ? "Paused" : "Playing") << "- waiting for the GStreamer error message";
     return;

--- a/src/engine/gstengine.h
+++ b/src/engine/gstengine.h
@@ -115,7 +115,7 @@ class GstEngine : public EngineBase, public GstBufferConsumer {
   void FadeoutFinished(const int pipeline_id);
   void FadeoutPauseFinished();
   void SeekNow();
-  void PlayDone(const GstStateChangeReturn ret, const bool pause, const quint64 offset_nanosec, const int pipeline_id);
+  void PlayDone(const GstStateChangeReturn ret, const bool pause, const int pipeline_id);
 
   void BufferingStarted();
   void BufferingProgress(int percent);

--- a/src/engine/gstenginepipeline.cpp
+++ b/src/engine/gstenginepipeline.cpp
@@ -1146,6 +1146,8 @@ void GstEnginePipeline::SourceSetupCallback(GstElement *playbin, GstElement *sou
 
   GstEnginePipeline *instance = reinterpret_cast<GstEnginePipeline*>(self);
 
+  qLog(Debug) << "Pipeline" << instance->id() << "source-setup, source element is" << G_OBJECT_TYPE_NAME(source);
+
   {
     QMutexLocker l(&instance->mutex_source_device_);
     if (g_object_class_find_property(G_OBJECT_GET_CLASS(source), "device") && !instance->source_device().isEmpty()) {

--- a/src/engine/gstenginepipeline.cpp
+++ b/src/engine/gstenginepipeline.cpp
@@ -1167,6 +1167,11 @@ void GstEnginePipeline::SourceSetupCallback(GstElement *playbin, GstElement *sou
     g_object_set(source, "ssl-strict", instance->strict_ssl_enabled_.load() ? TRUE : FALSE, nullptr);
   }
 
+  if (g_object_class_find_property(G_OBJECT_GET_CLASS(source), "automatic-redirect")) {
+    qLog(Debug) << "Enabling automatic redirect";
+    g_object_set(source, "automatic-redirect", TRUE, nullptr);
+  }
+
   {
     QMutexLocker l(&instance->mutex_proxy_);
     if (!instance->proxy_address_.isEmpty() && g_object_class_find_property(G_OBJECT_GET_CLASS(source), "proxy")) {
@@ -1766,13 +1771,6 @@ void GstEnginePipeline::ElementMessageReceived(GstMessage *msg) {
     g_free(description);
     g_free(detail);
     Q_EMIT Error(id(), static_cast<int>(GST_LIBRARY_ERROR), GST_CORE_ERROR_MISSING_PLUGIN, message, QString());
-  }
-  else if (gst_structure_has_name(structure, "redirect")) {
-    const char *uri = gst_structure_get_string(structure, "new-location");
-
-    // Set the redirect URL.  In mmssrc redirect messages come during the initial state change to PLAYING, so callers can pick up this URL after the state change has failed.
-    QMutexLocker l(&mutex_redirect_url_);
-    redirect_url_ = uri;
   }
 
 }

--- a/src/engine/gstenginepipeline.h
+++ b/src/engine/gstenginepipeline.h
@@ -143,9 +143,6 @@ class GstEnginePipeline : public QObject {
 
   bool exclusive_mode() const { return exclusive_mode_; }
 
-  QByteArray redirect_url() const { return redirect_url_; }
-  QMutex *mutex_redirect_url() { return &mutex_redirect_url_; }
-
   QString source_device() const { return source_device_; }
 
  Q_SIGNALS:
@@ -329,10 +326,6 @@ class GstEnginePipeline : public QObject {
 
   // Set temporarily when switching out the decode bin, so metadata doesn't get sent while the Player still thinks it's playing the last song
   std::atomic<bool> ignore_tags_;
-
-  // When the gstreamer source requests a redirect we store the URL here and callers can pick it up after the state change to PLAYING fails.
-  mutable QMutex mutex_redirect_url_;
-  QByteArray redirect_url_;
 
   // When we need to specify the device to use as source (for CD device)
   QString source_device_;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback completion handling to reliably associate state changes with the active pipeline.
  * Stream startup failures now follow the standard error flow without attempting alternate retry logic.
  * Preserved the current playback pipeline so error reporting remains consistent.
  * Enabled automatic redirect support for compatible sources and removed manual redirect-message processing to prevent inconsistent retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->