### PR TITLE
Playlist: Show the edit immediately, and always reload after tag edit

### DIFF
--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -459,7 +459,8 @@ bool Playlist::setData(const QModelIndex &idx, const QVariant &value, const int 
 
   const int row = idx.row();
   const PlaylistItemPtr item = item_at(row);
-  Song song = item->OriginalMetadata();
+  const Song pre_edit_metadata = item->OriginalMetadata();
+  Song song = pre_edit_metadata;
 
   if (idx.data() == value) return false;
 
@@ -476,8 +477,8 @@ bool Playlist::setData(const QModelIndex &idx, const QVariant &value, const int 
     TagReaderReplyPtr reply = tagreader_client_->WriteFileAsync(song.url().toLocalFile(), song);
     QPersistentModelIndex persistent_index = QPersistentModelIndex(idx);
     SharedPtr<QMetaObject::Connection> connection = make_shared<QMetaObject::Connection>();
-    *connection = QObject::connect(&*reply, &TagReaderReply::Finished, this, [this, reply, persistent_index, item, save_generation, connection]() {
-      SongSaveComplete(reply, persistent_index, item, save_generation);
+    *connection = QObject::connect(&*reply, &TagReaderReply::Finished, this, [this, reply, persistent_index, item, save_generation, pre_edit_metadata, connection]() {
+      SongSaveComplete(reply, persistent_index, item, save_generation, pre_edit_metadata);
       QObject::disconnect(*connection);
     }, Qt::QueuedConnection);
   }
@@ -492,22 +493,27 @@ bool Playlist::setData(const QModelIndex &idx, const QVariant &value, const int 
 
 }
 
-void Playlist::SongSaveComplete(TagReaderReplyPtr reply, const QPersistentModelIndex &idx, const PlaylistItemPtr &item, const quint64 save_generation) {
+void Playlist::SongSaveComplete(TagReaderReplyPtr reply, const QPersistentModelIndex &idx, const PlaylistItemPtr &item, const quint64 save_generation, const Song &pre_edit_metadata) {
 
-  if (idx.isValid()) {
-    if (!reply->success()) {
-      if (reply->error().isEmpty()) {
-        Q_EMIT Error(tr("Could not write metadata to %1").arg(reply->filename()));
-      }
-      else {
-        Q_EMIT Error(tr("Could not write metadata to %1: %2").arg(reply->filename(), reply->error()));
-      }
+  if (!idx.isValid()) return;
+
+  // A newer edit has already superseded this write (its own completion, still pending or already applied, is responsible for reconciling the item), so touching the item now would race it and could clobber the newer optimistic value with this stale write's outcome.
+  if (item->save_generation() != save_generation) return;
+
+  if (!reply->success()) {
+    if (reply->error().isEmpty()) {
+      Q_EMIT Error(tr("Could not write metadata to %1").arg(reply->filename()));
     }
-    // A newer edit has already superseded this write (its own completion, still pending or already applied, is responsible for reconciling the item), so reloading now would race it and could clobber the newer optimistic value with this stale write's result.
-    if (item->save_generation() != save_generation) return;
-    // Resync with the actual file contents unconditionally: on success this just confirms the value already shown optimistically by setData(), while on failure it reverts that optimistic update back to what is genuinely on disk instead of leaving the cell showing an edit that was never actually written.
-    ItemReload(idx, true, item, save_generation);
+    else {
+      Q_EMIT Error(tr("Could not write metadata to %1: %2").arg(reply->filename(), reply->error()));
+    }
+    // Restore the pre-edit metadata directly rather than relying on ItemReload()/BackgroundReload() to revert it: if that reload itself fails to read the file (returning an invalid Song), ItemReloadComplete() would leave the never-written optimistic value in place and still schedule a save, persisting/displaying a value that was never actually written to disk.
+    UpdateItemMetadata(idx.row(), item, pre_edit_metadata, false);
+    return;
   }
+
+  // Resync with the actual file contents: this confirms the value already shown optimistically by setData(), picking up any normalization the tag writer applied.
+  ItemReload(idx, true, item, save_generation);
 
 }
 

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -470,11 +470,14 @@ bool Playlist::setData(const QModelIndex &idx, const QVariant &value, const int 
     UpdateItemMetadata(row, item, song, false);
     Q_EMIT EditingFinished(id_, idx);
 
+    // Bump the item's save generation so a still-in-flight completion from an earlier edit to this same item can recognize (once it eventually completes) that it has been superseded, and avoid clobbering this newer edit with its own stale result.
+    const quint64 save_generation = item->BumpSaveGeneration();
+
     TagReaderReplyPtr reply = tagreader_client_->WriteFileAsync(song.url().toLocalFile(), song);
     QPersistentModelIndex persistent_index = QPersistentModelIndex(idx);
     SharedPtr<QMetaObject::Connection> connection = make_shared<QMetaObject::Connection>();
-    *connection = QObject::connect(&*reply, &TagReaderReply::Finished, this, [this, reply, persistent_index, item, connection]() {
-      SongSaveComplete(reply, persistent_index);
+    *connection = QObject::connect(&*reply, &TagReaderReply::Finished, this, [this, reply, persistent_index, item, save_generation, connection]() {
+      SongSaveComplete(reply, persistent_index, item, save_generation);
       QObject::disconnect(*connection);
     }, Qt::QueuedConnection);
   }
@@ -489,7 +492,7 @@ bool Playlist::setData(const QModelIndex &idx, const QVariant &value, const int 
 
 }
 
-void Playlist::SongSaveComplete(TagReaderReplyPtr reply, const QPersistentModelIndex &idx) {
+void Playlist::SongSaveComplete(TagReaderReplyPtr reply, const QPersistentModelIndex &idx, const PlaylistItemPtr &item, const quint64 save_generation) {
 
   if (idx.isValid()) {
     if (!reply->success()) {
@@ -500,8 +503,10 @@ void Playlist::SongSaveComplete(TagReaderReplyPtr reply, const QPersistentModelI
         Q_EMIT Error(tr("Could not write metadata to %1: %2").arg(reply->filename(), reply->error()));
       }
     }
+    // A newer edit has already superseded this write (its own completion, still pending or already applied, is responsible for reconciling the item), so reloading now would race it and could clobber the newer optimistic value with this stale write's result.
+    if (item->save_generation() != save_generation) return;
     // Resync with the actual file contents unconditionally: on success this just confirms the value already shown optimistically by setData(), while on failure it reverts that optimistic update back to what is genuinely on disk instead of leaving the cell showing an edit that was never actually written.
-    ItemReload(idx, true);
+    ItemReload(idx, true, item, save_generation);
   }
 
 }
@@ -509,33 +514,38 @@ void Playlist::SongSaveComplete(TagReaderReplyPtr reply, const QPersistentModelI
 void Playlist::ItemReload(const QPersistentModelIndex &idx, const bool metadata_edit) {
 
   if (idx.isValid()) {
-    PlaylistItemPtr item = item_at(idx.row());
+    const PlaylistItemPtr item = item_at(idx.row());
     if (item) {
-      QFuture<Song> future = item->BackgroundReload();
-      QFutureWatcher<Song> *watcher = new QFutureWatcher<Song>(this);
-      QObject::connect(watcher, &QFutureWatcher<Song>::finished, this, [this, watcher, idx, metadata_edit]() {
-        ItemReloadComplete(idx, watcher->result(), metadata_edit);
-        watcher->deleteLater();
-      });
-      watcher->setFuture(future);
+      ItemReload(idx, metadata_edit, item, item->save_generation());
     }
   }
 
 }
 
-void Playlist::ItemReloadComplete(const QPersistentModelIndex &idx, const Song &new_metadata, const bool metadata_edit) {
+void Playlist::ItemReload(const QPersistentModelIndex &idx, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation) {
+
+  QFuture<Song> future = item->BackgroundReload();
+  QFutureWatcher<Song> *watcher = new QFutureWatcher<Song>(this);
+  QObject::connect(watcher, &QFutureWatcher<Song>::finished, this, [this, watcher, idx, metadata_edit, item, save_generation]() {
+    ItemReloadComplete(idx, watcher->result(), metadata_edit, item, save_generation);
+    watcher->deleteLater();
+  });
+  watcher->setFuture(future);
+
+}
+
+void Playlist::ItemReloadComplete(const QPersistentModelIndex &idx, const Song &new_metadata, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation) {
 
   if (idx.isValid()) {
-    const PlaylistItemPtr item = item_at(idx.row());
-    if (item) {
-      if (new_metadata.is_valid()) {
-        UpdateItemMetadata(idx.row(), item, new_metadata, false);
-      }
-      if (metadata_edit) {
-        Q_EMIT EditingFinished(id_, idx);
-      }
-      ScheduleSaveAsync();
+    // Another edit superseded this one while the reload was in flight: skip applying this now-stale result so it doesn't clobber the newer edit.
+    if (item->save_generation() != save_generation) return;
+    if (new_metadata.is_valid()) {
+      UpdateItemMetadata(idx.row(), item, new_metadata, false);
     }
+    if (metadata_edit) {
+      Q_EMIT EditingFinished(id_, idx);
+    }
+    ScheduleSaveAsync();
   }
 
 }

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -507,13 +507,13 @@ void Playlist::SongSaveComplete(TagReaderReplyPtr reply, const QPersistentModelI
     else {
       Q_EMIT Error(tr("Could not write metadata to %1: %2").arg(reply->filename(), reply->error()));
     }
-    // Restore the pre-edit metadata directly rather than relying on ItemReload()/BackgroundReload() to revert it: if that reload itself fails to read the file (returning an invalid Song), ItemReloadComplete() would leave the never-written optimistic value in place and still schedule a save, persisting/displaying a value that was never actually written to disk.
-    UpdateItemMetadata(idx.row(), item, pre_edit_metadata, false);
+    // Resync with the actual file contents rather than assuming pre_edit_metadata still matches what's on disk: with consecutive edits to the same item, pre_edit_metadata is whatever the previous (optimistic) edit left in place, which can itself be a value that was never successfully written (e.g. its own write is still in flight, or already failed but was ignored here due to the generation guard above). Reading the file collapses any such chain of unconfirmed edits to the genuine on-disk state. Only if that reload itself fails to read the file do we fall back to pre_edit_metadata as a last resort.
+    ItemReload(idx, true, item, save_generation, pre_edit_metadata);
     return;
   }
 
   // Resync with the actual file contents: this confirms the value already shown optimistically by setData(), picking up any normalization the tag writer applied.
-  ItemReload(idx, true, item, save_generation);
+  ItemReload(idx, true, item, save_generation, Song());
 
 }
 
@@ -522,31 +522,35 @@ void Playlist::ItemReload(const QPersistentModelIndex &idx, const bool metadata_
   if (idx.isValid()) {
     const PlaylistItemPtr item = item_at(idx.row());
     if (item) {
-      ItemReload(idx, metadata_edit, item, item->save_generation());
+      ItemReload(idx, metadata_edit, item, item->save_generation(), Song());
     }
   }
 
 }
 
-void Playlist::ItemReload(const QPersistentModelIndex &idx, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation) {
+void Playlist::ItemReload(const QPersistentModelIndex &idx, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation, const Song &fallback_metadata) {
 
   QFuture<Song> future = item->BackgroundReload();
   QFutureWatcher<Song> *watcher = new QFutureWatcher<Song>(this);
-  QObject::connect(watcher, &QFutureWatcher<Song>::finished, this, [this, watcher, idx, metadata_edit, item, save_generation]() {
-    ItemReloadComplete(idx, watcher->result(), metadata_edit, item, save_generation);
+  QObject::connect(watcher, &QFutureWatcher<Song>::finished, this, [this, watcher, idx, metadata_edit, item, save_generation, fallback_metadata]() {
+    ItemReloadComplete(idx, watcher->result(), metadata_edit, item, save_generation, fallback_metadata);
     watcher->deleteLater();
   });
   watcher->setFuture(future);
 
 }
 
-void Playlist::ItemReloadComplete(const QPersistentModelIndex &idx, const Song &new_metadata, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation) {
+void Playlist::ItemReloadComplete(const QPersistentModelIndex &idx, const Song &new_metadata, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation, const Song &fallback_metadata) {
 
   if (idx.isValid()) {
     // Another edit superseded this one while the reload was in flight: skip applying this now-stale result so it doesn't clobber the newer edit.
     if (item->save_generation() != save_generation) return;
     if (new_metadata.is_valid()) {
       UpdateItemMetadata(idx.row(), item, new_metadata, false);
+    }
+    else if (fallback_metadata.is_valid()) {
+      // The reload itself failed to read the file (e.g. a transient I/O error): fall back to the best metadata we still have rather than leaving whatever optimistic value was showing beforehand, which in the write-failure path this fallback comes from is known to have never been written to disk.
+      UpdateItemMetadata(idx.row(), item, fallback_metadata, false);
     }
     if (metadata_edit) {
       Q_EMIT EditingFinished(id_, idx);

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -466,6 +466,10 @@ bool Playlist::setData(const QModelIndex &idx, const QVariant &value, const int 
   if (!set_column_value(song, static_cast<Column>(idx.column()), value)) return false;
 
   if (song.url().isLocalFile()) {
+    // Show the edit immediately: otherwise the cell keeps displaying the pre-edit value (the view re-reads it right after the editor closes) until the write-then-reread round trip below completes asynchronously, which can take a perceptible moment and looks like the edit was reverted.
+    UpdateItemMetadata(row, item, song, false);
+    Q_EMIT EditingFinished(id_, idx);
+
     TagReaderReplyPtr reply = tagreader_client_->WriteFileAsync(song.url().toLocalFile(), song);
     QPersistentModelIndex persistent_index = QPersistentModelIndex(idx);
     SharedPtr<QMetaObject::Connection> connection = make_shared<QMetaObject::Connection>();
@@ -488,10 +492,7 @@ bool Playlist::setData(const QModelIndex &idx, const QVariant &value, const int 
 void Playlist::SongSaveComplete(TagReaderReplyPtr reply, const QPersistentModelIndex &idx) {
 
   if (idx.isValid()) {
-    if (reply->success()) {
-      ItemReload(idx, true);
-    }
-    else {
+    if (!reply->success()) {
       if (reply->error().isEmpty()) {
         Q_EMIT Error(tr("Could not write metadata to %1").arg(reply->filename()));
       }
@@ -499,6 +500,8 @@ void Playlist::SongSaveComplete(TagReaderReplyPtr reply, const QPersistentModelI
         Q_EMIT Error(tr("Could not write metadata to %1: %2").arg(reply->filename(), reply->error()));
       }
     }
+    // Resync with the actual file contents unconditionally: on success this just confirms the value already shown optimistically by setData(), while on failure it reverts that optimistic update back to what is genuinely on disk instead of leaving the cell showing an edit that was never actually written.
+    ItemReload(idx, true);
   }
 
 }

--- a/src/playlist/playlist.h
+++ b/src/playlist/playlist.h
@@ -385,7 +385,7 @@ class Playlist : public QAbstractListModel {
   void TracksDequeued();
   void TracksEnqueued(const QModelIndex &parent_idx, const int begin, const int end);
   void QueueLayoutChanged();
-  void SongSaveComplete(TagReaderReplyPtr reply, const QPersistentModelIndex &idx, const PlaylistItemPtr &item, const quint64 save_generation);
+  void SongSaveComplete(TagReaderReplyPtr reply, const QPersistentModelIndex &idx, const PlaylistItemPtr &item, const quint64 save_generation, const Song &pre_edit_metadata);
   void ItemReload(const QPersistentModelIndex &idx, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation);
   void ItemReloadComplete(const QPersistentModelIndex &idx, const Song &new_metadata, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation);
   void ItemsLoaded();

--- a/src/playlist/playlist.h
+++ b/src/playlist/playlist.h
@@ -386,8 +386,8 @@ class Playlist : public QAbstractListModel {
   void TracksEnqueued(const QModelIndex &parent_idx, const int begin, const int end);
   void QueueLayoutChanged();
   void SongSaveComplete(TagReaderReplyPtr reply, const QPersistentModelIndex &idx, const PlaylistItemPtr &item, const quint64 save_generation, const Song &pre_edit_metadata);
-  void ItemReload(const QPersistentModelIndex &idx, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation);
-  void ItemReloadComplete(const QPersistentModelIndex &idx, const Song &new_metadata, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation);
+  void ItemReload(const QPersistentModelIndex &idx, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation, const Song &fallback_metadata);
+  void ItemReloadComplete(const QPersistentModelIndex &idx, const Song &new_metadata, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation, const Song &fallback_metadata);
   void ItemsLoaded();
   void ScheduleSave();
   void ForceScheduleSave();

--- a/src/playlist/playlist.h
+++ b/src/playlist/playlist.h
@@ -83,6 +83,7 @@ class Playlist : public QAbstractListModel {
   friend class PlaylistUndoCommandRemoveItems;
   friend class PlaylistUndoCommandMoveItems;
   friend class PlaylistUndoCommandReOrderItems;
+  friend class PlaylistTest;
 
  public:
   explicit Playlist(const SharedPtr<TaskManager> task_manager,
@@ -384,8 +385,9 @@ class Playlist : public QAbstractListModel {
   void TracksDequeued();
   void TracksEnqueued(const QModelIndex &parent_idx, const int begin, const int end);
   void QueueLayoutChanged();
-  void SongSaveComplete(TagReaderReplyPtr reply, const QPersistentModelIndex &idx);
-  void ItemReloadComplete(const QPersistentModelIndex &idx, const Song &new_metadata, const bool metadata_edit);
+  void SongSaveComplete(TagReaderReplyPtr reply, const QPersistentModelIndex &idx, const PlaylistItemPtr &item, const quint64 save_generation);
+  void ItemReload(const QPersistentModelIndex &idx, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation);
+  void ItemReloadComplete(const QPersistentModelIndex &idx, const Song &new_metadata, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation);
   void ItemsLoaded();
   void ScheduleSave();
   void ForceScheduleSave();

--- a/src/playlist/playlistitem.cpp
+++ b/src/playlist/playlistitem.cpp
@@ -40,7 +40,7 @@
 using std::make_shared;
 using namespace Qt::Literals::StringLiterals;
 
-PlaylistItem::PlaylistItem(const Song::Source source, const QUuid &uuid, const bool signal) : source_(source), uuid_(uuid.isNull() ? QUuid::createUuid() : uuid), uuid_generated_(uuid.isNull()), signal_(signal), should_skip_(false) {}
+PlaylistItem::PlaylistItem(const Song::Source source, const QUuid &uuid, const bool signal) : source_(source), uuid_(uuid.isNull() ? QUuid::createUuid() : uuid), uuid_generated_(uuid.isNull()), signal_(signal), should_skip_(false), save_generation_(0) {}
 
 PlaylistItem::~PlaylistItem() = default;
 

--- a/src/playlist/playlistitem.h
+++ b/src/playlist/playlistitem.h
@@ -99,6 +99,11 @@ class PlaylistItem : public enable_shared_from_this<PlaylistItem> {
   virtual Song Reload() { return Song(); }
   QFuture<Song> BackgroundReload();
 
+  // Identifies the most recent edit made to this item through the playlist (e.g. inline tag editing).
+  // A caller starting an asynchronous write/reload round trip should capture the value returned by BumpSaveGeneration() and compare it against save_generation() once the round trip completes: a mismatch means a newer edit has since superseded it, so the (now stale) result must not be applied.
+  quint64 save_generation() const { return save_generation_; }
+  quint64 BumpSaveGeneration() { return ++save_generation_; }
+
   // Background colors.
   void SetBackgroundColor(const short priority, const QColor &color);
   bool HasBackgroundColor(const short priority) const;
@@ -125,6 +130,7 @@ class PlaylistItem : public enable_shared_from_this<PlaylistItem> {
   bool uuid_generated_;
   bool signal_;
   bool should_skip_;
+  quint64 save_generation_;
 
   enum class DatabaseColumn {
     CollectionId

--- a/src/playlist/songplaylistitem.h
+++ b/src/playlist/songplaylistitem.h
@@ -43,6 +43,7 @@ class SongPlaylistItem : public PlaylistItem {
 
   Song OriginalMetadata() const override { return song_; }
   QUrl OriginalUrl() const override { return song_.url(); }
+  void SetOriginalMetadata(const Song &song) override { song_ = song; }
 
   void SetArtManual(const QUrl &cover_url) override;
 

--- a/tests/src/playlist_test.cpp
+++ b/tests/src/playlist_test.cpp
@@ -27,6 +27,7 @@
 
 #include "collection/collectionplaylistitem.h"
 #include "playlist/playlist.h"
+#include "playlist/songplaylistitem.h"
 #include "mock_settingsprovider.h"
 #include "mock_playlistitem.h"
 
@@ -39,8 +40,8 @@ using namespace Qt::Literals::StringLiterals;
 
 // clazy:excludeall=non-pod-global-static,returning-void-expression
 
-namespace {
-
+// Declared at file scope (rather than inside the anonymous namespace below, where the TEST_F-generated fixture subclasses live) so that Playlist's "friend class PlaylistTest;" resolves to this exact class.
+// C++ friendship isn't inherited, so tests that need access to Playlist's private members go through the CallXxx() helpers below rather than calling them directly from a TEST_F body.
 class PlaylistTest : public ::testing::Test {
  protected:
   PlaylistTest()
@@ -65,10 +66,17 @@ class PlaylistTest : public ::testing::Test {
     return PlaylistItemPtr(MakeMockItem(title, artist, album, length));
   }
 
+  // Forwards to the private Playlist::ItemReloadComplete(), to let tests exercise the save-generation staleness check directly instead of via a real asynchronous write-then-reread round trip.
+  void CallItemReloadComplete(const QPersistentModelIndex &idx, const Song &new_metadata, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation) {
+    playlist_.ItemReloadComplete(idx, new_metadata, metadata_edit, item, save_generation);
+  }
+
   Playlist playlist_;  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
   PlaylistSequence sequence_;  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
 
 };
+
+namespace {
 
 TEST_F(PlaylistTest, Basic) {
   EXPECT_EQ(0, playlist_.rowCount(QModelIndex()));
@@ -583,6 +591,40 @@ TEST_F(PlaylistTest, TakePreviousRowConsumesHistory) {
 
   // Verify fallback is stable: repeated calls without new history still return the sequence-based previous
   EXPECT_EQ(1, playlist_.take_previous_row(false));
+
+}
+
+// Regression test for a race between two consecutive inline edits to the same playlist item: if the first edit's write-then-reread round trip completes after the second edit's, it must not clobber the second (newer) edit with its own stale result.
+TEST_F(PlaylistTest, StaleReloadCompletionDoesNotClobberNewerEdit) {
+
+  Song song;
+  song.Init(u"Title"_s, u"OriginalArtist"_s, u"Album"_s, 123);
+  song.set_url(QUrl::fromLocalFile(u"/tmp/does-not-need-to-exist.mp3"_s));
+
+  PlaylistItemPtr item = std::make_shared<SongPlaylistItem>(song, false);
+  playlist_.InsertItems(PlaylistItemPtrList() << item, -1);
+  const QPersistentModelIndex idx(playlist_.index(0, static_cast<int>(Playlist::Column::Artist)));
+
+  ASSERT_EQ(u"OriginalArtist"_s, item->OriginalMetadata().artist());
+
+  // Simulate the user making two consecutive edits to the same cell before the first edit's async write-then-reread round trip (see Playlist::setData()) has completed: each edit bumps the item's save generation, exactly as setData() does.
+  const quint64 generation_edit_one = item->BumpSaveGeneration();
+  const quint64 generation_edit_two = item->BumpSaveGeneration();
+  ASSERT_NE(generation_edit_one, generation_edit_two);
+
+  Song metadata_edit_one = item->OriginalMetadata();
+  metadata_edit_one.set_artist(u"EditOneArtist"_s);
+
+  Song metadata_edit_two = item->OriginalMetadata();
+  metadata_edit_two.set_artist(u"EditTwoArtist"_s);
+
+  // The second (newer) edit's reload completes first.
+  CallItemReloadComplete(idx, metadata_edit_two, true, item, generation_edit_two);
+  EXPECT_EQ(u"EditTwoArtist"_s, item->OriginalMetadata().artist());
+
+  // The first edit's reload, started earlier but slower, completes afterwards. Its captured generation no longer matches the item's current generation, so this stale completion must be discarded rather than clobbering the newer edit.
+  CallItemReloadComplete(idx, metadata_edit_one, true, item, generation_edit_one);
+  EXPECT_EQ(u"EditTwoArtist"_s, item->OriginalMetadata().artist());
 
 }
 

--- a/tests/src/playlist_test.cpp
+++ b/tests/src/playlist_test.cpp
@@ -28,6 +28,7 @@
 #include "collection/collectionplaylistitem.h"
 #include "playlist/playlist.h"
 #include "playlist/songplaylistitem.h"
+#include "tagreader/tagreaderclient.h"
 #include "tagreader/tagreaderreply.h"
 #include "tagreader/tagreaderresult.h"
 #include "mock_settingsprovider.h"
@@ -35,6 +36,9 @@
 
 #include <QtDebug>
 #include <QUndoStack>
+#include <QThread>
+#include <QEventLoop>
+#include <QTimer>
 
 using ::testing::Return;
 
@@ -54,6 +58,15 @@ class PlaylistTest : public ::testing::Test {
     playlist_.set_sequence(&sequence_);
   }
 
+  // TagReaderClient::Instance() is a process-wide singleton: the constructor only ever assigns sInstance the first time one is constructed, and nothing ever resets sInstance back to nullptr on destruction.
+  // SongPlaylistItem::Reload() (invoked by ItemReload()'s background task) reads through that singleton, so tests exercising it need one to exist - but it must be set up once for the whole test suite (via SetUpTestSuite(), run once before any PlaylistTest test) and never torn down here, in a per-test fixture: stopping its thread after an individual test would leave sInstance pointing at an object whose event loop is no longer running, and no later construction attempt would replace it (the "only assign if not already set" check would just see the stale pointer and do nothing), hanging or misbehaving every subsequent test in this binary that touches the singleton.
+  static void SetUpTestSuite() {
+    sTagReaderClientThread = new QThread();
+    sTagReaderClient = new TagReaderClient();
+    sTagReaderClient->moveToThread(sTagReaderClientThread);
+    sTagReaderClientThread->start();
+  }
+
   MockPlaylistItem *MakeMockItem(const QString &title, const QString &artist = QString(), const QString &album = QString(), int length = 123) const {
     Song metadata;
     metadata.Init(title, artist, album, length);
@@ -69,19 +82,42 @@ class PlaylistTest : public ::testing::Test {
   }
 
   // Forwards to the private Playlist::ItemReloadComplete(), to let tests exercise the save-generation staleness check directly instead of via a real asynchronous write-then-reread round trip.
-  void CallItemReloadComplete(const QPersistentModelIndex &idx, const Song &new_metadata, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation) {
-    playlist_.ItemReloadComplete(idx, new_metadata, metadata_edit, item, save_generation);
+  void CallItemReloadComplete(const QPersistentModelIndex &idx, const Song &new_metadata, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation, const Song &fallback_metadata = Song()) {
+    playlist_.ItemReloadComplete(idx, new_metadata, metadata_edit, item, save_generation, fallback_metadata);
   }
 
-  // Forwards to the private Playlist::SongSaveComplete(), to let tests exercise the write-failure/pre-edit-restore path directly instead of via a real asynchronous tag write.
+  // Forwards to the private Playlist::SongSaveComplete(), to let tests exercise the write-failure path directly instead of via a real asynchronous tag write. On failure this now triggers a real (asynchronous) ItemReload(), so callers must pump the event loop (see WaitForEditingFinished()) for the result to apply.
   void CallSongSaveComplete(TagReaderReplyPtr reply, const QPersistentModelIndex &idx, const PlaylistItemPtr &item, const quint64 save_generation, const Song &pre_edit_metadata) {
     playlist_.SongSaveComplete(reply, idx, item, save_generation, pre_edit_metadata);
+  }
+
+  // Blocks until Playlist::EditingFinished fires, i.e. until an in-flight ItemReload()'s background reload has completed and ItemReloadComplete() has run.
+  // Bounded by timeout_ms so a regression that stops EditingFinished from firing (or a reload that never completes) fails the test instead of hanging the whole run indefinitely, which would otherwise take down CI.
+  void WaitForEditingFinished(const int timeout_ms = 5000) {
+    QEventLoop loop;
+    QObject::connect(&playlist_, &Playlist::EditingFinished, &loop, &QEventLoop::quit);
+    bool timed_out = false;
+    QTimer::singleShot(timeout_ms, &loop, [&loop, &timed_out]() {
+      timed_out = true;
+      loop.quit();
+    });
+    loop.exec();
+    if (timed_out) {
+      FAIL() << "Timed out after " << timeout_ms << " ms waiting for Playlist::EditingFinished";
+    }
   }
 
   Playlist playlist_;  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
   PlaylistSequence sequence_;  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
 
+  // Shared for the whole test suite - see the comment on SetUpTestSuite() above.
+  static TagReaderClient *sTagReaderClient;  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
+  static QThread *sTagReaderClientThread;  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
+
 };
+
+TagReaderClient *PlaylistTest::sTagReaderClient = nullptr;
+QThread *PlaylistTest::sTagReaderClientThread = nullptr;
 
 namespace {
 
@@ -635,13 +671,17 @@ TEST_F(PlaylistTest, StaleReloadCompletionDoesNotClobberNewerEdit) {
 
 }
 
-// Regression test: if the tag write itself fails, the optimistic value shown by setData() must be reverted to what was on disk before the edit, rather than left displayed (and later persisted) despite never having been written.
-TEST_F(PlaylistTest, FailedSaveRestoresPreEditMetadata) {
+// Regression test: if the tag write itself fails and the subsequent reload also can't read the file (here because it doesn't exist), the optimistic value shown by setData() must fall back to the pre-edit value instead of being left displayed (and later persisted) despite never having been written.
+TEST_F(PlaylistTest, FailedSaveAndFailedReloadFallsBackToPreEditMetadata) {
 
   Song song;
   song.Init(u"Title"_s, u"OriginalArtist"_s, u"Album"_s, 123);
-  song.set_url(QUrl::fromLocalFile(u"/tmp/does-not-need-to-exist.mp3"_s));
-
+  QTemporaryFile missing_file;
+  ASSERT_TRUE(missing_file.open());
+  const QString missing_path = missing_file.fileName();
+  missing_file.close();
+  ASSERT_TRUE(missing_file.remove());
+  song.set_url(QUrl::fromLocalFile(missing_path));
   PlaylistItemPtr item = std::make_shared<SongPlaylistItem>(song, false);
   playlist_.InsertItems(PlaylistItemPtrList() << item, -1);
   const QPersistentModelIndex idx(playlist_.index(0, static_cast<int>(Playlist::Column::Artist)));
@@ -655,14 +695,62 @@ TEST_F(PlaylistTest, FailedSaveRestoresPreEditMetadata) {
   playlist_.UpdateItemMetadata(0, item, edited_metadata, false);
   ASSERT_EQ(u"EditedArtist"_s, item->OriginalMetadata().artist());
 
-  // The write fails.
+  // The write fails, and since the file doesn't exist, the reload SongSaveComplete() triggers to resync with disk will fail too.
   TagReaderReplyPtr reply(new TagReaderReply(song.url().toLocalFile()));
   reply->set_result(TagReaderResult(TagReaderResult::ErrorCode::FileSaveError));
 
   CallSongSaveComplete(reply, idx, item, save_generation, pre_edit_metadata);
+  WaitForEditingFinished();
 
-  // The optimistic edit must be reverted to the pre-edit value instead of being left displayed (and later persisted) despite never having been written to disk.
+  // With no genuine disk state to fall back on, the pre-edit value is the best available: the optimistic edit must not be left displayed (and persisted) despite never having been written to disk.
   EXPECT_EQ(u"OriginalArtist"_s, item->OriginalMetadata().artist());
+
+}
+
+// Regression test: for consecutive edits to the same item, the metadata restored after a failed write must reflect the actual on-disk state, not just whatever the previous (possibly also-unwritten) optimistic edit happened to leave in place.
+TEST_F(PlaylistTest, FailedSaveReloadsActualDiskStateRatherThanStalePreEditChain) {
+
+  TemporaryResource resource(u":/audio/strawberry.mp3"_s);
+
+  // Establish a known baseline actually on disk.
+  Song baseline;
+  baseline.Init(u"Title"_s, u"RealDiskArtist"_s, u"Album"_s, 123);
+  baseline.set_url(QUrl::fromLocalFile(resource.fileName()));
+  {
+    TagReaderReplyPtr write_reply = sTagReaderClient->WriteFileAsync(resource.fileName(), baseline);
+    QEventLoop loop;
+    QObject::connect(&*write_reply, &TagReaderReply::Finished, &loop, &QEventLoop::quit);
+    loop.exec();
+    ASSERT_TRUE(write_reply->success());
+  }
+
+  PlaylistItemPtr item = std::make_shared<SongPlaylistItem>(baseline, false);
+  playlist_.InsertItems(PlaylistItemPtrList() << item, -1);
+  const QPersistentModelIndex idx(playlist_.index(0, static_cast<int>(Playlist::Column::Artist)));
+
+  // Edit 1: optimistically applied, its write is still (conceptually) in flight. Its generation isn't needed here since edit 1's own (still in-flight) completion is never delivered in this test.
+  item->BumpSaveGeneration();
+  Song metadata_edit_one = item->OriginalMetadata();
+  metadata_edit_one.set_artist(u"EditOneArtist"_s);
+  playlist_.UpdateItemMetadata(0, item, metadata_edit_one, false);
+
+  // Edit 2 follows before edit 1's write completes: its pre-edit value is edit 1's optimistic (unconfirmed) artist, not what is genuinely on disk.
+  const Song pre_edit_metadata_two = item->OriginalMetadata();
+  ASSERT_EQ(u"EditOneArtist"_s, pre_edit_metadata_two.artist());
+  const quint64 generation_edit_two = item->BumpSaveGeneration();
+  Song metadata_edit_two = pre_edit_metadata_two;
+  metadata_edit_two.set_artist(u"EditTwoArtist"_s);
+  playlist_.UpdateItemMetadata(0, item, metadata_edit_two, false);
+
+  // Edit 2's write fails.
+  TagReaderReplyPtr reply(new TagReaderReply(resource.fileName()));
+  reply->set_result(TagReaderResult(TagReaderResult::ErrorCode::FileSaveError));
+
+  CallSongSaveComplete(reply, idx, item, generation_edit_two, pre_edit_metadata_two);
+  WaitForEditingFinished();
+
+  // The item must reflect what is genuinely on disk ("RealDiskArtist"), not edit 1's stale, never-confirmed optimistic value ("EditOneArtist") that pre_edit_metadata_two happened to carry.
+  EXPECT_EQ(u"RealDiskArtist"_s, item->OriginalMetadata().artist());
 
 }
 

--- a/tests/src/playlist_test.cpp
+++ b/tests/src/playlist_test.cpp
@@ -28,6 +28,8 @@
 #include "collection/collectionplaylistitem.h"
 #include "playlist/playlist.h"
 #include "playlist/songplaylistitem.h"
+#include "tagreader/tagreaderreply.h"
+#include "tagreader/tagreaderresult.h"
 #include "mock_settingsprovider.h"
 #include "mock_playlistitem.h"
 
@@ -69,6 +71,11 @@ class PlaylistTest : public ::testing::Test {
   // Forwards to the private Playlist::ItemReloadComplete(), to let tests exercise the save-generation staleness check directly instead of via a real asynchronous write-then-reread round trip.
   void CallItemReloadComplete(const QPersistentModelIndex &idx, const Song &new_metadata, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation) {
     playlist_.ItemReloadComplete(idx, new_metadata, metadata_edit, item, save_generation);
+  }
+
+  // Forwards to the private Playlist::SongSaveComplete(), to let tests exercise the write-failure/pre-edit-restore path directly instead of via a real asynchronous tag write.
+  void CallSongSaveComplete(TagReaderReplyPtr reply, const QPersistentModelIndex &idx, const PlaylistItemPtr &item, const quint64 save_generation, const Song &pre_edit_metadata) {
+    playlist_.SongSaveComplete(reply, idx, item, save_generation, pre_edit_metadata);
   }
 
   Playlist playlist_;  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
@@ -625,6 +632,37 @@ TEST_F(PlaylistTest, StaleReloadCompletionDoesNotClobberNewerEdit) {
   // The first edit's reload, started earlier but slower, completes afterwards. Its captured generation no longer matches the item's current generation, so this stale completion must be discarded rather than clobbering the newer edit.
   CallItemReloadComplete(idx, metadata_edit_one, true, item, generation_edit_one);
   EXPECT_EQ(u"EditTwoArtist"_s, item->OriginalMetadata().artist());
+
+}
+
+// Regression test: if the tag write itself fails, the optimistic value shown by setData() must be reverted to what was on disk before the edit, rather than left displayed (and later persisted) despite never having been written.
+TEST_F(PlaylistTest, FailedSaveRestoresPreEditMetadata) {
+
+  Song song;
+  song.Init(u"Title"_s, u"OriginalArtist"_s, u"Album"_s, 123);
+  song.set_url(QUrl::fromLocalFile(u"/tmp/does-not-need-to-exist.mp3"_s));
+
+  PlaylistItemPtr item = std::make_shared<SongPlaylistItem>(song, false);
+  playlist_.InsertItems(PlaylistItemPtrList() << item, -1);
+  const QPersistentModelIndex idx(playlist_.index(0, static_cast<int>(Playlist::Column::Artist)));
+
+  const Song pre_edit_metadata = item->OriginalMetadata();
+
+  // Simulate setData()'s optimistic update: bump the save generation and apply the edited value immediately, exactly as setData() does before the async write starts.
+  const quint64 save_generation = item->BumpSaveGeneration();
+  Song edited_metadata = pre_edit_metadata;
+  edited_metadata.set_artist(u"EditedArtist"_s);
+  playlist_.UpdateItemMetadata(0, item, edited_metadata, false);
+  ASSERT_EQ(u"EditedArtist"_s, item->OriginalMetadata().artist());
+
+  // The write fails.
+  TagReaderReplyPtr reply(new TagReaderReply(song.url().toLocalFile()));
+  reply->set_result(TagReaderResult(TagReaderResult::ErrorCode::FileSaveError));
+
+  CallSongSaveComplete(reply, idx, item, save_generation, pre_edit_metadata);
+
+  // The optimistic edit must be reverted to the pre-edit value instead of being left displayed (and later persisted) despite never having been written to disk.
+  EXPECT_EQ(u"OriginalArtist"_s, item->OriginalMetadata().artist());
 
 }
 


### PR DESCRIPTION
Possible fix for #2239

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Optimistic metadata changes now appear immediately in the UI.
  * Save/reload handling is now out-of-order safe, so older background results won’t overwrite newer edits.
  * If a save fails, the app shows more detailed error information and restores metadata to the correct prior (or disk) state instead of leaving stale optimistic values.
* **Tests**
  * Added regression coverage for stale completion ordering and for correct fallback behavior when save and reload fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->