### PR TITLE
Refactor playlist item reload

### DIFF
--- a/src/collection/collectionplaylistitem.cpp
+++ b/src/collection/collectionplaylistitem.cpp
@@ -23,9 +23,7 @@
 #include <QUrl>
 #include <QUuid>
 
-#include "core/logging.h"
 #include "collectionplaylistitem.h"
-#include "tagreader/tagreaderclient.h"
 
 class SqlRow;
 
@@ -50,22 +48,6 @@ bool CollectionPlaylistItem::InitFromQuery(const SqlRow &query) {
   song_.InitFromQuery(query, true, col);
 
   return song_.is_valid();
-
-}
-
-Song CollectionPlaylistItem::Reload(const SharedPtr<TagReaderClient> tagreader_client) {
-
-  if (!song_.url().isLocalFile()) return Song();
-  if (!tagreader_client) return Song();
-
-  Song result = song_;
-  const TagReaderResult tag_result = tagreader_client->ReadFileBlocking(result.url().toLocalFile(), &result);
-  if (!tag_result.success()) {
-    qLog(Error) << "Could not reload file" << result.url() << tag_result.error_string();
-    return Song();
-  }
-
-  return result;
 
 }
 

--- a/src/collection/collectionplaylistitem.h
+++ b/src/collection/collectionplaylistitem.h
@@ -43,7 +43,6 @@ class CollectionPlaylistItem : public PlaylistItem {
   bool IsLocalCollectionItem() const override { return song_.source() == Song::Source::Collection; }
 
   bool InitFromQuery(const SqlRow &query) override;
-  Song Reload(const SharedPtr<TagReaderClient> tagreader_client) override;
 
   void SetArtManual(const QUrl &cover_url) override;
 

--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -1562,7 +1562,7 @@ void MainWindow::MediaPlaying() {
   bool enable_play_pause(false);
   bool can_seek(false);
 
-  PlaylistItemPtr item(app_->player()->GetCurrentItem());
+  PlaylistItemPtr item = app_->player()->GetCurrentItem();
   if (item) {
     enable_play_pause = !(item->options() & PlaylistItem::Option::PauseDisabled);
     can_seek = !(item->options() & PlaylistItem::Option::SeekDisabled);
@@ -1863,7 +1863,7 @@ void MainWindow::Seeked(const qint64 microseconds) {
 
 void MainWindow::UpdateTrackPosition() {
 
-  PlaylistItemPtr item(app_->player()->GetCurrentItem());
+  PlaylistItemPtr item = app_->player()->GetCurrentItem();
   if (!item) return;
 
   const qint64 length = (item->EffectiveMetadata().length_nanosec() / kNsecPerSec);
@@ -2282,14 +2282,14 @@ void MainWindow::RescanSongs() {
   for (const QModelIndex &proxy_index : proxy_indexes) {
     const QModelIndex source_index = app_->playlist_manager()->current()->filter()->mapToSource(proxy_index);
     if (!source_index.isValid()) continue;
-    PlaylistItemPtr item(app_->playlist_manager()->current()->item_at(source_index.row()));
+    PlaylistItemPtr item = app_->playlist_manager()->current()->item_at(source_index.row());
     if (!item) continue;
     if (item->IsLocalCollectionItem()) {
       songs << item->EffectiveMetadata();
     }
     else if (item->EffectiveMetadata().source() == Song::Source::LocalFile) {
       QPersistentModelIndex persistent_index = QPersistentModelIndex(source_index);
-      app_->playlist_manager()->current()->ItemReload(persistent_index, false);
+      app_->playlist_manager()->current()->ReloadItem(persistent_index, item);
     }
   }
 
@@ -2308,7 +2308,7 @@ void MainWindow::EditTracks() {
   for (const QModelIndex &proxy_index : proxy_indexes) {
     const QModelIndex source_index = app_->playlist_manager()->current()->filter()->mapToSource(proxy_index);
     if (!source_index.isValid()) continue;
-    PlaylistItemPtr item(app_->playlist_manager()->current()->item_at(source_index.row()));
+    PlaylistItemPtr item = app_->playlist_manager()->current()->item_at(source_index.row());
     if (!item) continue;
     Song song = item->OriginalMetadata();
     if (song.IsEditable()) {
@@ -2795,7 +2795,7 @@ void MainWindow::AddFilesToTranscoder() {
   for (const QModelIndex &proxy_index : proxy_indexes) {
     const QModelIndex source_index = app_->playlist_manager()->current()->filter()->mapToSource(proxy_index);
     if (!source_index.isValid()) continue;
-    PlaylistItemPtr item(app_->playlist_manager()->current()->item_at(source_index.row()));
+    PlaylistItemPtr item = app_->playlist_manager()->current()->item_at(source_index.row());
     if (!item) continue;
     Song song = item->OriginalMetadata();
     if (!song.is_valid() || !song.url().isLocalFile()) continue;
@@ -3537,7 +3537,7 @@ void MainWindow::FetchStreamingMetadata() {
   for (const QModelIndex &proxy_index : proxy_indexes) {
     const QModelIndex source_index = app_->playlist_manager()->current()->filter()->mapToSource(proxy_index);
     if (!source_index.isValid()) continue;
-    PlaylistItemPtr item(app_->playlist_manager()->current()->item_at(source_index.row()));
+    PlaylistItemPtr item = app_->playlist_manager()->current()->item_at(source_index.row());
     if (!item) continue;
 
     const Song &song = item->EffectiveMetadata();
@@ -3618,8 +3618,7 @@ void MainWindow::ProcessMetadataQueue() {
             if (fetched_song.year() > 0) updated_song.set_year(fetched_song.year());
             if (fetched_song.length_nanosec() > 0) updated_song.set_length_nanosec(fetched_song.length_nanosec());
             if (fetched_song.art_automatic().isValid()) updated_song.set_art_automatic(fetched_song.art_automatic());
-            playlist_item->SetOriginalMetadata(updated_song);
-            app_->playlist_manager()->current()->ItemReload(metadata_queue_entry.persistent_index, false);
+            app_->playlist_manager()->current()->UpdateItemMetadata(metadata_queue_entry.persistent_index.row(), playlist_item, updated_song, false);
           }
         }
         request->deleteLater();
@@ -3668,8 +3667,7 @@ void MainWindow::ProcessMetadataQueue() {
             if (fetched_song.year() > 0) updated_song.set_year(fetched_song.year());
             if (fetched_song.length_nanosec() > 0) updated_song.set_length_nanosec(fetched_song.length_nanosec());
             if (fetched_song.art_automatic().isValid()) updated_song.set_art_automatic(fetched_song.art_automatic());
-            playlist_item->SetOriginalMetadata(updated_song);
-            app_->playlist_manager()->current()->ItemReload(metadata_queue_entry.persistent_index, false);
+            app_->playlist_manager()->current()->UpdateItemMetadata(metadata_queue_entry.persistent_index.row(), playlist_item, updated_song, false);
           }
         }
         request->deleteLater();

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -467,20 +467,7 @@ bool Playlist::setData(const QModelIndex &idx, const QVariant &value, const int 
   if (!set_column_value(song, static_cast<Column>(idx.column()), value)) return false;
 
   if (song.url().isLocalFile()) {
-    // Show the edit immediately: otherwise the cell keeps displaying the pre-edit value (the view re-reads it right after the editor closes) until the write-then-reread round trip below completes asynchronously, which can take a perceptible moment and looks like the edit was reverted.
-    UpdateItemMetadata(row, item, song, false);
-    Q_EMIT EditingFinished(id_, idx);
-
-    // Bump the item's save generation so a still-in-flight completion from an earlier edit to this same item can recognize (once it eventually completes) that it has been superseded, and avoid clobbering this newer edit with its own stale result.
-    const quint64 save_generation = item->BumpSaveGeneration();
-
-    TagReaderReplyPtr reply = tagreader_client_->WriteFileAsync(song.url().toLocalFile(), song);
-    QPersistentModelIndex persistent_index = QPersistentModelIndex(idx);
-    SharedPtr<QMetaObject::Connection> connection = make_shared<QMetaObject::Connection>();
-    *connection = QObject::connect(&*reply, &TagReaderReply::Finished, this, [this, reply, persistent_index, item, save_generation, pre_edit_metadata, connection]() {
-      SongSaveComplete(reply, persistent_index, item, save_generation, pre_edit_metadata);
-      QObject::disconnect(*connection);
-    }, Qt::QueuedConnection);
+    SaveItem(idx, item, song, pre_edit_metadata);
   }
   else if (song.is_stream()) {
     item->SetOriginalMetadata(song);
@@ -493,7 +480,28 @@ bool Playlist::setData(const QModelIndex &idx, const QVariant &value, const int 
 
 }
 
-void Playlist::SongSaveComplete(TagReaderReplyPtr reply, const QPersistentModelIndex &idx, const PlaylistItemPtr &item, const quint64 save_generation, const Song &pre_edit_metadata) {
+void Playlist::SaveItem(const QModelIndex &idx, PlaylistItemPtr item, const Song &song, const Song &pre_edit_metadata) {
+
+  const int row = idx.row();
+
+  // Show the edit immediately: otherwise the cell keeps displaying the pre-edit value (the view re-reads it right after the editor closes) until the write-then-reread round trip below completes asynchronously, which can take a perceptible moment and looks like the edit was reverted.
+  UpdateItemMetadata(row, item, song, false);
+  Q_EMIT EditingFinished(id_, idx);
+
+  // Bump the item's save generation so a still-in-flight completion from an earlier edit to this same item can recognize (once it eventually completes) that it has been superseded, and avoid clobbering this newer edit with its own stale result.
+  const quint64 save_generation = item->BumpSaveGeneration();
+
+  TagReaderReplyPtr reply = tagreader_client_->WriteFileAsync(song.url().toLocalFile(), song);
+  QPersistentModelIndex persistent_index = QPersistentModelIndex(idx);
+  SharedPtr<QMetaObject::Connection> connection = make_shared<QMetaObject::Connection>();
+  *connection = QObject::connect(&*reply, &TagReaderReply::Finished, this, [this, reply, persistent_index, item, save_generation, pre_edit_metadata, connection]() {
+    SaveItemComplete(reply, persistent_index, item, save_generation, pre_edit_metadata);
+    QObject::disconnect(*connection);
+  }, Qt::QueuedConnection);
+
+}
+
+void Playlist::SaveItemComplete(TagReaderReplyPtr reply, const QPersistentModelIndex &idx, PlaylistItemPtr item, const quint64 save_generation, const Song &pre_edit_metadata) {
 
   if (!idx.isValid()) return;
 
@@ -508,55 +516,66 @@ void Playlist::SongSaveComplete(TagReaderReplyPtr reply, const QPersistentModelI
       Q_EMIT Error(tr("Could not write metadata to %1: %2").arg(reply->filename(), reply->error()));
     }
     // Resync with the actual file contents rather than assuming pre_edit_metadata still matches what's on disk: with consecutive edits to the same item, pre_edit_metadata is whatever the previous (optimistic) edit left in place, which can itself be a value that was never successfully written (e.g. its own write is still in flight, or already failed but was ignored here due to the generation guard above). Reading the file collapses any such chain of unconfirmed edits to the genuine on-disk state. Only if that reload itself fails to read the file do we fall back to pre_edit_metadata as a last resort.
-    ItemReload(idx, true, item, save_generation, pre_edit_metadata);
+    ReloadItem(idx, item, true, save_generation, pre_edit_metadata);
     return;
   }
 
   // Resync with the actual file contents: this confirms the value already shown optimistically by setData(), picking up any normalization the tag writer applied.
-  ItemReload(idx, true, item, save_generation, Song());
+  ReloadItem(idx, item, true, save_generation, Song());
 
 }
 
-void Playlist::ItemReload(const QPersistentModelIndex &idx, const bool metadata_edit) {
+void Playlist::ReloadItem(const QPersistentModelIndex &idx, PlaylistItemPtr item, const bool saved, const quint64 save_generation, const Song &fallback_metadata) {
 
-  if (idx.isValid()) {
-    const PlaylistItemPtr item = item_at(idx.row());
-    if (item) {
-      ItemReload(idx, metadata_edit, item, item->save_generation(), Song());
-    }
+  // For a plain (non-save-triggered) reload the caller has no meaningful generation to hand in, so snapshot the item's current one here at kick-off time: if some other edit bumps it before this reload completes, ReloadItemComplete's staleness check below will then correctly detect that and discard this now-stale result instead of clobbering the newer edit.
+  const quint64 current_save_generation = saved ? save_generation : item->save_generation();
+
+  const Song original_song = item->OriginalMetadata();
+  if (!original_song.url().isLocalFile()) {
+    ReloadItemComplete(idx, item, Song(), saved, current_save_generation, fallback_metadata);
+    return;
   }
 
+  TagReaderReadFileReplyPtr reply = tagreader_client_->ReadFileAsync(original_song.url().toLocalFile(), original_song);
+  SharedPtr<QMetaObject::Connection> connection = make_shared<QMetaObject::Connection>();
+  *connection = QObject::connect(&*reply, &TagReaderReadFileReply::Finished, this, [this, reply, idx, item, saved, current_save_generation, fallback_metadata, connection](const QString &filename, const Song &song, const TagReaderResult &result) {
+    Song new_metadata;
+    if (result.success()) {
+      new_metadata = song;
+    }
+    else {
+      qLog(Error) << "Could not reload file" << filename << result.error_string();
+    }
+    ReloadItemComplete(idx, item, new_metadata, saved, current_save_generation, fallback_metadata);
+    QObject::disconnect(*connection);
+  }, Qt::QueuedConnection);
+
 }
 
-void Playlist::ItemReload(const QPersistentModelIndex &idx, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation, const Song &fallback_metadata) {
+void Playlist::ReloadItemComplete(const QPersistentModelIndex &idx, PlaylistItemPtr item, const Song &new_metadata, const bool saved, const quint64 save_generation, const Song &fallback_metadata) {
 
-  QFuture<Song> future = item->BackgroundReload(tagreader_client_);
-  QFutureWatcher<Song> *watcher = new QFutureWatcher<Song>(this);
-  QObject::connect(watcher, &QFutureWatcher<Song>::finished, this, [this, watcher, idx, metadata_edit, item, save_generation, fallback_metadata]() {
-    ItemReloadComplete(idx, watcher->result(), metadata_edit, item, save_generation, fallback_metadata);
-    watcher->deleteLater();
-  });
-  watcher->setFuture(future);
-
-}
-
-void Playlist::ItemReloadComplete(const QPersistentModelIndex &idx, const Song &new_metadata, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation, const Song &fallback_metadata) {
-
-  if (idx.isValid()) {
-    // Another edit superseded this one while the reload was in flight: skip applying this now-stale result so it doesn't clobber the newer edit.
-    if (item->save_generation() != save_generation) return;
-    if (new_metadata.is_valid()) {
-      UpdateItemMetadata(idx.row(), item, new_metadata, false);
-    }
-    else if (fallback_metadata.is_valid()) {
-      // The reload itself failed to read the file (e.g. a transient I/O error): fall back to the best metadata we still have rather than leaving whatever optimistic value was showing beforehand, which in the write-failure path this fallback comes from is known to have never been written to disk.
-      UpdateItemMetadata(idx.row(), item, fallback_metadata, false);
-    }
-    if (metadata_edit) {
-      Q_EMIT EditingFinished(id_, idx);
-    }
-    ScheduleSaveAsync();
+  if (!idx.isValid()) {
+    return;
   }
+
+  // Another edit superseded this one while the reload was in flight: skip applying this now-stale result so it doesn't clobber the newer edit.
+  if (item->save_generation() != save_generation) {
+    return;
+  }
+
+  if (new_metadata.is_valid()) {
+    UpdateItemMetadata(idx.row(), item, new_metadata, false);
+  }
+  else if (fallback_metadata.is_valid()) {
+    // The reload itself failed to read the file (e.g. a transient I/O error): fall back to the best metadata we still have rather than leaving whatever optimistic value was showing beforehand, which in the write-failure path this fallback comes from is known to have never been written to disk.
+    UpdateItemMetadata(idx.row(), item, fallback_metadata, false);
+  }
+
+  if (saved) {
+    Q_EMIT EditingFinished(id_, idx);
+  }
+
+  ScheduleSaveAsync();
 
 }
 
@@ -2095,10 +2114,10 @@ void Playlist::RemoveItemsNotInQueue() {
 void Playlist::ReloadItems(const QList<int> &rows) {
 
   for (const int row : rows) {
-    const PlaylistItemPtr item = item_at(row);
+    PlaylistItemPtr item = item_at(row);
     const QPersistentModelIndex idx = index(row, 0);
     if (idx.isValid()) {
-      ItemReload(idx, false);
+      ReloadItem(idx, item);
     }
   }
 
@@ -2481,21 +2500,27 @@ bool Playlist::MinorMetadataChange(const Song &old_metadata, const Song &new_met
 
 }
 
-void Playlist::UpdateItemMetadata(PlaylistItemPtr item, const Song &new_metadata, const bool stream_metadata_update) {
+bool Playlist::UpdateItemMetadata(PlaylistItemPtr item, const Song &new_metadata, const bool stream_metadata_update) {
 
   if (!items_.contains(item)) {
-    return;
+    return false;
   }
 
+  bool any_changed = false;
   for (int row = static_cast<int>(items_.indexOf(item, 0)); row != -1; row = static_cast<int>(items_.indexOf(item, row + 1))) {
-    UpdateItemMetadata(row, item, new_metadata, stream_metadata_update);
+    const bool changed = UpdateItemMetadata(row, item, new_metadata, stream_metadata_update);
+    if (changed) {
+      any_changed = true;
+    }
   }
+
+  return any_changed;
 
 }
 
-void Playlist::UpdateItemMetadata(const int row, PlaylistItemPtr item, const Song &new_metadata, const bool stream_metadata_update) {
+bool Playlist::UpdateItemMetadata(const int row, PlaylistItemPtr item, const Song &new_metadata, const bool stream_metadata_update) {
 
-  if (new_metadata.IsEqual(stream_metadata_update ? item->EffectiveMetadata() : item->OriginalMetadata())) return;
+  if (new_metadata.IsEqual(stream_metadata_update ? item->EffectiveMetadata() : item->OriginalMetadata())) return false;
 
   const Song old_metadata = item->EffectiveMetadata();
   const Columns changed_columns = ChangedColumns(old_metadata, new_metadata);
@@ -2522,6 +2547,8 @@ void Playlist::UpdateItemMetadata(const int row, PlaylistItemPtr item, const Son
   }
 
   Q_EMIT PlaylistItemMetadataChanged(id_, item->uuid());
+
+  return true;
 
 }
 

--- a/src/playlist/playlist.h
+++ b/src/playlist/playlist.h
@@ -287,8 +287,8 @@ class Playlist : public QAbstractListModel {
 
   static Columns ChangedColumns(const Song &metadata1, const Song &metadata2);
   static bool MinorMetadataChange(const Song &old_metadata, const Song &new_metadata);
-  void UpdateItemMetadata(PlaylistItemPtr item, const Song &new_metadata, const bool stream_metadata_update);
-  void UpdateItemMetadata(const int row, PlaylistItemPtr item, const Song &new_metadata, const bool stream_metadata_update);
+  bool UpdateItemMetadata(PlaylistItemPtr item, const Song &new_metadata, const bool stream_metadata_update);
+  bool UpdateItemMetadata(const int row, PlaylistItemPtr item, const Song &new_metadata, const bool stream_metadata_update);
   void RowDataChanged(const int row, const Columns &columns);
 
   // Changes rating of a song to the given value asynchronously
@@ -297,7 +297,7 @@ class Playlist : public QAbstractListModel {
 
   void set_auto_sort(const bool auto_sort) { auto_sort_ = auto_sort; }
 
-  void ItemReload(const QPersistentModelIndex &idx, const bool metadata_edit);
+  void ReloadItem(const QPersistentModelIndex &idx, PlaylistItemPtr item, const bool saved = false, const quint64 save_generation = -1, const Song &fallback_metadata = Song());
 
  public Q_SLOTS:
   void set_current_row(const int i, const Playlist::AutoScroll autoscroll = Playlist::AutoScroll::Maybe, const bool is_stopping = false, const bool force_inform = false);
@@ -382,14 +382,15 @@ class Playlist : public QAbstractListModel {
 
   void ClearCollectionItems();
 
+  void SaveItem(const QModelIndex &idx, PlaylistItemPtr item, const Song &song, const Song &pre_edit_metadata);
+
  private Q_SLOTS:
   void TracksAboutToBeDequeued(const QModelIndex &idx, const int begin, const int end);
   void TracksDequeued();
   void TracksEnqueued(const QModelIndex &parent_idx, const int begin, const int end);
   void QueueLayoutChanged();
-  void SongSaveComplete(TagReaderReplyPtr reply, const QPersistentModelIndex &idx, const PlaylistItemPtr &item, const quint64 save_generation, const Song &pre_edit_metadata);
-  void ItemReload(const QPersistentModelIndex &idx, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation, const Song &fallback_metadata);
-  void ItemReloadComplete(const QPersistentModelIndex &idx, const Song &new_metadata, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation, const Song &fallback_metadata);
+  void SaveItemComplete(TagReaderReplyPtr reply, const QPersistentModelIndex &idx, PlaylistItemPtr item, const quint64 save_generation, const Song &pre_edit_metadata);
+  void ReloadItemComplete(const QPersistentModelIndex &idx, PlaylistItemPtr item, const Song &new_metadata, const bool saved, const quint64 save_generation, const Song &fallback_metadata);
   void ItemsLoaded();
   void ScheduleSave();
   void ForceScheduleSave();

--- a/src/playlist/playlistbackend.cpp
+++ b/src/playlist/playlistbackend.cpp
@@ -47,6 +47,7 @@
 #include "core/sqlquery.h"
 #include "core/sqlrow.h"
 #include "collection/collectionbackend.h"
+#include "tagreader/tagreaderclient.h"
 #include "playlistitem.h"
 #include "songplaylistitem.h"
 #include "playlistbackend.h"
@@ -281,6 +282,22 @@ Song PlaylistBackend::NewSongFromQuery(const SqlRow &row, SharedPtr<NewSongFromQ
 
 }
 
+Song PlaylistBackend::ReloadPlaylistItem(PlaylistItemPtr item) const {
+
+  const Song original_song = item->OriginalMetadata();
+  if (!original_song.url().isLocalFile()) return Song();
+
+  Song result = original_song;
+  const TagReaderResult tag_result = tagreader_client_->ReadFileBlocking(result.url().toLocalFile(), &result);
+  if (!tag_result.success()) {
+    qLog(Error) << "Could not reload file" << result.url() << tag_result.error_string();
+    return Song();
+  }
+
+  return result;
+
+}
+
 // If song had a CUE and the CUE still exists, the metadata from it will be applied here.
 
 PlaylistItemPtr PlaylistBackend::RestoreCueData(PlaylistItemPtr item, SharedPtr<NewSongFromQueryState> state) {
@@ -290,14 +307,14 @@ PlaylistItemPtr PlaylistBackend::RestoreCueData(PlaylistItemPtr item, SharedPtr<
 
   CueParser cue_parser(tagreader_client_, collection_backend_);
 
-  Song song = item->EffectiveMetadata();
+  const Song song = item->EffectiveMetadata();
   // We're only interested in .cue songs here
   if (!song.has_cue()) return item;
 
   QString cue_path = song.cue_path();
   // If .cue was deleted - reload the song
   if (!QFile::exists(cue_path)) {
-    const Song reloaded_song = item->Reload(tagreader_client_);
+    const Song reloaded_song = ReloadPlaylistItem(item);
     if (reloaded_song.is_valid()) {
       item->SetOriginalMetadata(reloaded_song);
     }
@@ -329,7 +346,7 @@ PlaylistItemPtr PlaylistBackend::RestoreCueData(PlaylistItemPtr item, SharedPtr<
   }
 
   // There's no such section in the related .cue -> reload the song
-  const Song reloaded_song = item->Reload(tagreader_client_);
+  const Song reloaded_song = ReloadPlaylistItem(item);
   if (reloaded_song.is_valid()) {
     item->SetOriginalMetadata(reloaded_song);
   }

--- a/src/playlist/playlistbackend.h
+++ b/src/playlist/playlistbackend.h
@@ -99,8 +99,9 @@ class PlaylistBackend : public QObject {
   };
 
   static QString PlaylistItemsQuery();
-  Song NewSongFromQuery(const SqlRow &row, SharedPtr<NewSongFromQueryState> state);
   PlaylistItemPtr NewPlaylistItemFromQuery(const SqlRow &row, SharedPtr<NewSongFromQueryState> state);
+  Song NewSongFromQuery(const SqlRow &row, SharedPtr<NewSongFromQueryState> state);
+  Song ReloadPlaylistItem(PlaylistItemPtr item) const;
   PlaylistItemPtr RestoreCueData(PlaylistItemPtr item, SharedPtr<NewSongFromQueryState> state);
 
   enum GetPlaylistsFlags {

--- a/src/playlist/playlistitem.cpp
+++ b/src/playlist/playlistitem.cpp
@@ -23,8 +23,6 @@
 
 #include <memory>
 
-#include <QtConcurrentRun>
-#include <QFuture>
 #include <QUuid>
 #include <QColor>
 
@@ -126,14 +124,6 @@ void PlaylistItem::BindToQuery(SqlQuery *query) const {
 
   DatabaseSongMetadata().BindToQuery(query);
 
-}
-
-static Song ReloadPlaylistItem(PlaylistItemPtr item, SharedPtr<TagReaderClient> tagreader_client) {
-  return item->Reload(tagreader_client);
-}
-
-QFuture<Song> PlaylistItem::BackgroundReload(const SharedPtr<TagReaderClient> tagreader_client) {
-  return QtConcurrent::run(ReloadPlaylistItem, shared_from_this(), tagreader_client);
 }
 
 void PlaylistItem::SetBackgroundColor(short priority, const QColor &color) {

--- a/src/playlist/playlistitem.h
+++ b/src/playlist/playlistitem.h
@@ -24,9 +24,6 @@
 
 #include "config.h"
 
-#include <memory>
-
-#include <QFuture>
 #include <QMetaType>
 #include <QList>
 #include <QMap>
@@ -45,11 +42,8 @@ class QAction;
 
 class SqlQuery;
 class SqlRow;
-class TagReaderClient;
 
-using std::enable_shared_from_this;
-
-class PlaylistItem : public enable_shared_from_this<PlaylistItem> {
+class PlaylistItem {
  public:
   explicit PlaylistItem(const Song::Source source, const QUuid &uuid = QUuid(), const bool signal = false);
   virtual ~PlaylistItem();
@@ -97,8 +91,6 @@ class PlaylistItem : public enable_shared_from_this<PlaylistItem> {
 
   virtual bool InitFromQuery(const SqlRow &query) = 0;
   void BindToQuery(SqlQuery *query) const;
-  virtual Song Reload(const SharedPtr<TagReaderClient> tagreader_client) { Q_UNUSED(tagreader_client); return Song(); }
-  QFuture<Song> BackgroundReload(const SharedPtr<TagReaderClient> tagreader_client);
 
   // Identifies the most recent edit made to this item through the playlist (e.g. inline tag editing).
   // A caller starting an asynchronous write/reload round trip should capture the value returned by BumpSaveGeneration() and compare it against save_generation() once the round trip completes: a mismatch means a newer edit has since superseded it, so the (now stale) result must not be applied.

--- a/src/playlist/songplaylistitem.cpp
+++ b/src/playlist/songplaylistitem.cpp
@@ -24,10 +24,8 @@
 #include <QUuid>
 #include <QUrl>
 
-#include "core/logging.h"
 #include "core/song.h"
 #include "core/sqlrow.h"
-#include "tagreader/tagreaderclient.h"
 #include "playlistitem.h"
 #include "songplaylistitem.h"
 
@@ -37,22 +35,6 @@ SongPlaylistItem::SongPlaylistItem(const Song &song, const bool signal) : Playli
 bool SongPlaylistItem::InitFromQuery(const SqlRow &query) {
   song_.InitFromQuery(query, false, static_cast<int>(Song::kRowIdColumns.count()));
   return true;
-}
-
-Song SongPlaylistItem::Reload(const SharedPtr<TagReaderClient> tagreader_client) {
-
-  if (!song_.url().isLocalFile()) return Song();
-  if (!tagreader_client) return Song();
-
-  Song result = song_;
-  const TagReaderResult tag_result = tagreader_client->ReadFileBlocking(result.url().toLocalFile(), &result);
-  if (!tag_result.success()) {
-    qLog(Error) << "Could not reload file" << result.url() << tag_result.error_string();
-    return Song();
-  }
-
-  return result;
-
 }
 
 void SongPlaylistItem::SetArtManual(const QUrl &cover_url) {

--- a/src/playlist/songplaylistitem.h
+++ b/src/playlist/songplaylistitem.h
@@ -39,7 +39,6 @@ class SongPlaylistItem : public PlaylistItem {
   // Restores a stream- or file-related playlist item using query row.
   // If it's a file related playlist item, this will restore its CUE attributes (if any) but won't parse the CUE!
   bool InitFromQuery(const SqlRow &query) override;
-  Song Reload(const SharedPtr<TagReaderClient> tagreader_client) override;
 
   Song OriginalMetadata() const override { return song_; }
   QUrl OriginalUrl() const override { return song_.url(); }

--- a/src/tagreader/tagreaderclient.cpp
+++ b/src/tagreader/tagreaderclient.cpp
@@ -174,7 +174,7 @@ void TagReaderClient::ProcessRequest(TagReaderRequestPtr request) {
     }
   }
   else if (TagReaderReadFileRequestPtr read_file_request = dynamic_pointer_cast<TagReaderReadFileRequest>(request)) {
-    Song song;
+    Song song = read_file_request->song;
     result = ReadFileBlocking(read_file_request->filename, &song);
     if (result.error_code == TagReaderResult::ErrorCode::FileOpenError || result.error_code == TagReaderResult::ErrorCode::Unsupported) {
       result = gmereader_.ReadFile(read_file_request->filename, &song);
@@ -272,7 +272,7 @@ TagReaderResult TagReaderClient::ReadFileBlocking(const QString &filename, Song 
 
 }
 
-TagReaderReadFileReplyPtr TagReaderClient::ReadFileAsync(const QString &filename) {
+TagReaderReadFileReplyPtr TagReaderClient::ReadFileAsync(const QString &filename, const Song &song) {
 
   Q_ASSERT(QThread::currentThread() != thread());
 
@@ -281,6 +281,7 @@ TagReaderReadFileReplyPtr TagReaderClient::ReadFileAsync(const QString &filename
   TagReaderReadFileRequestPtr request = TagReaderReadFileRequest::Create(filename);
   request->reply = reply;
   request->filename = filename;
+  request->song = song;
 
   EnqueueRequest(request);
 

--- a/src/tagreader/tagreaderclient.h
+++ b/src/tagreader/tagreaderclient.h
@@ -65,7 +65,7 @@ class TagReaderClient : public QObject {
   [[nodiscard]] TagReaderReplyPtr IsMediaFileAsync(const QString &filename);
 
   TagReaderResult ReadFileBlocking(const QString &filename, Song *song);
-  [[nodiscard]] TagReaderReadFileReplyPtr ReadFileAsync(const QString &filename);
+  [[nodiscard]] TagReaderReadFileReplyPtr ReadFileAsync(const QString &filename, const Song &song = Song());
 
 #ifdef HAVE_STREAMTAGREADER
   TagReaderResult ReadStreamBlocking(const QUrl &url, const QString &filename, const quint64 size, const quint64 mtime, const QString &token_type, const QString &access_token, Song *song);

--- a/src/tagreader/tagreaderreadfilerequest.h
+++ b/src/tagreader/tagreaderreadfilerequest.h
@@ -23,6 +23,7 @@
 #include <QString>
 
 #include "includes/shared_ptr.h"
+#include "core/song.h"
 #include "tagreaderrequest.h"
 
 using std::make_shared;
@@ -31,6 +32,8 @@ class TagReaderReadFileRequest : public TagReaderRequest {
  public:
   explicit TagReaderReadFileRequest(const QString &_filename);
   static SharedPtr<TagReaderReadFileRequest> Create(const QString &filename) { return make_shared<TagReaderReadFileRequest>(filename); }
+
+  Song song;
 };
 
 using TagReaderReadFileRequestPtr = SharedPtr<TagReaderReadFileRequest>;

--- a/tests/src/mock_playlistitem.h
+++ b/tests/src/mock_playlistitem.h
@@ -42,7 +42,6 @@ class MockPlaylistItem : public PlaylistItem {
   MOCK_METHOD0(ClearStreamMetadata, void());
   MOCK_METHOD1(SetArtManual, void(const QUrl &cover_url));
   MOCK_METHOD1(InitFromQuery, bool(const SqlRow &settings));
-  MOCK_METHOD1(Reload, Song(const SharedPtr<TagReaderClient> tagreader_client));
   MOCK_CONST_METHOD1(DatabaseValue, QVariant(DatabaseColumn));
 };
 

--- a/tests/src/playlist_test.cpp
+++ b/tests/src/playlist_test.cpp
@@ -51,7 +51,7 @@ using namespace Qt::Literals::StringLiterals;
 class PlaylistTest : public ::testing::Test {
  protected:
   // tagreader_client_/tagreader_client_thread_ are declared (and so, per C++ member initialization order, constructed) before playlist_ below: Playlist::tagreader_client_ is a const member set once at construction time, from the SharedPtr this fixture passes in here - so the real TagReaderClient must already exist by then.
-  // PlaylistItem::Reload() (invoked by ItemReload()'s background task, via SongPlaylistItem/CollectionPlaylistItem) takes that same SharedPtr through Playlist rather than reaching for a process-wide singleton, so constructing and tearing this down per test (like tagreader_test.cpp does) is safe - there is no shared global state left for one test's teardown to leave dangling for another.
+  // ReloadItem()'s background task takes that same SharedPtr through Playlist rather than reaching for a process-wide singleton, so constructing and tearing this down per test (like tagreader_test.cpp does) is safe - there is no shared global state left for one test's teardown to leave dangling for another.
   PlaylistTest()
       : tagreader_client_(new TagReaderClient()),
         tagreader_client_thread_(new QThread()),
@@ -85,17 +85,17 @@ class PlaylistTest : public ::testing::Test {
     return PlaylistItemPtr(MakeMockItem(title, artist, album, length));
   }
 
-  // Forwards to the private Playlist::ItemReloadComplete(), to let tests exercise the save-generation staleness check directly instead of via a real asynchronous write-then-reread round trip.
-  void CallItemReloadComplete(const QPersistentModelIndex &idx, const Song &new_metadata, const bool metadata_edit, const PlaylistItemPtr &item, const quint64 save_generation, const Song &fallback_metadata = Song()) {
-    playlist_.ItemReloadComplete(idx, new_metadata, metadata_edit, item, save_generation, fallback_metadata);
+  // Forwards to the private Playlist::ReloadItemComplete(), to let tests exercise the save-generation staleness check directly instead of via a real asynchronous write-then-reread round trip.
+  void CallReloadItemComplete(const QPersistentModelIndex &idx, const PlaylistItemPtr &item, const Song &new_metadata, const bool saved, const quint64 save_generation, const Song &fallback_metadata = Song()) {
+    playlist_.ReloadItemComplete(idx, item, new_metadata, saved, save_generation, fallback_metadata);
   }
 
-  // Forwards to the private Playlist::SongSaveComplete(), to let tests exercise the write-failure path directly instead of via a real asynchronous tag write. On failure this now triggers a real (asynchronous) ItemReload(), so callers must pump the event loop (see WaitForEditingFinished()) for the result to apply.
-  void CallSongSaveComplete(TagReaderReplyPtr reply, const QPersistentModelIndex &idx, const PlaylistItemPtr &item, const quint64 save_generation, const Song &pre_edit_metadata) {
-    playlist_.SongSaveComplete(reply, idx, item, save_generation, pre_edit_metadata);
+  // Forwards to the private Playlist::SaveItemComplete(), to let tests exercise the write-failure path directly instead of via a real asynchronous tag write. On failure this now triggers a real (asynchronous) ReloadItem(), so callers must pump the event loop (see WaitForEditingFinished()) for the result to apply.
+  void CallSaveItemComplete(TagReaderReplyPtr reply, const QPersistentModelIndex &idx, const PlaylistItemPtr &item, const quint64 save_generation, const Song &pre_edit_metadata) {
+    playlist_.SaveItemComplete(reply, idx, item, save_generation, pre_edit_metadata);
   }
 
-  // Blocks until Playlist::EditingFinished fires, i.e. until an in-flight ItemReload()'s background reload has completed and ItemReloadComplete() has run.
+  // Blocks until Playlist::EditingFinished fires, i.e. until an in-flight ReloadItem()'s background reload has completed and ReloadItemComplete() has run.
   // Bounded by timeout_ms so a regression that stops EditingFinished from firing (or a reload that never completes) fails the test instead of hanging the whole run indefinitely, which would otherwise take down CI.
   void WaitForEditingFinished(const int timeout_ms = 5000) {
     QEventLoop loop;
@@ -663,12 +663,42 @@ TEST_F(PlaylistTest, StaleReloadCompletionDoesNotClobberNewerEdit) {
   metadata_edit_two.set_artist(u"EditTwoArtist"_s);
 
   // The second (newer) edit's reload completes first.
-  CallItemReloadComplete(idx, metadata_edit_two, true, item, generation_edit_two);
+  CallReloadItemComplete(idx, item, metadata_edit_two, true, generation_edit_two);
   EXPECT_EQ(u"EditTwoArtist"_s, item->OriginalMetadata().artist());
 
   // The first edit's reload, started earlier but slower, completes afterwards. Its captured generation no longer matches the item's current generation, so this stale completion must be discarded rather than clobbering the newer edit.
-  CallItemReloadComplete(idx, metadata_edit_one, true, item, generation_edit_one);
+  CallReloadItemComplete(idx, item, metadata_edit_one, true, generation_edit_one);
   EXPECT_EQ(u"EditTwoArtist"_s, item->OriginalMetadata().artist());
+
+}
+
+TEST_F(PlaylistTest, StalePlainReloadCompletionDoesNotClobberInFlightEdit) {
+
+  Song song;
+  song.Init(u"Title"_s, u"OriginalArtist"_s, u"Album"_s, 123);
+  song.set_url(QUrl::fromLocalFile(u"/tmp/does-not-need-to-exist.mp3"_s));
+
+  PlaylistItemPtr item = std::make_shared<SongPlaylistItem>(song, false);
+  playlist_.InsertItems(PlaylistItemPtrList() << item, -1);
+  const QPersistentModelIndex idx(playlist_.index(0, static_cast<int>(Playlist::Column::Artist)));
+
+  ASSERT_EQ(u"OriginalArtist"_s, item->OriginalMetadata().artist());
+
+  // Simulate a plain reload (e.g. ReloadItems()/RescanSongs()) starting - it snapshots the item's generation at kick-off, exactly as Playlist::ReloadItem() does for a non-save-triggered reload.
+  const quint64 generation_at_reload_start = item->save_generation();
+
+  // Before that reload completes, the user edits the same cell, which bumps the item's save generation, exactly as setData() does.
+  item->BumpSaveGeneration();
+  Song edited_metadata = item->OriginalMetadata();
+  edited_metadata.set_artist(u"EditedArtist"_s);
+  playlist_.UpdateItemMetadata(0, item, edited_metadata, false);
+  ASSERT_EQ(u"EditedArtist"_s, item->OriginalMetadata().artist());
+
+  // The plain reload, started before the edit, now completes with saved=false and its stale, pre-edit generation. It must not clobber the newer edit just because it wasn't itself a save-triggered reload.
+  Song stale_reloaded_metadata = song;
+  stale_reloaded_metadata.set_artist(u"ReloadedOriginalArtist"_s);
+  CallReloadItemComplete(idx, item, stale_reloaded_metadata, false, generation_at_reload_start);
+  EXPECT_EQ(u"EditedArtist"_s, item->OriginalMetadata().artist());
 
 }
 
@@ -696,11 +726,11 @@ TEST_F(PlaylistTest, FailedSaveAndFailedReloadFallsBackToPreEditMetadata) {
   playlist_.UpdateItemMetadata(0, item, edited_metadata, false);
   ASSERT_EQ(u"EditedArtist"_s, item->OriginalMetadata().artist());
 
-  // The write fails, and since the file doesn't exist, the reload SongSaveComplete() triggers to resync with disk will fail too.
+  // The write fails, and since the file doesn't exist, the reload SaveItemComplete() triggers to resync with disk will fail too.
   TagReaderReplyPtr reply(new TagReaderReply(song.url().toLocalFile()));
   reply->set_result(TagReaderResult(TagReaderResult::ErrorCode::FileSaveError));
 
-  CallSongSaveComplete(reply, idx, item, save_generation, pre_edit_metadata);
+  CallSaveItemComplete(reply, idx, item, save_generation, pre_edit_metadata);
   WaitForEditingFinished();
 
   // With no genuine disk state to fall back on, the pre-edit value is the best available: the optimistic edit must not be left displayed (and persisted) despite never having been written to disk.
@@ -747,7 +777,7 @@ TEST_F(PlaylistTest, FailedSaveReloadsActualDiskStateRatherThanStalePreEditChain
   TagReaderReplyPtr reply(new TagReaderReply(resource.fileName()));
   reply->set_result(TagReaderResult(TagReaderResult::ErrorCode::FileSaveError));
 
-  CallSongSaveComplete(reply, idx, item, generation_edit_two, pre_edit_metadata_two);
+  CallSaveItemComplete(reply, idx, item, generation_edit_two, pre_edit_metadata_two);
   WaitForEditingFinished();
 
   // The item must reflect what is genuinely on disk ("RealDiskArtist"), not edit 1's stale, never-confirmed optimistic value ("EditOneArtist") that pre_edit_metadata_two happened to carry.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playlist metadata saving/reloading so stale async completions no longer overwrite newer edits.
  * Enhanced failed-save handling: optimistic changes are rolled back to the best available metadata (pre-edit or disk state).
  * Successful saves now confirm by reloading from disk to normalize stored tags.
  * Local-file rescans and cue-based restorations now refresh metadata more consistently.
* **Tests**
  * Expanded regression coverage for stale reload completions (save-triggered and non-save reload) and improved assertions for failed-write rollback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->