### PR TITLE
tests: add missing GSTREAMER_APP pkgConfig in CMakeLists.txt

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,6 +77,7 @@ macro(add_test_file test_source gui_required)
       PkgConfig::GLIB
       PkgConfig::GOBJECT
       PkgConfig::GSTREAMER_BASE
+      PkgConfig::GSTREAMER_APP
       Qt${QT_VERSION_MAJOR}::Core
       Qt${QT_VERSION_MAJOR}::Concurrent
       Qt${QT_VERSION_MAJOR}::Network


### PR DESCRIPTION
Included by waveformloader_test, introduced in #2137 by @octaviospain 
```
In file included from /build/source/src/waveform/waveformloader.h:31,
                 from /build/source/tests/src/waveformloader_test.cpp:42:
/build/source/src/waveform/waveformpipeline.h:28:10: fatal error: gst/app/gstappsink.h: No such file or directory
   28 | #include <gst/app/gstappsink.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

Detected in https://github.com/NixOS/nixpkgs/pull/513573

Note: I am far from being a c++ expert, feel free to improve this PR as you see fit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test builds to include the required multimedia application support, improving test compilation and execution reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->