### PR TITLE
Strip stale build-machine rpaths

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1034,16 +1034,6 @@ jobs:
         working-directory: build
         run: make deploy
 
-      - name: Manually Codesign
-        if: github.repository == 'strawberrymusicplayer/strawberry' && github.event.pull_request.head.repo.fork == false && matrix.runner == 'macos-15-intel'
-        working-directory: build
-        run: codesign -s 383J84DVB6 -f strawberry.app/Contents/Frameworks/{libpcre2-8.0.dylib,libpcre2-16.0.dylib,libpng16.16.dylib,libfreetype.6.dylib,libzstd.1.dylib,libbrotlicommon.1.dylib,libbrotlienc.1.dylib,libbrotlidec.1.dylib,libsoup-3.0.0.dylib,libnghttp2.14.dylib,libpsl.5.dylib} strawberry.app/Contents/Frameworks/png.framework/png strawberry.app
-
-      - name: Manually Codesign
-        if: github.repository == 'strawberrymusicplayer/strawberry' && github.event.pull_request.head.repo.fork == false && matrix.runner == 'macos-15'
-        working-directory: build
-        run: codesign -s 383J84DVB6 -f strawberry.app/Contents/Frameworks/png.framework/png strawberry.app
-
       - name: Deploy check
         working-directory: build
         run: make deploycheck

--- a/cmake/Dmg.cmake
+++ b/cmake/Dmg.cmake
@@ -29,12 +29,23 @@ if(MACDEPLOYQT_EXECUTABLE)
     set(CREATEDMG_SKIP_JENKINS_ARG "--skip-jenkins")
   endif()
 
-  add_custom_target(deploy
+  set(DEPLOY_COMMANDS
     COMMAND mkdir -p ${CMAKE_BINARY_DIR}/strawberry.app/Contents/{Frameworks,Resources}
     COMMAND cp -v ${CMAKE_BINARY_DIR}/dist/macos/Info.plist ${CMAKE_BINARY_DIR}/strawberry.app/Contents/
     COMMAND cp -v ${CMAKE_SOURCE_DIR}/dist/macos/strawberry.icns ${CMAKE_BINARY_DIR}/strawberry.app/Contents/Resources/
     COMMAND ${CMAKE_SOURCE_DIR}/dist/macos/macgstcopy.sh ${CMAKE_BINARY_DIR}/strawberry.app
-    COMMAND ${MACDEPLOYQT_EXECUTABLE} strawberry.app -verbose=3 -executable=${CMAKE_BINARY_DIR}/strawberry.app/Contents/PlugIns/gst-plugin-scanner ${MACDEPLOYQT_CODESIGN}
+    COMMAND ${MACDEPLOYQT_EXECUTABLE} strawberry.app -verbose=3 -executable=${CMAKE_BINARY_DIR}/strawberry.app/Contents/PlugIns/gst-plugin-scanner -no-codesign
+    COMMAND ${CMAKE_SOURCE_DIR}/dist/macos/macfixrpaths.sh ${CMAKE_BINARY_DIR}/strawberry.app
+  )
+  if(APPLE_DEVELOPER_ID)
+    # Sign anything macdeployqt's own dependency walk will never reach (e.g. dlopen'ed libsoup and its dependencies) before macdeployqt does its final pass and seals the outer app bundle's resources.
+    # Signing these after that seal is computed invalidates it ("nested code is modified or invalid"), so this must run before, not after, the real codesign.
+    list(APPEND DEPLOY_COMMANDS COMMAND ${CMAKE_SOURCE_DIR}/dist/macos/macfixadhocsign.sh ${CMAKE_BINARY_DIR}/strawberry.app ${APPLE_DEVELOPER_ID})
+  endif()
+  list(APPEND DEPLOY_COMMANDS COMMAND ${MACDEPLOYQT_EXECUTABLE} strawberry.app -verbose=3 -executable=${CMAKE_BINARY_DIR}/strawberry.app/Contents/PlugIns/gst-plugin-scanner ${MACDEPLOYQT_CODESIGN})
+
+  add_custom_target(deploy
+    ${DEPLOY_COMMANDS}
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     DEPENDS strawberry
   )

--- a/dist/macos/macfixadhocsign.sh
+++ b/dist/macos/macfixadhocsign.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# Sign any Mach-O binary left with only an ad-hoc/linker signature after macdeployqt has run.
+#
+# macdeployqt's codesign step only walks the Mach-O dependency graph starting from Contents/MacOS and Contents/PlugIns.
+# Libraries that are never declared as a linked dependency of anything on that walk - such as libsoup, which GStreamer dlopens by name rather than links against, and in turn its own dependencies libnghttp2/libpsl - are never queued for signing and are left with the ad-hoc signature applied at build time.
+# Apple notarization requires every executable in the bundle to carry the same Developer ID signature, so find and fix any stragglers here.
+
+if [ "$1" = "" ] || [ "$2" = "" ]; then
+  echo "Usage: $0 <bundledir> <identity>"
+  exit 1
+fi
+bundledir=$1
+identity=$2
+
+find "${bundledir}/Contents/Frameworks" "${bundledir}/Contents/PlugIns" -type f 2>/dev/null | while read -r f; do
+  file "$f" | grep -q "Mach-O" || continue
+  codesign -dvvv "$f" 2>&1 | grep -q "TeamIdentifier=${identity}" && continue
+  echo "Signing ${f} (was only ad-hoc signed)"
+  codesign --force --preserve-metadata=identifier,entitlements -s "${identity}" "$f" || exit 1
+done

--- a/dist/macos/macfixrpaths.sh
+++ b/dist/macos/macfixrpaths.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+# Strip stale build-machine rpaths (e.g. /opt/strawberry_macos_arm64_release/lib) from Mach-O binaries already deployed into the app bundle.
+#
+# Third-party libraries built against the strawberry_macos_* prefix keep that absolute path as one of their LC_RPATH entries, and it is never needed at runtime: the relative rpath macdeployqt adds to the main executable and Qt frameworks is enough,
+# since dyld searches the rpaths of every loaded image.
+# Left in place, this absolute path is still present on the machine doing the build, so macdeployqt's own @rpath dependency resolver can resolve a library back to that external copy instead of the one already inside the bundle,
+# and then skips signing it because it thinks it is an external system dependency.
+#
+# Run this after deploying with "macdeployqt ... -no-codesign" and before the final "macdeployqt ... -codesign=<identity>" pass.
+
+if [ "$1" = "" ]; then
+  echo "Usage: $0 <bundledir>"
+  exit 1
+fi
+bundledir=$1
+
+find "${bundledir}/Contents/Frameworks" "${bundledir}/Contents/PlugIns" -type f 2>/dev/null | while read -r f; do
+  file "$f" | grep -q "Mach-O" || continue
+  otool -l "$f" 2>/dev/null | grep -A2 "cmd LC_RPATH" | sed -n 's/^ *path \(.*\) (offset.*/\1/p' | while IFS= read -r rpath; do
+    case "$rpath" in
+      /opt/strawberry_macos_*)
+        echo "Deleting stale rpath ${rpath} from ${f}"
+        install_name_tool -delete_rpath "$rpath" "$f" || exit 1
+        ;;
+    esac
+  done
+done


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS application packaging and code-signing reliability.
  * Updated the deployment process to apply signing in the correct sequence, helping produce properly sealed app bundles.
  * Removed redundant manual signing steps from the macOS build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->