### PR TITLE
CI: Notarize DMG

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1038,6 +1038,16 @@ jobs:
         working-directory: build
         run: make dmg
 
+      - name: Notarize DMG
+        if: github.repository == 'strawberrymusicplayer/strawberry' && (github.event_name == 'release' || (github.event_name == 'push' && github.event.pull_request.head.repo.fork == false && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/ci' || github.ref == 'refs/heads/macos')))
+        working-directory: build
+        run: xcrun notarytool submit *.dmg --apple-id "${{secrets.APPLE_NOTARIZATION_APPLE_ID}}" --team-id "383J84DVB6" --password "${{secrets.APPLE_NOTARIZATION_PASSWORD}}" --wait
+
+      - name: Staple notarization ticket
+        if: github.repository == 'strawberrymusicplayer/strawberry' && (github.event_name == 'release' || (github.event_name == 'push' && github.event.pull_request.head.repo.fork == false && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/ci' || github.ref == 'refs/heads/macos')))
+        working-directory: build
+        run: xcrun stapler staple *.dmg
+
       - name: SSH Setup
         if: github.repository == 'strawberrymusicplayer/strawberry' && (github.event_name == 'release' || (github.event_name == 'push' && github.event.pull_request.head.repo.fork == false && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/ci' || github.ref == 'refs/heads/macos')))
         uses: shimataro/ssh-key-action@v2
@@ -1157,6 +1167,14 @@ jobs:
       - name: Create DMG
         working-directory: build
         run: make dmg
+
+      - name: Notarize DMG
+        working-directory: build
+        run: xcrun notarytool submit *.dmg --apple-id "${{secrets.APPLE_NOTARIZATION_APPLE_ID}}" --team-id "383J84DVB6" --password "${{secrets.APPLE_NOTARIZATION_PASSWORD}}" --wait
+
+      - name: Staple notarization ticket
+        working-directory: build
+        run: xcrun stapler staple *.dmg
 
       - name: Set Upload path
         id: set-upload-path

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1038,10 +1038,14 @@ jobs:
         working-directory: build
         run: make dmg
 
+      - name: Store notarization credentials
+        if: github.repository == 'strawberrymusicplayer/strawberry' && (github.event_name == 'release' || (github.event_name == 'push' && github.event.pull_request.head.repo.fork == false && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/ci' || github.ref == 'refs/heads/macos')))
+        run: xcrun notarytool store-credentials "strawberry-notarization" --apple-id "${{secrets.APPLE_NOTARIZATION_APPLE_ID}}" --team-id "383J84DVB6" --password "${{secrets.APPLE_NOTARIZATION_PASSWORD}}"
+
       - name: Notarize DMG
         if: github.repository == 'strawberrymusicplayer/strawberry' && (github.event_name == 'release' || (github.event_name == 'push' && github.event.pull_request.head.repo.fork == false && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/ci' || github.ref == 'refs/heads/macos')))
         working-directory: build
-        run: xcrun notarytool submit *.dmg --apple-id "${{secrets.APPLE_NOTARIZATION_APPLE_ID}}" --team-id "383J84DVB6" --password "${{secrets.APPLE_NOTARIZATION_PASSWORD}}" --wait
+        run: xcrun notarytool submit *.dmg --keychain-profile "strawberry-notarization" --wait
 
       - name: Staple notarization ticket
         if: github.repository == 'strawberrymusicplayer/strawberry' && (github.event_name == 'release' || (github.event_name == 'push' && github.event.pull_request.head.repo.fork == false && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/ci' || github.ref == 'refs/heads/macos')))
@@ -1168,9 +1172,12 @@ jobs:
         working-directory: build
         run: make dmg
 
+      - name: Store notarization credentials
+        run: xcrun notarytool store-credentials "strawberry-notarization" --apple-id "${{secrets.APPLE_NOTARIZATION_APPLE_ID}}" --team-id "383J84DVB6" --password "${{secrets.APPLE_NOTARIZATION_PASSWORD}}"
+
       - name: Notarize DMG
         working-directory: build
-        run: xcrun notarytool submit *.dmg --apple-id "${{secrets.APPLE_NOTARIZATION_APPLE_ID}}" --team-id "383J84DVB6" --password "${{secrets.APPLE_NOTARIZATION_PASSWORD}}" --wait
+        run: xcrun notarytool submit *.dmg --keychain-profile "strawberry-notarization" --wait
 
       - name: Staple notarization ticket
         working-directory: build

--- a/cmake/Dmg.cmake
+++ b/cmake/Dmg.cmake
@@ -17,7 +17,7 @@ if(MACDEPLOYTOOL_EXECUTABLE)
     COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --component macos_bundle_resources
   )
   if(APPLE_DEVELOPER_ID)
-    list(APPEND DEPLOY_COMMANDS COMMAND ${MACDEPLOYTOOL_EXECUTABLE} strawberry.app --verbose=3 --codesign=${APPLE_DEVELOPER_ID} --gstreamer-plugins=all)
+    list(APPEND DEPLOY_COMMANDS COMMAND ${MACDEPLOYTOOL_EXECUTABLE} strawberry.app --verbose=3 --sign-for-notarization=${APPLE_DEVELOPER_ID} --gstreamer-plugins=all)
   else()
     list(APPEND DEPLOY_COMMANDS COMMAND ${MACDEPLOYTOOL_EXECUTABLE} strawberry.app --verbose=3 --no-codesign --gstreamer-plugins=all)
   endif()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS application notarization for public and private builds.
  * Added notarization-ticket stapling to macOS packages.
  * macOS deployment packages are now signed using the notarization-specific signing process when configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->