### PR TITLE
StyleSheetLoader: Re-apply style unconditionally

### DIFF
--- a/src/core/stylesheetloader.cpp
+++ b/src/core/stylesheetloader.cpp
@@ -2,7 +2,7 @@
  * Strawberry Music Player
  * This file was part of Clementine.
  * Copyright 2010, David Sansome <me@davidsansome.com>
- * Copyright 2018-2021, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2018-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -65,7 +65,6 @@ void StyleSheetLoader::SetStyleSheet(QWidget *widget, const QString &filename) {
   SharedPtr<StyleSheetData> styledata = make_shared<StyleSheetData>();
   styledata->filename_ = filename;
   styledata->stylesheet_template_ = stylesheet;
-  styledata->stylesheet_current_ = widget->styleSheet();
   styledata_.insert(widget, styledata);
 
   widget->installEventFilter(this);
@@ -113,10 +112,7 @@ void StyleSheetLoader::UpdateStyleSheet(QWidget *widget, SharedPtr<StyleSheetDat
   stylesheet.replace(QLatin1String("macos"), QLatin1String("*"));
 #endif
 
-  if (stylesheet != styledata->stylesheet_current_) {
-    styledata->stylesheet_current_ = stylesheet;
-    widget->setStyleSheet(stylesheet);
-  }
+  widget->setStyleSheet(stylesheet);
 
 }
 

--- a/src/core/stylesheetloader.h
+++ b/src/core/stylesheetloader.h
@@ -2,7 +2,7 @@
  * Strawberry Music Player
  * This file was part of Clementine.
  * Copyright 2010, David Sansome <me@davidsansome.com>
- * Copyright 2018-2021, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2018-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,7 +25,6 @@
 #include "config.h"
 
 #include <QObject>
-#include <QPair>
 #include <QHash>
 #include <QPalette>
 #include <QString>
@@ -54,7 +53,6 @@ class StyleSheetLoader : public QObject {
     StyleSheetData() {}
     QString filename_;
     QString stylesheet_template_;
-    QString stylesheet_current_;
   };
 
  private:


### PR DESCRIPTION
Fixes custom palette colors sometimes not applying

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stylesheet refresh behavior so widget styles are consistently reapplied.
  * Prevented stale styling from remaining after stylesheet updates.
  * Improved visual consistency when refreshing or regenerating application styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->