### PR TITLE
Add missing parent to QFutureWatcher

### DIFF
--- a/src/collection/collectionmodel.cpp
+++ b/src/collection/collectionmodel.cpp
@@ -971,7 +971,7 @@ CollectionItem *CollectionModel::CreateCompilationArtistNode(CollectionItem *par
 void CollectionModel::LoadSongsFromSqlAsync() {
 
   QFuture<SongList> future = QtConcurrent::run(&CollectionModel::LoadSongsFromSql, this, options_active_.filter_options);
-  QFutureWatcher<SongList> *watcher = new QFutureWatcher<SongList>();
+  QFutureWatcher<SongList> *watcher = new QFutureWatcher<SongList>(this);
   QObject::connect(watcher, &QFutureWatcher<void>::finished, this, &CollectionModel::LoadSongsFromSqlAsyncFinished);
   watcher->setFuture(future);
 

--- a/src/collection/collectionmodel.cpp
+++ b/src/collection/collectionmodel.cpp
@@ -972,7 +972,7 @@ void CollectionModel::LoadSongsFromSqlAsync() {
 
   QFuture<SongList> future = QtConcurrent::run(&CollectionModel::LoadSongsFromSql, this, options_active_.filter_options);
   QFutureWatcher<SongList> *watcher = new QFutureWatcher<SongList>(this);
-  QObject::connect(watcher, &QFutureWatcher<void>::finished, this, &CollectionModel::LoadSongsFromSqlAsyncFinished);
+  QObject::connect(watcher, &QFutureWatcher<SongList>::finished, this, &CollectionModel::LoadSongsFromSqlAsyncFinished);
   watcher->setFuture(future);
 
 }

--- a/src/covermanager/albumcoverchoicecontroller.cpp
+++ b/src/covermanager/albumcoverchoicecontroller.cpp
@@ -727,7 +727,7 @@ void AlbumCoverChoiceController::SaveCoverEmbeddedToCollectionSongs(const Song &
 void AlbumCoverChoiceController::SaveCoverEmbeddedToCollectionSongs(const QString &effective_albumartist, const QString &effective_album, const QString &cover_filename, const QByteArray &image_data, const QString &mime_type) {
 
   QFuture<SongList> future = QtConcurrent::run(&CollectionBackend::GetAlbumSongs, collection_backend_, effective_albumartist, effective_album, CollectionFilterOptions());
-  QFutureWatcher<SongList> *watcher = new QFutureWatcher<SongList>();
+  QFutureWatcher<SongList> *watcher = new QFutureWatcher<SongList>(this);
   QObject::connect(watcher, &QFutureWatcher<SongList>::finished, this, [this, watcher, cover_filename, image_data, mime_type]() {
     const SongList collection_songs = watcher->result();
     watcher->deleteLater();

--- a/src/device/deviceproperties.cpp
+++ b/src/device/deviceproperties.cpp
@@ -243,7 +243,7 @@ void DeviceProperties::UpdateFormats() {
     supported_formats_.clear();
 
     QFuture<bool> future = QtConcurrent::run(&ConnectedDevice::GetSupportedFiletypes, device, &supported_formats_);
-    QFutureWatcher<bool> *watcher = new QFutureWatcher<bool>();
+    QFutureWatcher<bool> *watcher = new QFutureWatcher<bool>(this);
     QObject::connect(watcher, &QFutureWatcher<bool>::finished, this, &DeviceProperties::UpdateFormatsFinished);
     watcher->setFuture(future);
 

--- a/src/engine/gstengine.cpp
+++ b/src/engine/gstengine.cpp
@@ -301,7 +301,7 @@ bool GstEngine::Play(const bool pause, const quint64 offset_nanosec) {
   delayed_state_pause_ = false;
   delayed_state_offset_nanosec_ = 0;
 
-  QFutureWatcher<GstStateChangeReturn> *watcher = new QFutureWatcher<GstStateChangeReturn>();
+  QFutureWatcher<GstStateChangeReturn> *watcher = new QFutureWatcher<GstStateChangeReturn>(this);
   const int pipeline_id = current_pipeline_->id();
   QObject::connect(watcher, &QFutureWatcher<GstStateChangeReturn>::finished, this, [this, watcher, pipeline_id, pause]() {
     const GstStateChangeReturn ret = watcher->result();

--- a/src/moodbar/moodbaritemdelegate.cpp
+++ b/src/moodbar/moodbaritemdelegate.cpp
@@ -220,7 +220,7 @@ void MoodbarItemDelegate::StartLoadingColors(const QUrl &url, const QByteArray &
   data->state_ = Data::State::LoadingColors;
 
   QFuture<ColorVector> future = QtConcurrent::run(MoodbarRenderer::Colors, bytes, style_, qApp->palette());
-  QFutureWatcher<ColorVector> *watcher = new QFutureWatcher<ColorVector>();
+  QFutureWatcher<ColorVector> *watcher = new QFutureWatcher<ColorVector>(this);
   QObject::connect(watcher, &QFutureWatcher<ColorVector>::finished, this, [this, watcher, url]() {
     ColorsLoaded(url, watcher->result());
     watcher->deleteLater();
@@ -251,7 +251,7 @@ void MoodbarItemDelegate::StartLoadingImage(const QUrl &url, Data *data) {
   data->state_ = Data::State::LoadingImage;
 
   QFuture<QImage> future = QtConcurrent::run(MoodbarRenderer::RenderToImage, data->colors_, data->desired_size_);
-  QFutureWatcher<QImage> *watcher = new QFutureWatcher<QImage>();
+  QFutureWatcher<QImage> *watcher = new QFutureWatcher<QImage>(this);
   QObject::connect(watcher, &QFutureWatcher<QImage>::finished, this, [this, watcher, url]() {
     ImageLoaded(url, watcher->result());
     watcher->deleteLater();

--- a/src/organize/organizedialog.cpp
+++ b/src/organize/organizedialog.cpp
@@ -394,7 +394,7 @@ bool OrganizeDialog::SetUrls(const QList<QUrl> &urls) {
 bool OrganizeDialog::SetFilenames(const QStringList &filenames) {
 
   songs_future_ = QtConcurrent::run(&OrganizeDialog::LoadSongsBlocking, this, filenames);
-  QFutureWatcher<SongList> *watcher = new QFutureWatcher<SongList>();
+  QFutureWatcher<SongList> *watcher = new QFutureWatcher<SongList>(this);
   QObject::connect(watcher, &QFutureWatcher<SongList>::finished, this, [this, watcher]() {
     SetSongs(watcher->result());
     watcher->deleteLater();

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -1685,7 +1685,7 @@ void Playlist::Restore() {
 
   cancel_restore_ = false;
   QFuture<PlaylistItemPtrList> future = QtConcurrent::run(&PlaylistBackend::GetPlaylistItems, playlist_backend_, id_);
-  QFutureWatcher<PlaylistItemPtrList> *watcher = new QFutureWatcher<PlaylistItemPtrList>();
+  QFutureWatcher<PlaylistItemPtrList> *watcher = new QFutureWatcher<PlaylistItemPtrList>(this);
   QObject::connect(watcher, &QFutureWatcher<PlaylistItemPtrList>::finished, this, &Playlist::ItemsLoaded);
   watcher->setFuture(future);
 

--- a/src/playlist/playlistdelegates.cpp
+++ b/src/playlist/playlistdelegates.cpp
@@ -416,7 +416,7 @@ static TagCompletionModel *InitCompletionModel(SharedPtr<CollectionBackend> back
 TagCompleter::TagCompleter(SharedPtr<CollectionBackend> backend, const Playlist::Column column, QLineEdit *editor) : QCompleter(editor), editor_(editor) {
 
   QFuture<TagCompletionModel*> future = QtConcurrent::run(&InitCompletionModel, backend, column);
-  QFutureWatcher<TagCompletionModel*> *watcher = new QFutureWatcher<TagCompletionModel*>();
+  QFutureWatcher<TagCompletionModel*> *watcher = new QFutureWatcher<TagCompletionModel*>(this);
   QObject::connect(watcher, &QFutureWatcher<TagCompletionModel*>::finished, this, &TagCompleter::ModelReady);
   watcher->setFuture(future);
 

--- a/src/playlist/playlistmanager.cpp
+++ b/src/playlist/playlistmanager.cpp
@@ -234,7 +234,7 @@ void PlaylistManager::Save(const int id, const QString &playlist_name, const QSt
   else {
     // Playlist is not in the playlist manager: probably save action was triggered from the left sidebar and the playlist isn't loaded.
     QFuture<SongList> future = QtConcurrent::run(&PlaylistBackend::GetPlaylistSongs, playlist_backend_, id);
-    QFutureWatcher<SongList> *watcher = new QFutureWatcher<SongList>();
+    QFutureWatcher<SongList> *watcher = new QFutureWatcher<SongList>(this);
     QObject::connect(watcher, &QFutureWatcher<SongList>::finished, this, [this, watcher, playlist_name, filename, path_type]() {
       ItemsLoadedForSavePlaylist(playlist_name, watcher->result(), filename, path_type);
       watcher->deleteLater();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability during asynchronous song loading, playlist handling, playback, cover saving, device format detection, and moodbar rendering.
  * Reduced the risk of lingering background operations when related windows or components are closed.

* **Refactor**
  * Improved background task lifecycle management by ensuring asynchronous watchers are properly tied to their owning components across collection, playlist, organization, device, media, and moodbar features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->