### PR TITLE
Remove TagReaderClient singleton

### DIFF
--- a/src/collection/collectionplaylistitem.cpp
+++ b/src/collection/collectionplaylistitem.cpp
@@ -53,12 +53,13 @@ bool CollectionPlaylistItem::InitFromQuery(const SqlRow &query) {
 
 }
 
-Song CollectionPlaylistItem::Reload() {
+Song CollectionPlaylistItem::Reload(const SharedPtr<TagReaderClient> tagreader_client) {
 
   if (!song_.url().isLocalFile()) return Song();
+  if (!tagreader_client) return Song();
 
   Song result = song_;
-  const TagReaderResult tag_result = TagReaderClient::Instance()->ReadFileBlocking(result.url().toLocalFile(), &result);
+  const TagReaderResult tag_result = tagreader_client->ReadFileBlocking(result.url().toLocalFile(), &result);
   if (!tag_result.success()) {
     qLog(Error) << "Could not reload file" << result.url() << tag_result.error_string();
     return Song();

--- a/src/collection/collectionplaylistitem.h
+++ b/src/collection/collectionplaylistitem.h
@@ -43,7 +43,7 @@ class CollectionPlaylistItem : public PlaylistItem {
   bool IsLocalCollectionItem() const override { return song_.source() == Song::Source::Collection; }
 
   bool InitFromQuery(const SqlRow &query) override;
-  Song Reload() override;
+  Song Reload(const SharedPtr<TagReaderClient> tagreader_client) override;
 
   void SetArtManual(const QUrl &cover_url) override;
 

--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -2342,7 +2342,7 @@ void MainWindow::EditTagDialogAccepted() {
       item->SetOriginalMetadata(updated_song);
     }
     else {
-      item->Reload();
+      item->Reload(app_->tagreader_client());
     }
   }
 
@@ -3248,7 +3248,7 @@ void MainWindow::AutoCompleteTagsAccepted() {
 
   for (int i = 0; i < autocomplete_tag_items_.count(); ++i) {
     PlaylistItemPtr item = autocomplete_tag_items_.at(i);
-    const Song reloaded_song = item->Reload();
+    const Song reloaded_song = item->Reload(app_->tagreader_client());
     if (reloaded_song.is_valid()) {
       item->SetOriginalMetadata(reloaded_song);
     }

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -530,7 +530,7 @@ void Playlist::ItemReload(const QPersistentModelIndex &idx, const bool metadata_
 
 void Playlist::ItemReload(const QPersistentModelIndex &idx, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation, const Song &fallback_metadata) {
 
-  QFuture<Song> future = item->BackgroundReload();
+  QFuture<Song> future = item->BackgroundReload(tagreader_client_);
   QFutureWatcher<Song> *watcher = new QFutureWatcher<Song>(this);
   QObject::connect(watcher, &QFutureWatcher<Song>::finished, this, [this, watcher, idx, metadata_edit, item, save_generation, fallback_metadata]() {
     ItemReloadComplete(idx, watcher->result(), metadata_edit, item, save_generation, fallback_metadata);

--- a/src/playlist/playlistbackend.cpp
+++ b/src/playlist/playlistbackend.cpp
@@ -297,7 +297,7 @@ PlaylistItemPtr PlaylistBackend::RestoreCueData(PlaylistItemPtr item, SharedPtr<
   QString cue_path = song.cue_path();
   // If .cue was deleted - reload the song
   if (!QFile::exists(cue_path)) {
-    const Song reloaded_song = item->Reload();
+    const Song reloaded_song = item->Reload(tagreader_client_);
     if (reloaded_song.is_valid()) {
       item->SetOriginalMetadata(reloaded_song);
     }
@@ -329,7 +329,7 @@ PlaylistItemPtr PlaylistBackend::RestoreCueData(PlaylistItemPtr item, SharedPtr<
   }
 
   // There's no such section in the related .cue -> reload the song
-  const Song reloaded_song = item->Reload();
+  const Song reloaded_song = item->Reload(tagreader_client_);
   if (reloaded_song.is_valid()) {
     item->SetOriginalMetadata(reloaded_song);
   }

--- a/src/playlist/playlistitem.cpp
+++ b/src/playlist/playlistitem.cpp
@@ -128,12 +128,12 @@ void PlaylistItem::BindToQuery(SqlQuery *query) const {
 
 }
 
-static Song ReloadPlaylistItem(PlaylistItemPtr item) {
-  return item->Reload();
+static Song ReloadPlaylistItem(PlaylistItemPtr item, SharedPtr<TagReaderClient> tagreader_client) {
+  return item->Reload(tagreader_client);
 }
 
-QFuture<Song> PlaylistItem::BackgroundReload() {
-  return QtConcurrent::run(ReloadPlaylistItem, shared_from_this());
+QFuture<Song> PlaylistItem::BackgroundReload(const SharedPtr<TagReaderClient> tagreader_client) {
+  return QtConcurrent::run(ReloadPlaylistItem, shared_from_this(), tagreader_client);
 }
 
 void PlaylistItem::SetBackgroundColor(short priority, const QColor &color) {

--- a/src/playlist/playlistitem.h
+++ b/src/playlist/playlistitem.h
@@ -45,6 +45,7 @@ class QAction;
 
 class SqlQuery;
 class SqlRow;
+class TagReaderClient;
 
 using std::enable_shared_from_this;
 
@@ -96,8 +97,8 @@ class PlaylistItem : public enable_shared_from_this<PlaylistItem> {
 
   virtual bool InitFromQuery(const SqlRow &query) = 0;
   void BindToQuery(SqlQuery *query) const;
-  virtual Song Reload() { return Song(); }
-  QFuture<Song> BackgroundReload();
+  virtual Song Reload(const SharedPtr<TagReaderClient> tagreader_client) { Q_UNUSED(tagreader_client); return Song(); }
+  QFuture<Song> BackgroundReload(const SharedPtr<TagReaderClient> tagreader_client);
 
   // Identifies the most recent edit made to this item through the playlist (e.g. inline tag editing).
   // A caller starting an asynchronous write/reload round trip should capture the value returned by BumpSaveGeneration() and compare it against save_generation() once the round trip completes: a mismatch means a newer edit has since superseded it, so the (now stale) result must not be applied.

--- a/src/playlist/songplaylistitem.cpp
+++ b/src/playlist/songplaylistitem.cpp
@@ -39,12 +39,13 @@ bool SongPlaylistItem::InitFromQuery(const SqlRow &query) {
   return true;
 }
 
-Song SongPlaylistItem::Reload() {
+Song SongPlaylistItem::Reload(const SharedPtr<TagReaderClient> tagreader_client) {
 
   if (!song_.url().isLocalFile()) return Song();
+  if (!tagreader_client) return Song();
 
   Song result = song_;
-  const TagReaderResult tag_result = TagReaderClient::Instance()->ReadFileBlocking(result.url().toLocalFile(), &result);
+  const TagReaderResult tag_result = tagreader_client->ReadFileBlocking(result.url().toLocalFile(), &result);
   if (!tag_result.success()) {
     qLog(Error) << "Could not reload file" << result.url() << tag_result.error_string();
     return Song();

--- a/src/playlist/songplaylistitem.h
+++ b/src/playlist/songplaylistitem.h
@@ -39,7 +39,7 @@ class SongPlaylistItem : public PlaylistItem {
   // Restores a stream- or file-related playlist item using query row.
   // If it's a file related playlist item, this will restore its CUE attributes (if any) but won't parse the CUE!
   bool InitFromQuery(const SqlRow &query) override;
-  Song Reload() override;
+  Song Reload(const SharedPtr<TagReaderClient> tagreader_client) override;
 
   Song OriginalMetadata() const override { return song_; }
   QUrl OriginalUrl() const override { return song_.url(); }

--- a/src/tagreader/tagreaderclient.cpp
+++ b/src/tagreader/tagreaderclient.cpp
@@ -55,8 +55,6 @@
 using std::dynamic_pointer_cast;
 using namespace Qt::Literals::StringLiterals;
 
-TagReaderClient *TagReaderClient::sInstance = nullptr;
-
 TagReaderClient::TagReaderClient(QObject *parent)
     : QObject(parent),
       original_thread_(thread()),
@@ -64,10 +62,6 @@ TagReaderClient::TagReaderClient(QObject *parent)
       processing_(false) {
 
   setObjectName(QLatin1String(QObject::metaObject()->className()));
-
-  if (!sInstance) {
-    sInstance = this;
-  }
 
 }
 

--- a/src/tagreader/tagreaderclient.h
+++ b/src/tagreader/tagreaderclient.h
@@ -55,8 +55,6 @@ class TagReaderClient : public QObject {
  public:
   explicit TagReaderClient(QObject *parent = nullptr);
 
-  static TagReaderClient *Instance() { return sInstance; }
-
   void Start();
   void ExitAsync();
 
@@ -110,8 +108,6 @@ class TagReaderClient : public QObject {
   void SaveSongsRatingAsync(const SongList &songs);
 
  private:
-  static TagReaderClient *sInstance;
-
   QThread *original_thread_;
   QQueue<TagReaderRequestPtr> requests_;
   mutable QMutex mutex_requests_;

--- a/tests/src/mock_playlistitem.h
+++ b/tests/src/mock_playlistitem.h
@@ -42,7 +42,7 @@ class MockPlaylistItem : public PlaylistItem {
   MOCK_METHOD0(ClearStreamMetadata, void());
   MOCK_METHOD1(SetArtManual, void(const QUrl &cover_url));
   MOCK_METHOD1(InitFromQuery, bool(const SqlRow &settings));
-  MOCK_METHOD0(Reload, Song());
+  MOCK_METHOD1(Reload, Song(const SharedPtr<TagReaderClient> tagreader_client));
   MOCK_CONST_METHOD1(DatabaseValue, QVariant(DatabaseColumn));
 };
 

--- a/tests/src/playlist_test.cpp
+++ b/tests/src/playlist_test.cpp
@@ -50,21 +50,25 @@ using namespace Qt::Literals::StringLiterals;
 // C++ friendship isn't inherited, so tests that need access to Playlist's private members go through the CallXxx() helpers below rather than calling them directly from a TEST_F body.
 class PlaylistTest : public ::testing::Test {
  protected:
+  // tagreader_client_/tagreader_client_thread_ are declared (and so, per C++ member initialization order, constructed) before playlist_ below: Playlist::tagreader_client_ is a const member set once at construction time, from the SharedPtr this fixture passes in here - so the real TagReaderClient must already exist by then.
+  // PlaylistItem::Reload() (invoked by ItemReload()'s background task, via SongPlaylistItem/CollectionPlaylistItem) takes that same SharedPtr through Playlist rather than reaching for a process-wide singleton, so constructing and tearing this down per test (like tagreader_test.cpp does) is safe - there is no shared global state left for one test's teardown to leave dangling for another.
   PlaylistTest()
-      : playlist_(nullptr, nullptr, nullptr, nullptr, nullptr, 1),
-        sequence_(nullptr, new DummySettingsProvider) {}
+      : tagreader_client_(new TagReaderClient()),
+        tagreader_client_thread_(new QThread()),
+        playlist_(nullptr, nullptr, nullptr, nullptr, tagreader_client_, 1),
+        sequence_(nullptr, new DummySettingsProvider) {
+    tagreader_client_->moveToThread(tagreader_client_thread_);
+    tagreader_client_thread_->start();
+  }
+
+  ~PlaylistTest() override {
+    tagreader_client_thread_->exit();
+    tagreader_client_thread_->wait(5000);
+    delete tagreader_client_thread_;
+  }
 
   void SetUp() override {
     playlist_.set_sequence(&sequence_);
-  }
-
-  // TagReaderClient::Instance() is a process-wide singleton: the constructor only ever assigns sInstance the first time one is constructed, and nothing ever resets sInstance back to nullptr on destruction.
-  // SongPlaylistItem::Reload() (invoked by ItemReload()'s background task) reads through that singleton, so tests exercising it need one to exist - but it must be set up once for the whole test suite (via SetUpTestSuite(), run once before any PlaylistTest test) and never torn down here, in a per-test fixture: stopping its thread after an individual test would leave sInstance pointing at an object whose event loop is no longer running, and no later construction attempt would replace it (the "only assign if not already set" check would just see the stale pointer and do nothing), hanging or misbehaving every subsequent test in this binary that touches the singleton.
-  static void SetUpTestSuite() {
-    sTagReaderClientThread = new QThread();
-    sTagReaderClient = new TagReaderClient();
-    sTagReaderClient->moveToThread(sTagReaderClientThread);
-    sTagReaderClientThread->start();
   }
 
   MockPlaylistItem *MakeMockItem(const QString &title, const QString &artist = QString(), const QString &album = QString(), int length = 123) const {
@@ -107,17 +111,14 @@ class PlaylistTest : public ::testing::Test {
     }
   }
 
-  Playlist playlist_;  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
-  PlaylistSequence sequence_;  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
+  // Declaration order matters here: these must precede playlist_ so they are constructed first - see the comment above the constructor.
+  SharedPtr<TagReaderClient> tagreader_client_;
+  QThread *tagreader_client_thread_;
 
-  // Shared for the whole test suite - see the comment on SetUpTestSuite() above.
-  static TagReaderClient *sTagReaderClient;  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
-  static QThread *sTagReaderClientThread;  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
+  Playlist playlist_;
+  PlaylistSequence sequence_;
 
 };
-
-TagReaderClient *PlaylistTest::sTagReaderClient = nullptr;
-QThread *PlaylistTest::sTagReaderClientThread = nullptr;
 
 namespace {
 
@@ -717,7 +718,7 @@ TEST_F(PlaylistTest, FailedSaveReloadsActualDiskStateRatherThanStalePreEditChain
   baseline.Init(u"Title"_s, u"RealDiskArtist"_s, u"Album"_s, 123);
   baseline.set_url(QUrl::fromLocalFile(resource.fileName()));
   {
-    TagReaderReplyPtr write_reply = sTagReaderClient->WriteFileAsync(resource.fileName(), baseline);
+    TagReaderReplyPtr write_reply = tagreader_client_->WriteFileAsync(resource.fileName(), baseline);
     QEventLoop loop;
     QObject::connect(&*write_reply, &TagReaderReply::Finished, &loop, &QEventLoop::quit);
     loop.exec();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved song metadata reloading by routing refresh operations through the active tag-reading service for both manual edits and background reloads.
  * Preserved metadata recovery when CUE files are missing or no longer match playlist entries by reloading underlying songs using the same tag-reading service.
  * Removed reliance on a global tag-reader singleton, improving consistency across reload workflows (including Song and playlist items).

* **Tests**
  * Updated playlist tests to manage their own tag-reading service per test for better isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->