### PR TITLE
GstEnginePipeline: Abandon pipelines stuck in a state change

### DIFF
--- a/src/engine/gstenginepipeline.cpp
+++ b/src/engine/gstenginepipeline.cpp
@@ -51,6 +51,7 @@
 #include <QFutureWatcher>
 #include <QMutex>
 #include <QMutexLocker>
+#include <QDeadlineTimer>
 #include <QMetaType>
 #include <QByteArray>
 #include <QList>
@@ -93,6 +94,10 @@ constexpr int GST_PLAY_FLAG_SOFT_VOLUME = 0x00000010;
 constexpr int kGstStateTimeoutNanosecs = 10000000;
 constexpr std::chrono::milliseconds kFaderFudgeMsec = 2000ms;
 constexpr std::chrono::milliseconds kFaderTimeoutMsec = 3000ms;
+
+// How long a requested state change may run before the pipeline is considered stuck and abandoned.
+// A buggy source element can block gst_element_set_state() forever (e.g. souphttpsrc waiting on a HTTP request that unlock() fails to cancel when the connection silently died); without a deadline that would freeze pipeline teardown and eventually the whole application.
+constexpr std::chrono::seconds kFinishWatchdogTimeout = 20s;
 
 constexpr int kEqBandCount = 10;
 constexpr int kEqBandFrequencies[] = { 60, 170, 310, 600, 1000, 3000, 6000, 12000, 14000, 16000 };
@@ -218,6 +223,8 @@ GstEnginePipeline::GstEnginePipeline(QObject *parent)
       about_to_finish_(false),
       finish_requested_(false),
       finished_(false),
+      stuck_(false),
+      timer_finish_watchdog_(new QTimer(this)),
       bus_message_generation_(0),
       set_state_async_in_progress_(0) {
 
@@ -236,6 +243,10 @@ GstEnginePipeline::GstEnginePipeline(QObject *parent)
   timer_fader_timeout_->setSingleShot(true);
   QObject::connect(timer_fader_timeout_, &QTimer::timeout, this, &GstEnginePipeline::FaderTimelineTimeout);
 
+  timer_finish_watchdog_->setSingleShot(true);
+  timer_finish_watchdog_->setInterval(kFinishWatchdogTimeout);
+  QObject::connect(timer_finish_watchdog_, &QTimer::timeout, this, &GstEnginePipeline::FinishWatchdogTimeout);
+
 }
 
 GstEnginePipeline::~GstEnginePipeline() {
@@ -246,8 +257,9 @@ GstEnginePipeline::~GstEnginePipeline() {
 
     // Wait for any ongoing state changes for this pipeline to complete before setting to NULL.
     // This prevents race conditions with async state transitions.
-    {
-      // Copy futures to local list to avoid holding mutex during waitForFinished()
+    // The wait is deadline-bounded: a state change stuck inside a broken source element would otherwise block this destructor (and with it the calling thread) forever.
+    if (!stuck_.load()) {
+      // Copy futures to local list to avoid holding mutex while waiting
       QList<QFuture<GstStateChangeReturn>> futures_to_wait;
       {
         QMutexLocker locker(&mutex_pending_state_changes_);
@@ -255,42 +267,56 @@ GstEnginePipeline::~GstEnginePipeline() {
         pending_state_changes_.clear();
       }
 
-      // Wait for all pending futures to complete
-      for (QFuture<GstStateChangeReturn> &future : futures_to_wait) {
-        future.waitForFinished();
+      QDeadlineTimer deadline(kFinishWatchdogTimeout);
+      for (const QFuture<GstStateChangeReturn> &future : std::as_const(futures_to_wait)) {
+        while (!future.isFinished() && !deadline.hasExpired()) QThread::msleep(50);
+        if (!future.isFinished()) {
+          stuck_ = true;
+          break;
+        }
       }
     }
 
-    // Setting the pipeline to NULL flushes it, which releases any pad still blocked in a serialized event (e.g. a manufactured-EOS gst_pad_send_event() call from ErrorMessageReceived(), still running on a worker thread).
-    // This must happen with pipeline_ still referenced/valid but before we wait for those pad-send futures below, otherwise waitForFinished() could block forever: nothing else would ever unblock that pad.
-    gst_element_set_state(pipeline_, GST_STATE_NULL);
+    if (stuck_.load()) {
+      // A state change never completed, so a GStreamer thread may still be inside gst_element_set_state() holding locks on this pipeline.
+      // Setting it to NULL or unreffing it here could block forever or crash; leaking the pipeline is the lesser harm.
+      // This also skips waiting for pending pad send events below, since without the NULL flush a manufactured-EOS pad send could block forever as well.
+      qLog(Error) << "Pipeline" << id() << "is stuck in a state change, abandoning it without cleanup";
+      pipeline_ = nullptr;
+      audiobin_ = nullptr;
+    }
+    else {
+      // Setting the pipeline to NULL flushes it, which releases any pad still blocked in a serialized event (e.g. a manufactured-EOS gst_pad_send_event() call from ErrorMessageReceived(), still running on a worker thread).
+      // This must happen with pipeline_ still referenced/valid but before we wait for those pad-send futures below, otherwise waitForFinished() could block forever: nothing else would ever unblock that pad.
+      gst_element_set_state(pipeline_, GST_STATE_NULL);
 
-    // Now wait for any manufactured-EOS pad sends still running on a worker thread, since they act directly on audiobin_'s pad and must not race with tearing it down below.
-    {
-      QList<QFuture<gboolean>> futures_to_wait;
+      // Now wait for any manufactured-EOS pad sends still running on a worker thread, since they act directly on audiobin_'s pad and must not race with tearing it down below.
       {
-        QMutexLocker locker(&mutex_pending_pad_send_events_);
-        futures_to_wait = pending_pad_send_events_;
-        pending_pad_send_events_.clear();
+        QList<QFuture<gboolean>> futures_to_wait;
+        {
+          QMutexLocker locker(&mutex_pending_pad_send_events_);
+          futures_to_wait = pending_pad_send_events_;
+          pending_pad_send_events_.clear();
+        }
+
+        for (QFuture<gboolean> &future : futures_to_wait) {
+          future.waitForFinished();
+        }
       }
 
-      for (QFuture<gboolean> &future : futures_to_wait) {
-        future.waitForFinished();
+      GstElement *audiobin = nullptr;
+      g_object_get(GST_OBJECT(pipeline_), "audio-sink", &audiobin, nullptr);
+
+      gst_object_unref(GST_OBJECT(pipeline_));
+      pipeline_ = nullptr;
+
+      if (audiobin_ && audiobin_ != audiobin) {
+        gst_object_unref(GST_OBJECT(audiobin_));
       }
-    }
-
-    GstElement *audiobin = nullptr;
-    g_object_get(GST_OBJECT(pipeline_), "audio-sink", &audiobin, nullptr);
-
-    gst_object_unref(GST_OBJECT(pipeline_));
-    pipeline_ = nullptr;
-
-    if (audiobin_ && audiobin_ != audiobin) {
-      gst_object_unref(GST_OBJECT(audiobin_));
-    }
-    audiobin_ = nullptr;
-    if (audiobin) {
-      gst_object_unref(GST_OBJECT(audiobin));
+      audiobin_ = nullptr;
+      if (audiobin) {
+        gst_object_unref(GST_OBJECT(audiobin));
+      }
     }
   }
 
@@ -536,6 +562,8 @@ bool GstEnginePipeline::Finish() {
     // Drive the pipeline to NULL without blocking; SetStateFinishedSlot() emits Finished() once it settles.
     // Routing through the async queue orders this NULL request after any state change already queued, and SetStateAsyncSlot() drops those queued non-NULL requests now that finishing has been requested.
     SetStateAsync(GST_STATE_NULL);
+    // If the NULL transition never settles (a source element can be stuck in a network request that ignores unlock), FinishWatchdogTimeout() abandons the pipeline so the engine is not blocked forever.
+    timer_finish_watchdog_->start();
   }
 
   return finished_.load();
@@ -2221,10 +2249,35 @@ void GstEnginePipeline::EmitFinishedIfQuiescent() {
   }
   if (!quiescent) return;
 
+  EmitFinishedOnce();
+
+}
+
+void GstEnginePipeline::EmitFinishedOnce() {
+
   bool expected = false;
   if (finished_.compare_exchange_strong(expected, true)) {
+    timer_finish_watchdog_->stop();
     Q_EMIT Finished();
   }
+
+}
+
+void GstEnginePipeline::FinishWatchdogTimeout() {
+
+  if (finished_.load()) return;
+
+  int pending = 0;
+  {
+    QMutexLocker locker(&mutex_pending_state_changes_);
+    pending = static_cast<int>(pending_state_changes_.size());
+  }
+
+  qLog(Error) << "Pipeline" << id() << "did not reach the NULL state within" << kFinishWatchdogTimeout.count() << "seconds (" << pending << "state change(s) still in flight), abandoning it";
+
+  // Mark the pipeline as stuck so the destructor knows a GStreamer thread may still hold locks on it and leaks it instead of blocking, then release Finish() waiters so the engine can move on.
+  stuck_ = true;
+  EmitFinishedOnce();
 
 }
 

--- a/src/engine/gstenginepipeline.cpp
+++ b/src/engine/gstenginepipeline.cpp
@@ -51,6 +51,7 @@
 #include <QFutureWatcher>
 #include <QMutex>
 #include <QMutexLocker>
+#include <QDeadlineTimer>
 #include <QMetaType>
 #include <QByteArray>
 #include <QList>
@@ -93,6 +94,10 @@ constexpr int GST_PLAY_FLAG_SOFT_VOLUME = 0x00000010;
 constexpr int kGstStateTimeoutNanosecs = 10000000;
 constexpr std::chrono::milliseconds kFaderFudgeMsec = 2000ms;
 constexpr std::chrono::milliseconds kFaderTimeoutMsec = 3000ms;
+
+// How long a requested state change may run before the pipeline is considered stuck and abandoned.
+// A buggy source element can block gst_element_set_state() forever (e.g. souphttpsrc waiting on a HTTP request that unlock() fails to cancel when the connection silently died); without a deadline that would freeze pipeline teardown and eventually the whole application.
+constexpr std::chrono::seconds kFinishWatchdogTimeout = 20s;
 
 constexpr int kEqBandCount = 10;
 constexpr int kEqBandFrequencies[] = { 60, 170, 310, 600, 1000, 3000, 6000, 12000, 14000, 16000 };
@@ -201,7 +206,10 @@ GstEnginePipeline::GstEnginePipeline(QObject *parent)
       about_to_finish_(false),
       finish_requested_(false),
       finished_(false),
+      stuck_(false),
+      timer_finish_watchdog_(new QTimer(this)),
       bus_message_generation_(0),
+      state_threadpool_(new QThreadPool),
       set_state_async_in_progress_(0),
       set_state_request_generation_(0) {
 
@@ -212,12 +220,16 @@ GstEnginePipeline::GstEnginePipeline(QObject *parent)
 
   // A single thread, so gst_element_set_state() calls for this pipeline are always applied in the order they were requested.
   // Two of them running concurrently would let the pipeline settle in whichever state happened to be applied last rather than the one requested last.
-  state_threadpool_.setMaxThreadCount(1);
+  state_threadpool_->setMaxThreadCount(1);
   // Let idle threads expire sooner than the 30 second default: with one pool per pipeline, an idle thread per pipeline would otherwise be kept around for that long whenever several pipelines exist concurrently (the current one, a fadeout and any pipeline still on its way to NULL).
-  state_threadpool_.setExpiryTimeout(2000);
+  state_threadpool_->setExpiryTimeout(2000);
 
   eq_band_gains_.reserve(kEqBandCount);
   for (int i = 0; i < kEqBandCount; ++i) eq_band_gains_ << 0;
+
+  timer_finish_watchdog_->setSingleShot(true);
+  timer_finish_watchdog_->setInterval(kFinishWatchdogTimeout);
+  QObject::connect(timer_finish_watchdog_, &QTimer::timeout, this, &GstEnginePipeline::FinishWatchdogTimeout);
 
 }
 
@@ -229,10 +241,10 @@ GstEnginePipeline::~GstEnginePipeline() {
 
     // Wait for any ongoing state changes for this pipeline to complete before setting to NULL.
     // This prevents race conditions with async state transitions.
-    // It is also what makes state_threadpool_ safe to hold as a member: each task captured the raw pipeline_ pointer that is unreffed below, and while ~QThreadPool() does block until its runnables have completed, it only runs after this destructor body has already unreffed the pipeline.
-    // So the pool must be empty by the time we get there, and waiting on the futures here is what guarantees that.
-    {
-      // Copy futures to local list to avoid holding mutex during waitForFinished()
+    // It is also what makes deleting state_threadpool_ below safe: each task captured the raw pipeline_ pointer that is unreffed before the pool is deleted, and while ~QThreadPool() does block until its runnables have completed, waiting on the futures here is what guarantees the pool is already empty by then.
+    // The wait is deadline-bounded: a state change stuck inside a broken source element would otherwise block this destructor (and with it the calling thread) forever.
+    if (!stuck_.load()) {
+      // Copy futures to local list to avoid holding mutex while waiting
       QList<QFuture<GstStateChangeReturn>> futures_to_wait;
       {
         QMutexLocker locker(&mutex_pending_state_changes_);
@@ -240,44 +252,64 @@ GstEnginePipeline::~GstEnginePipeline() {
         pending_state_changes_.clear();
       }
 
-      // Wait for all pending futures to complete
-      for (QFuture<GstStateChangeReturn> &future : futures_to_wait) {
-        future.waitForFinished();
+      QDeadlineTimer deadline(kFinishWatchdogTimeout);
+      for (const QFuture<GstStateChangeReturn> &future : std::as_const(futures_to_wait)) {
+        while (!future.isFinished() && !deadline.hasExpired()) QThread::msleep(50);
+        if (!future.isFinished()) {
+          stuck_ = true;
+          break;
+        }
       }
     }
 
-    // Setting the pipeline to NULL flushes it, which releases any pad still blocked in a serialized event (e.g. a manufactured-EOS gst_pad_send_event() call from ErrorMessageReceived(), still running on a worker thread).
-    // This must happen with pipeline_ still referenced/valid but before we wait for those pad-send futures below, otherwise waitForFinished() could block forever: nothing else would ever unblock that pad.
-    gst_element_set_state(pipeline_, GST_STATE_NULL);
+    if (stuck_.load()) {
+      // A state change never completed, so a GStreamer thread may still be inside gst_element_set_state() holding locks on this pipeline.
+      // Setting it to NULL or unreffing it here could block forever or crash; leaking the pipeline is the lesser harm.
+      // This also skips waiting for pending pad send events below, since without the NULL flush a manufactured-EOS pad send could block forever as well.
+      // The thread pool is leaked with it: its stuck runnable is what is blocked inside gst_element_set_state(), and ~QThreadPool() would wait for it forever.
+      qLog(Error) << "Pipeline" << id() << "is stuck in a state change, abandoning it without cleanup";
+      pipeline_ = nullptr;
+      audiobin_ = nullptr;
+      state_threadpool_ = nullptr;
+    }
+    else {
+      // Setting the pipeline to NULL flushes it, which releases any pad still blocked in a serialized event (e.g. a manufactured-EOS gst_pad_send_event() call from ErrorMessageReceived(), still running on a worker thread).
+      // This must happen with pipeline_ still referenced/valid but before we wait for those pad-send futures below, otherwise waitForFinished() could block forever: nothing else would ever unblock that pad.
+      gst_element_set_state(pipeline_, GST_STATE_NULL);
 
-    // Now wait for any manufactured-EOS pad sends still running on a worker thread, since they act directly on audiobin_'s pad and must not race with tearing it down below.
-    {
-      QList<QFuture<gboolean>> futures_to_wait;
+      // Now wait for any manufactured-EOS pad sends still running on a worker thread, since they act directly on audiobin_'s pad and must not race with tearing it down below.
       {
-        QMutexLocker locker(&mutex_pending_pad_send_events_);
-        futures_to_wait = pending_pad_send_events_;
-        pending_pad_send_events_.clear();
+        QList<QFuture<gboolean>> futures_to_wait;
+        {
+          QMutexLocker locker(&mutex_pending_pad_send_events_);
+          futures_to_wait = pending_pad_send_events_;
+          pending_pad_send_events_.clear();
+        }
+
+        for (QFuture<gboolean> &future : futures_to_wait) {
+          future.waitForFinished();
+        }
       }
 
-      for (QFuture<gboolean> &future : futures_to_wait) {
-        future.waitForFinished();
+      GstElement *audiobin = nullptr;
+      g_object_get(GST_OBJECT(pipeline_), "audio-sink", &audiobin, nullptr);
+
+      gst_object_unref(GST_OBJECT(pipeline_));
+      pipeline_ = nullptr;
+
+      if (audiobin_ && audiobin_ != audiobin) {
+        gst_object_unref(GST_OBJECT(audiobin_));
       }
-    }
-
-    GstElement *audiobin = nullptr;
-    g_object_get(GST_OBJECT(pipeline_), "audio-sink", &audiobin, nullptr);
-
-    gst_object_unref(GST_OBJECT(pipeline_));
-    pipeline_ = nullptr;
-
-    if (audiobin_ && audiobin_ != audiobin) {
-      gst_object_unref(GST_OBJECT(audiobin_));
-    }
-    audiobin_ = nullptr;
-    if (audiobin) {
-      gst_object_unref(GST_OBJECT(audiobin));
+      audiobin_ = nullptr;
+      if (audiobin) {
+        gst_object_unref(GST_OBJECT(audiobin));
+      }
     }
   }
+
+  // Deleted only after the pipeline is gone: ~QThreadPool() waits for its runnables, which all completed above unless the pipeline was abandoned as stuck, in which case the pool was already nulled so it leaks with the pipeline.
+  delete state_threadpool_;
+  state_threadpool_ = nullptr;
 
   qLog(Debug) << "Pipeline" << id() << "deleted";
 
@@ -538,6 +570,8 @@ bool GstEnginePipeline::Finish() {
     // Drive the pipeline to NULL without blocking; SetStateFinishedSlot() emits Finished() once it settles.
     // Routing through the async queue orders this NULL request after any state change already queued, and SetStateAsyncSlot() drops those queued non-NULL requests now that finishing has been requested.
     SetStateAsync(GST_STATE_NULL);
+    // If the NULL transition never settles (a source element can be stuck in a network request that ignores unlock), FinishWatchdogTimeout() abandons the pipeline so the engine is not blocked forever.
+    timer_finish_watchdog_->start();
   }
 
   return finished_.load();
@@ -2227,7 +2261,7 @@ QFuture<GstStateChangeReturn> GstEnginePipeline::ApplyState(const GstState state
     watcher->deleteLater();
     SetStateFinishedSlot(state, state_change_return);
   });
-  QFuture<GstStateChangeReturn> future = QtConcurrent::run(&state_threadpool_, &gst_element_set_state, pipeline_, state);
+  QFuture<GstStateChangeReturn> future = QtConcurrent::run(state_threadpool_, &gst_element_set_state, pipeline_, state);
   watcher->setFuture(future);
 
   // Track this future so the destructor can wait for it and so it counts as a state change in progress.
@@ -2277,10 +2311,35 @@ void GstEnginePipeline::EmitFinishedIfQuiescent() {
   }
   if (!quiescent) return;
 
+  EmitFinishedOnce();
+
+}
+
+void GstEnginePipeline::EmitFinishedOnce() {
+
   bool expected = false;
   if (finished_.compare_exchange_strong(expected, true)) {
+    timer_finish_watchdog_->stop();
     Q_EMIT Finished();
   }
+
+}
+
+void GstEnginePipeline::FinishWatchdogTimeout() {
+
+  if (finished_.load()) return;
+
+  int pending = 0;
+  {
+    QMutexLocker locker(&mutex_pending_state_changes_);
+    pending = static_cast<int>(pending_state_changes_.size());
+  }
+
+  qLog(Error) << "Pipeline" << id() << "did not reach the NULL state within" << kFinishWatchdogTimeout.count() << "seconds (" << pending << "state change(s) still in flight), abandoning it";
+
+  // Mark the pipeline as stuck so the destructor knows a GStreamer thread may still hold locks on it and leaks it instead of blocking, then release Finish() waiters so the engine can move on.
+  stuck_ = true;
+  EmitFinishedOnce();
 
 }
 

--- a/src/engine/gstenginepipeline.h
+++ b/src/engine/gstenginepipeline.h
@@ -172,6 +172,7 @@ class GstEnginePipeline : public QObject {
   QFuture<GstStateChangeReturn> ApplyState(const GstState state);
   void StartPlaybackAfterWarmup();
   void EmitFinishedIfQuiescent();
+  void EmitFinishedOnce();
   void SetNextUrl();
 
   // Static callbacks.  The GstEnginePipeline instance is passed in the last argument.
@@ -220,6 +221,7 @@ class GstEnginePipeline : public QObject {
   void SetStateAsyncSlot(const GstState state, const quint64 state_request_generation);
 
  private Q_SLOTS:
+  void FinishWatchdogTimeout();
   void SetStateFinishedSlot(const GstState state, const GstStateChangeReturn state_change_return);
   void SetFaderVolume(const qreal volume);
   void FaderTimelineStateChanged(const QTimeLine::State state);
@@ -411,12 +413,18 @@ class GstEnginePipeline : public QObject {
   std::atomic<bool> finish_requested_;
   std::atomic<bool> finished_;
 
+  // Set when a state change never completed within the watchdog deadline (e.g. a source element stuck in a network request that ignores unlock).
+  // A stuck pipeline is abandoned: Finished() is force-emitted so the engine can move on, and the destructor deliberately leaks the GStreamer objects instead of blocking forever.
+  std::atomic<bool> stuck_;
+  QTimer *timer_finish_watchdog_;
+
   // Identifies the current bus-watch session. Bumped by DisconnectCallbacks() so that GstBusMessageEvents posted from the GLib thread before teardown (Windows/macOS) are dropped instead of handled after the watch is gone or replaced.
   std::atomic<quint64> bus_message_generation_;
 
   // Per-pipeline thread pool for gst_element_set_state() calls, limited to one thread so that no two state changes run concurrently on this pipeline and queued tasks (submitted via SetStateAsync) run in submission order.
   // It is per-pipeline rather than shared so that a slow downwards transition on one pipeline (going to NULL can block until the streaming threads have stopped) cannot hold up another pipeline's state changes.
-  QThreadPool state_threadpool_;
+  // Held by pointer so the destructor can leak it together with a stuck pipeline: ~QThreadPool() waits for its runnables, and a state change stuck inside a broken source element would never let that wait return.
+  QThreadPool *state_threadpool_;
 
   // Number of SetStateAsync() requests that have been queued but not yet turned into a running state change.
   // Incremented (possibly from a GStreamer streaming thread) the moment a request is queued and decremented when its slot runs, so that a state change is never briefly invisible while handing off from the queue to a pending future.

--- a/src/engine/gstenginepipeline.h
+++ b/src/engine/gstenginepipeline.h
@@ -171,6 +171,7 @@ class GstEnginePipeline : public QObject {
   void SetStateAsync(const GstState state);
   void StartPlaybackAfterWarmup();
   void EmitFinishedIfQuiescent();
+  void EmitFinishedOnce();
   void SetNextUrl();
 
   // Static callbacks.  The GstEnginePipeline instance is passed in the last argument.
@@ -209,6 +210,7 @@ class GstEnginePipeline : public QObject {
   void ProcessPendingSeek(const GstState state);
 
  private Q_SLOTS:
+  void FinishWatchdogTimeout();
   void SetStateAsyncSlot(const GstState state);
   void SetStateFinishedSlot(const GstState state, const GstStateChangeReturn state_change_return);
   void SetFaderVolume(const qreal volume);
@@ -402,6 +404,11 @@ class GstEnginePipeline : public QObject {
   std::atomic<bool> about_to_finish_;
   std::atomic<bool> finish_requested_;
   std::atomic<bool> finished_;
+
+  // Set when a state change never completed within the watchdog deadline (e.g. a source element stuck in a network request that ignores unlock).
+  // A stuck pipeline is abandoned: Finished() is force-emitted so the engine can move on, and the destructor deliberately leaks the GStreamer objects instead of blocking forever.
+  std::atomic<bool> stuck_;
+  QTimer *timer_finish_watchdog_;
 
   // Identifies the current bus-watch session. Bumped by DisconnectCallbacks() so that GstBusMessageEvents posted from the GLib thread before teardown (Windows/macOS) are dropped instead of handled after the watch is gone or replaced.
   std::atomic<quint64> bus_message_generation_;


### PR DESCRIPTION

## Problem

While playing an internet radio stream on macOS, the TCP connection died silently (network change; `lsof` showed no open connections left for the process). The souphttpsrc streaming task ended up blocked forever in `gst_soup_http_src_do_request()` waiting on a `GCond` that `unlock()` failed to signal — despite souphttpsrc's default `timeout=15`/`retries=3`. This is an upstream bug in gst-plugins-good/libsoup (GStreamer 1.28.2), reported with full thread samples of two occurrences in https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/5238.

The consequence on Strawberry's side: `gst_element_set_state(pipeline, GST_STATE_NULL)` blocked forever in `gst_pad_stop_task()` waiting for the streaming task to exit. The pipeline never emitted `Finished()`, so it was parked in `old_pipelines_` forever, and as soon as its last reference was dropped, `~GstEnginePipeline()` blocked forever in `waitForFinished()` — freezing playback control and eventually the whole application. A thread sample of the hung process (attached to the upstream report) shows two pipelines stuck this way in the same session: the app retried with a fresh pipeline, which hung identically.

## Fix

Strawberry cannot fix the upstream race, but it can contain the damage:

- `Finish()` now starts a 20 second watchdog timer. If the NULL transition does not settle in time, the pipeline is marked stuck and `Finished()` is force-emitted so `GstEngine` can move on and playback keeps working.
- The destructor's wait for pending state changes is now deadline-bounded. A stuck pipeline is deliberately leaked (no `gst_element_set_state(NULL)`, no unref), since a GStreamer thread may still be inside `gst_element_set_state()` holding locks on it — a leaked pipeline object and one dead pool thread are the lesser harm compared to a frozen application.
- The duplicated Finished-emission logic is factored into `EmitFinishedOnce()`, which also stops the watchdog on the normal path.

## Testing

- All 16 unit tests pass (`ctest`, excluding `lyrics_live_tests`).
- Normal path exercised in the real app against a local HTTP stream server: play → stop (fade-out → `Finishing pipeline` → NULL → `Finished` → destructor) over three pipeline lifecycles, plus quitting via SIGTERM while a stream was playing. No watchdog false positives; every pipeline was destroyed cleanly and without delay.
- The stuck path itself could not be reproduced locally (the upstream race needs a silently dead connection; with a local stalling server souphttpsrc's timeout aborts correctly), so that path is verified by review only. Worst case if the watchdog misfires is a leaked pipeline plus an error log entry instead of a freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CM8kS4UmXUiG6nDaM8rTeA



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented application freezes when media pipelines become stuck during shutdown.
  * Added timeouts for stalled pipeline shutdowns, including unresponsive network sources.
  * Improved handling of incomplete state transitions so shutdown can continue without waiting indefinitely.
  * Prevented callbacks from accessing pipelines after they have been closed.
  * Ensured pipeline completion notifications are emitted only once.
  * Improved cleanup behavior for pipelines that finish shutting down normally.
  * Improved recovery when abandoning pipelines that cannot be stopped cleanly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->