### PR TITLE
Fix macOS bundle deploy breaking the GStreamer soup plugin

### DIFF
--- a/cmake/Dmg.cmake
+++ b/cmake/Dmg.cmake
@@ -29,12 +29,23 @@ if(MACDEPLOYQT_EXECUTABLE)
     set(CREATEDMG_SKIP_JENKINS_ARG "--skip-jenkins")
   endif()
 
+  if(APPLE_DEVELOPER_ID)
+    set(CODESIGN_IDENTITY ${APPLE_DEVELOPER_ID})
+  else()
+    set(CODESIGN_IDENTITY "-")
+  endif()
+
   add_custom_target(deploy
     COMMAND mkdir -p ${CMAKE_BINARY_DIR}/strawberry.app/Contents/{Frameworks,Resources}
     COMMAND cp -v ${CMAKE_BINARY_DIR}/dist/macos/Info.plist ${CMAKE_BINARY_DIR}/strawberry.app/Contents/
     COMMAND cp -v ${CMAKE_SOURCE_DIR}/dist/macos/strawberry.icns ${CMAKE_BINARY_DIR}/strawberry.app/Contents/Resources/
     COMMAND ${CMAKE_SOURCE_DIR}/dist/macos/macgstcopy.sh ${CMAKE_BINARY_DIR}/strawberry.app
     COMMAND ${MACDEPLOYQT_EXECUTABLE} strawberry.app -verbose=3 -executable=${CMAKE_BINARY_DIR}/strawberry.app/Contents/PlugIns/gst-plugin-scanner ${MACDEPLOYQT_CODESIGN}
+    # macdeployqt leaves some libraries with invalidated signatures: the libsoup copied by macgstcopy.sh (its dependencies get rewritten afterwards) and the dependencies macdeployqt pulls in for it (libsqlite3, libpsl, libnghttp2).
+    # A library with an invalid signature fails to dlopen on Apple Silicon, silently breaking the soup plugin (HTTP/HTTPS streaming), so re-sign everything and then the bundle itself.
+    COMMAND sh -c "codesign --force --sign '${CODESIGN_IDENTITY}' ${CMAKE_BINARY_DIR}/strawberry.app/Contents/Frameworks/*.dylib"
+    COMMAND sh -c "codesign --force --sign '${CODESIGN_IDENTITY}' ${CMAKE_BINARY_DIR}/strawberry.app/Contents/PlugIns/gstreamer/*.dylib ${CMAKE_BINARY_DIR}/strawberry.app/Contents/PlugIns/gio-modules/*.so ${CMAKE_BINARY_DIR}/strawberry.app/Contents/PlugIns/gst-plugin-scanner"
+    COMMAND codesign --force --sign ${CODESIGN_IDENTITY} ${CMAKE_BINARY_DIR}/strawberry.app
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     DEPENDS strawberry
   )

--- a/cmake/Dmg.cmake
+++ b/cmake/Dmg.cmake
@@ -43,8 +43,8 @@ if(MACDEPLOYQT_EXECUTABLE)
     COMMAND ${MACDEPLOYQT_EXECUTABLE} strawberry.app -verbose=3 -executable=${CMAKE_BINARY_DIR}/strawberry.app/Contents/PlugIns/gst-plugin-scanner ${MACDEPLOYQT_CODESIGN}
     # macdeployqt leaves some libraries with invalidated signatures: the libsoup copied by macgstcopy.sh (its dependencies get rewritten afterwards) and the dependencies macdeployqt pulls in for it (libsqlite3, libpsl, libnghttp2).
     # A library with an invalid signature fails to dlopen on Apple Silicon, silently breaking the soup plugin (HTTP/HTTPS streaming), so re-sign everything and then the bundle itself.
-    COMMAND sh -c "codesign --force --sign '${CODESIGN_IDENTITY}' ${CMAKE_BINARY_DIR}/strawberry.app/Contents/Frameworks/*.dylib"
-    COMMAND sh -c "codesign --force --sign '${CODESIGN_IDENTITY}' ${CMAKE_BINARY_DIR}/strawberry.app/Contents/PlugIns/gstreamer/*.dylib ${CMAKE_BINARY_DIR}/strawberry.app/Contents/PlugIns/gio-modules/*.so ${CMAKE_BINARY_DIR}/strawberry.app/Contents/PlugIns/gst-plugin-scanner"
+    COMMAND sh -c "codesign --force --sign '${CODESIGN_IDENTITY}' '${CMAKE_BINARY_DIR}/strawberry.app/Contents/Frameworks'/*.dylib"
+    COMMAND sh -c "codesign --force --sign '${CODESIGN_IDENTITY}' '${CMAKE_BINARY_DIR}/strawberry.app/Contents/PlugIns/gstreamer'/*.dylib '${CMAKE_BINARY_DIR}/strawberry.app/Contents/PlugIns/gio-modules'/*.so '${CMAKE_BINARY_DIR}/strawberry.app/Contents/PlugIns/gst-plugin-scanner'"
     COMMAND codesign --force --sign ${CODESIGN_IDENTITY} ${CMAKE_BINARY_DIR}/strawberry.app
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     DEPENDS strawberry

--- a/dist/macos/macgstcopy.sh
+++ b/dist/macos/macgstcopy.sh
@@ -113,8 +113,8 @@ udp
 volume
 vorbis
 wavenc
-wavpack
 wavparse
+wavpack
 xingmux
 "
 
@@ -133,6 +133,13 @@ for gst_plugin in $gst_plugins; do
   fi
   cp -v -f "${GST_PLUGIN_PATH}/${gst_plugin_filename}" "${bundledir}/Contents/PlugIns/gstreamer/" || exit 1
   install_name_tool -id "@rpath/${gst_plugin_filename}" "${bundledir}/Contents/PlugIns/gstreamer/${gst_plugin_filename}"
+  # Replace build-machine rpaths with the bundle frameworks directory.
+  # Plugins that load libraries at runtime by soname (soup, adaptivedemux2) resolve the dlopen through the plugin's rpaths, so a leftover rpath pointing into the build environment (e.g. homebrew) makes them load a library linked against a second copy of glib, which breaks them.
+  gst_plugin_rpaths=$(otool -l "${bundledir}/Contents/PlugIns/gstreamer/${gst_plugin_filename}" | grep -A2 LC_RPATH | grep ' path ' | awk '{print $2}')
+  for gst_plugin_rpath in ${gst_plugin_rpaths}; do
+    install_name_tool -delete_rpath "${gst_plugin_rpath}" "${bundledir}/Contents/PlugIns/gstreamer/${gst_plugin_filename}"
+  done
+  install_name_tool -add_rpath "@loader_path/../../Frameworks" "${bundledir}/Contents/PlugIns/gstreamer/${gst_plugin_filename}"
 done
 if [ "${missing_plugins}" = "1" ]; then
   exit 1


### PR DESCRIPTION
## Problem

Deploying the macOS bundle on a machine where the build environment's library paths still exist (e.g. a dev machine with Homebrew) produces an app whose HTTP/HTTPS streaming is silently broken, in two independent ways:

1. **Wrong libsoup loaded.** The soup and adaptivedemux2 plugins load libsoup at runtime via `dlopen` by soname, resolved through the plugin's rpaths. The plugins copied from the build environment keep an rpath pointing into it (e.g. `/opt/homebrew/opt/libsoup/lib`), so the system libsoup is loaded instead of the bundled one. That libsoup is linked against a second copy of glib, and with two GObject type systems in one process the soup type registrations resolve to garbage (log shows `g_object_new_is_valid_property: object class 'GstMiniObject' has no property named 'user-agent'` and invalid `accept-certificate`/`authenticate` signals).

2. **Invalid signatures.** macdeployqt rewrites the dependencies of the libsoup copied by `macgstcopy.sh` without re-signing it, and the dependencies it pulls in for it (libsqlite3, libpsl, libnghttp2) also end up with invalid signatures — macdeployqt's own verification even reports this at the end of the deploy. On Apple Silicon a library with an invalid signature fails to `dlopen` (SIGKILL), so the soup plugin registers no elements and playback fails with "Missing GStreamer plugin for HTTP protocol source".

## Fix

- `macgstcopy.sh`: replace the rpaths of every copied GStreamer plugin with `@loader_path/../../Frameworks`, so the runtime dlopen always resolves to the bundled libsoup.
- `Dmg.cmake` deploy target: after macdeployqt, re-sign the bundled dylibs/gio-modules/gst-plugin-scanner and the bundle itself (with `APPLE_DEVELOPER_ID` when set, ad-hoc otherwise).

## Testing

Deployed on an arm64 machine with Homebrew (previously reproducing both failure modes): `codesign -v` is now clean for every library and the bundle, macdeployqt's verification error is gone, and both an HTTP stream (icecast) and an HTTPS stream (Qobuz) play in the deployed bundle. Before the fix, the same setup produced the GType errors resp. "Missing GStreamer plugin for HTTP protocol source".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CM8kS4UmXUiG6nDaM8rTeA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS deployment by ensuring bundled frameworks, plugins/modules, and the final app bundle are consistently re-signed after packaging.
  * Added support for using the configured Apple Developer signing identity, with an automatic fallback suitable for unsigned development builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->