### PR TITLE
RadioBrowserService: Remove API servers that no longer exist

### DIFF
--- a/src/radios/radiobrowserservice.cpp
+++ b/src/radios/radiobrowserservice.cpp
@@ -42,9 +42,7 @@ using namespace Qt::Literals::StringLiterals;
 
 const QStringList RadioBrowserService::kServers = {
     u"de1.api.radio-browser.info"_s,
-    u"de2.api.radio-browser.info"_s,
-    u"nl1.api.radio-browser.info"_s,
-    u"at1.api.radio-browser.info"_s
+    u"de2.api.radio-browser.info"_s
 };
 
 RadioBrowserService::RadioBrowserService(const SharedPtr<TaskManager> task_manager, const SharedPtr<NetworkAccessManager> network, QObject *parent)


### PR DESCRIPTION
The radio-browser.info mirror network has shrunk: the `nl1` and `at1` mirrors have been shut down and their DNS records no longer exist (`NXDOMAIN`), only `de1` and `de2` remain (both currently resolving to the same host). Verified against the official server list — a mid-2025 snapshot of `/json/servers` still listed de1/nl1/at1 as separate hosts, the current one only lists de1.

Keeping the dead entries in `kServers` has no upside: when the service is unreachable, the round-robin has to fail through two extra DNS lookups before "No Radio Browser server available." is shown, and when it is reachable, a client that randomly starts at nl1/at1 always burns a failed attempt first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CM8kS4UmXUiG6nDaM8rTeA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the available Radio Browser server list to use the `de1` and `de2` API mirrors.
  * Removed the unavailable `nl1` and `at1` mirrors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->