### PR TITLE
GstEnginePipeline: Fix possible deadlock on error in track transition

### DIFF
--- a/src/engine/gstenginepipeline.cpp
+++ b/src/engine/gstenginepipeline.cpp
@@ -125,6 +125,22 @@ QThreadPool *GstEnginePipeline::shared_state_threadpool() {
 
 }
 
+QThreadPool *GstEnginePipeline::shared_pad_send_threadpool() {
+
+  // C++11 guarantees thread-safe initialization of static local variables
+  static QThreadPool pool;
+  static const auto init = []() {
+    // Kept separate from shared_state_threadpool(): a pad send here can block for as long as the current track takes to drain, and must never be able to starve that pool's (normally fast) state-change tasks.
+    pool.setMaxThreadCount(2);
+    return true;
+  }();
+
+  Q_UNUSED(init);
+
+  return &pool;
+
+}
+
 GstEnginePipeline::GstEnginePipeline(QObject *parent)
     : QObject(parent),
       id_(sId++),
@@ -176,6 +192,7 @@ GstEnginePipeline::GstEnginePipeline(QObject *parent)
       next_uri_set_(false),
       next_uri_need_reset_(false),
       next_uri_reset_(false),
+      next_uri_eos_manufactured_(false),
       volume_set_(false),
       volume_internal_(-1.0),
       volume_percent_(100),
@@ -244,7 +261,23 @@ GstEnginePipeline::~GstEnginePipeline() {
       }
     }
 
+    // Setting the pipeline to NULL flushes it, which releases any pad still blocked in a serialized event (e.g. a manufactured-EOS gst_pad_send_event() call from ErrorMessageReceived(), still running on a worker thread).
+    // This must happen with pipeline_ still referenced/valid but before we wait for those pad-send futures below, otherwise waitForFinished() could block forever: nothing else would ever unblock that pad.
     gst_element_set_state(pipeline_, GST_STATE_NULL);
+
+    // Now wait for any manufactured-EOS pad sends still running on a worker thread, since they act directly on audiobin_'s pad and must not race with tearing it down below.
+    {
+      QList<QFuture<gboolean>> futures_to_wait;
+      {
+        QMutexLocker locker(&mutex_pending_pad_send_events_);
+        futures_to_wait = pending_pad_send_events_;
+        pending_pad_send_events_.clear();
+      }
+
+      for (QFuture<gboolean> &future : futures_to_wait) {
+        future.waitForFinished();
+      }
+    }
 
     GstElement *audiobin = nullptr;
     g_object_get(GST_OBJECT(pipeline_), "audio-sink", &audiobin, nullptr);
@@ -1797,12 +1830,28 @@ void GstEnginePipeline::ErrorMessageReceived(GstMessage *msg) {
 
   if (pipeline_active_.load() && next_uri_set_.load() && (domain == GST_CORE_ERROR || domain == GST_RESOURCE_ERROR || domain == GST_STREAM_ERROR)) {
     // A track is still playing and the next uri is not playable. We ignore the error here so it can play until the end.
-    // But there is no message send to the bus when the current track finishes, we have to add an EOS ourself.
+    // But there is no message sent to the bus when the current track finishes, we have to add an EOS ourself.
+    // gst_pad_send_event() is a serialized event: sending it to audiobin_'s entrance pad queues it behind whatever of the current track's audio is already buffered downstream of that point, so it only reaches the sink (and surfaces as a real GST_MESSAGE_EOS, handled below) once that buffered audio has actually finished playing,
+    // which is what makes the current track play out to its natural end instead of being cut short.
+    // The call itself blocks the caller on that pad's stream lock for as long as that takes.
+    // Doing this on the main thread would freeze the UI for the remainder of the track,
+    // or deadlock it outright if the sink is also stalled waiting on a state change that can only be observed on the main thread.
+    // So it is dispatched on shared_pad_send_threadpool(), a pool kept separate from shared_state_threadpool() (used by SetState() below) so a long-blocked pad send can never starve state-change requests.
+    // Repeated error messages can arrive for the same failed next-URI (e.g. from multiple internal elements), but only the first should manufacture an EOS; the guard is reset per next-URI cycle in SetNextUrl().
+    bool expected = false;
+    if (!next_uri_eos_manufactured_.compare_exchange_strong(expected, true)) {
+      return;
+    }
     qLog(Info) << "Ignoring error" << domain << code << message << debugstr << "when loading next track";
     GstPad *pad = gst_element_get_static_pad(audiobin_, "sink");
     if (pad) {
-      gst_pad_send_event(pad, gst_event_new_eos());
-      gst_object_unref(pad);
+      QFuture<gboolean> future = QtConcurrent::run(shared_pad_send_threadpool(), [pad]() {
+        const gboolean result = gst_pad_send_event(pad, gst_event_new_eos());
+        gst_object_unref(pad);
+        return result;
+      });
+      QMutexLocker locker(&mutex_pending_pad_send_events_);
+      pending_pad_send_events_.append(future);
     }
     return;
   }
@@ -2610,6 +2659,9 @@ void GstEnginePipeline::SetNextUrl() {
 
   bool expected = false;
   if (!next_uri_set_.compare_exchange_strong(expected, true)) return;
+
+  // Starting a new next-URI cycle: allow ErrorMessageReceived() to manufacture (at most) one more EOS if this next URI also fails.
+  next_uri_eos_manufactured_ = false;
 
   // Set the next uri. When the current song ends it will be played automatically and a STREAM_START message is send to the bus.
   // When the next uri is not playable an error message is send when the pipeline goes to PLAY (or PAUSE) state or immediately if it is currently in PLAY state.

--- a/src/engine/gstenginepipeline.h
+++ b/src/engine/gstenginepipeline.h
@@ -225,6 +225,10 @@ class GstEnginePipeline : public QObject {
   // Shared thread pool for all pipeline state changes to prevent thread/FD exhaustion
   static QThreadPool *shared_state_threadpool();
 
+  // Separate shared thread pool for manufactured-EOS pad sends (see ErrorMessageReceived()).
+  // These can block for as long as the current track takes to finish draining, so they must not share shared_state_threadpool() with gst_element_set_state() calls, which are expected to complete quickly and whose timely completion drives playback control (pause/stop/seek); sharing would let a long-blocked pad send starve state changes.
+  static QThreadPool *shared_pad_send_threadpool();
+
   bool playbin3_support_;
   bool volume_full_range_support_;
 
@@ -354,6 +358,9 @@ class GstEnginePipeline : public QObject {
   std::atomic<bool> next_uri_need_reset_;
   std::atomic<bool> next_uri_reset_;
 
+  // Guards ErrorMessageReceived()'s manufactured-EOS path: reset to false each time a new next-URI is set (SetNextUrl()), and claimed with a single compare_exchange so repeated error messages about the same failed next-URI (e.g. from multiple internal elements) submit at most one manufactured EOS per next-URI cycle.
+  std::atomic<bool> next_uri_eos_manufactured_;
+
   // volume_set_, volume_internal_ and volume_percent_ are read independently in many places, but updates that mutate two or more together must hold mutex_volume_.
   mutable QMutex mutex_volume_;
   std::atomic<bool> volume_set_;
@@ -407,6 +414,12 @@ class GstEnginePipeline : public QObject {
   // Doubles as the source of truth for "a synchronous state change is in flight" and lets the destructor wait for them before unreffing the pipeline.
   QList<QFuture<GstStateChangeReturn>> pending_state_changes_;
   mutable QMutex mutex_pending_state_changes_;
+
+  // Running gst_pad_send_event() calls manufacturing an EOS for the "ignore error" gapless path in ErrorMessageReceived().
+  // gst_pad_send_event() blocks on the pad's stream lock until buffers already queued ahead of it (the remainder of the still-playing current track) have drained, so it is run off the main thread to avoid freezing (or deadlocking) the UI while that drains.
+  // Tracked here so the destructor can wait for it before unreffing the pipeline, exactly like pending_state_changes_.
+  QList<QFuture<gboolean>> pending_pad_send_events_;
+  mutable QMutex mutex_pending_pad_send_events_;
 };
 
 using GstEnginePipelinePtr = QSharedPointer<GstEnginePipeline>;


### PR DESCRIPTION
Fixes #2251

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pipeline shutdown reliability by waiting for any in-flight EOS-related pad sends to complete before tearing down the GStreamer pipeline.
  * Reduced race risk when skipping an unplayable track and advancing to the next URI by sending the EOS event asynchronously and ensuring it’s triggered only once per transition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->