### PR TITLE
Fix re-loading of playlist items metadata after editing tags

### DIFF
--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -2334,22 +2334,33 @@ void MainWindow::EditTagDialogAccepted() {
     return;
   }
 
+  Playlist *playlist = app_->playlist_manager()->current();
+  if (!playlist) {
+    return;
+  }
+
+  QList<int> rows_to_reload;
   for (int i = 0; i < items.count(); ++i) {
-    PlaylistItemPtr item = items[i];
-    const Song &updated_song = songs[i];
-    // For stream tracks, apply the metadata directly since there's no file to reload from
+    PlaylistItemPtr item = items.at(i);
+    const Song &updated_song = songs.at(i);
+    // For stream tracks, apply the metadata directly since there's no file to reload from.
     if (updated_song.is_stream_service()) {
-      item->SetOriginalMetadata(updated_song);
+      playlist->UpdateItemMetadata(item, updated_song, false);
+      continue;
     }
-    else {
-      item->Reload(app_->tagreader_client());
+    // The item's row may have shifted since the dialog was opened, and reloading below needs a row rather than just the item.
+    const int row = playlist->row_of(item);
+    if (row != -1) {
+      rows_to_reload << row;
     }
   }
 
-  // FIXME: This is really lame but we don't know what rows have changed.
-  ui_->playlist->view()->update();
+  // Reload the just-written files from disk (to pick up any normalization the tag writer applied) and refresh only the rows that changed, instead of repainting the whole view.
+  if (!rows_to_reload.isEmpty()) {
+    playlist->ReloadItems(rows_to_reload);
+  }
 
-  app_->playlist_manager()->current()->ScheduleSaveAsync();
+  playlist->ScheduleSaveAsync();
 
 }
 
@@ -3224,7 +3235,7 @@ void MainWindow::AutoCompleteTags() {
   for (const QModelIndex &proxy_index : proxy_indexes) {
     const QModelIndex source_index = app_->playlist_manager()->current()->filter()->mapToSource(proxy_index);
     if (!source_index.isValid()) continue;
-    PlaylistItemPtr item(app_->playlist_manager()->current()->item_at(source_index.row()));
+    PlaylistItemPtr item = app_->playlist_manager()->current()->item_at(source_index.row());
     if (!item) continue;
     Song song = item->OriginalMetadata();
     if (song.IsEditable()) {
@@ -3246,17 +3257,22 @@ void MainWindow::AutoCompleteTags() {
 
 void MainWindow::AutoCompleteTagsAccepted() {
 
-  for (int i = 0; i < autocomplete_tag_items_.count(); ++i) {
-    PlaylistItemPtr item = autocomplete_tag_items_.at(i);
-    const Song reloaded_song = item->Reload(app_->tagreader_client());
-    if (reloaded_song.is_valid()) {
-      item->SetOriginalMetadata(reloaded_song);
+  Playlist *playlist = app_->playlist_manager()->current();
+  if (playlist) {
+    QList<int> rows_to_reload;
+    for (int i = 0; i < autocomplete_tag_items_.count(); i++) {
+      const PlaylistItemPtr item = autocomplete_tag_items_.at(i);
+      const int row = playlist->row_of(item);
+      if (row != -1) {
+        rows_to_reload << row;
+      }
+    }
+    if (!rows_to_reload.isEmpty()) {
+      playlist->ReloadItems(rows_to_reload);
     }
   }
-  autocomplete_tag_items_.clear();
 
-  // This is really lame but we don't know what rows have changed
-  ui_->playlist->view()->update();
+  autocomplete_tag_items_.clear();
 
 }
 

--- a/src/playlist/playlist.h
+++ b/src/playlist/playlist.h
@@ -210,6 +210,8 @@ class Playlist : public QAbstractListModel {
   const PlaylistItemPtr &item_at(const int index) const { return items_[index]; }
   bool has_item_at(const int index) const { return index >= 0 && index < rowCount(); }
 
+  int row_of(const PlaylistItemPtr &item) const { return static_cast<int>(items_.indexOf(item)); }
+
   PlaylistItemPtr current_item() const;
   QUuid current_uuid() const;
 


### PR DESCRIPTION
Fixes #2257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata editing so changes appear promptly on affected playlist tracks.
  * Updated tag autocomplete to refresh only modified tracks, reducing unnecessary playlist updates.
  * Improved handling when no playlist is currently available.
  * Metadata changes are now saved asynchronously for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->