### PR TITLE
Avoid creating new network access manager for each subsonic request

### DIFF
--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -187,7 +187,7 @@ class ApplicationImpl {
         streaming_services_([app]() {
           StreamingServices *streaming_services = new StreamingServices();
 #ifdef HAVE_SUBSONIC
-          streaming_services->AddService(make_shared<SubsonicService>(app->task_manager(), app->database(), app->url_handlers(), app->albumcover_loader()));
+          streaming_services->AddService(make_shared<SubsonicService>(app->task_manager(), app->database(), app->network(), app->url_handlers(), app->albumcover_loader()));
 #endif
 #ifdef HAVE_TIDAL
           streaming_services->AddService(make_shared<TidalService>(app->task_manager(), app->database(), app->network(), app->url_handlers(), app->albumcover_loader()));

--- a/src/subsonic/subsonicbaserequest.cpp
+++ b/src/subsonic/subsonicbaserequest.cpp
@@ -20,7 +20,6 @@
 #include "config.h"
 
 #include <utility>
-#include <memory>
 
 #include <QtGlobal>
 #include <QObject>
@@ -29,7 +28,6 @@
 #include <QString>
 #include <QUrl>
 #include <QUrlQuery>
-#include <QNetworkAccessManager>
 #include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QCryptographicHash>
@@ -40,6 +38,7 @@
 #include <QJsonObject>
 #include <QJsonValue>
 
+#include "core/networkaccessmanager.h"
 #include "utilities/randutils.h"
 #include "subsonicservice.h"
 #include "subsonicbaserequest.h"
@@ -48,14 +47,10 @@
 
 using namespace Qt::Literals::StringLiterals;
 
-SubsonicBaseRequest::SubsonicBaseRequest(SubsonicService *service, QObject *parent)
+SubsonicBaseRequest::SubsonicBaseRequest(SubsonicService *service, const SharedPtr<NetworkAccessManager> network, QObject *parent)
     : QObject(parent),
-      service_(service),
-      network_(new QNetworkAccessManager) {
-
-  network_->setRedirectPolicy(QNetworkRequest::NoLessSafeRedirectPolicy);
-
-}
+      network_(network),
+      service_(service) {}
 
 QUrl SubsonicBaseRequest::CreateUrl(const QUrl &server_url, const SubsonicSettings::AuthMethod auth_method, const QString &username, const QString &password, const QString &ressource_name, const ParamList &params_provided) {
 
@@ -112,6 +107,8 @@ QNetworkReply *SubsonicBaseRequest::CreateGetRequest(const QString &ressource_na
   network_request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
   network_request.setAttribute(QNetworkRequest::Http2AllowedAttribute, http2());
   network_request.setTransferTimeout(QNetworkRequest::DefaultTransferTimeoutConstant);
+  network_request.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysNetwork);
+  network_request.setAttribute(QNetworkRequest::CacheSaveControlAttribute, false);
 
   QNetworkReply *reply = network_->get(network_request);
   QObject::connect(reply, &QNetworkReply::sslErrors, this, &SubsonicBaseRequest::HandleSSLErrors);

--- a/src/subsonic/subsonicbaserequest.h
+++ b/src/subsonic/subsonicbaserequest.h
@@ -34,19 +34,19 @@
 #include <QSslError>
 #include <QJsonObject>
 
-#include "includes/scoped_ptr.h"
+#include "includes/shared_ptr.h"
 #include "constants/subsonicsettings.h"
 #include "core/jsonbaserequest.h"
 #include "subsonicservice.h"
 
-class QNetworkAccessManager;
 class QNetworkReply;
+class NetworkAccessManager;
 
 class SubsonicBaseRequest : public QObject {
   Q_OBJECT
 
  public:
-  explicit SubsonicBaseRequest(SubsonicService *service, QObject *parent = nullptr);
+  explicit SubsonicBaseRequest(SubsonicService *service, const SharedPtr<NetworkAccessManager> network, QObject *parent = nullptr);
 
   using JsonObjectResult = JsonBaseRequest::JsonObjectResult;
   using ErrorCode = JsonBaseRequest::ErrorCode;
@@ -76,9 +76,11 @@ class SubsonicBaseRequest : public QObject {
  private Q_SLOTS:
   void HandleSSLErrors(const QList<QSslError> &ssl_errors);
 
+ protected:
+  const SharedPtr<NetworkAccessManager> network_;
+
  private:
   SubsonicService *service_;
-  ScopedPtr<QNetworkAccessManager> network_;
 };
 
 #endif  // SUBSONICBASEREQUEST_H

--- a/src/subsonic/subsonicrequest.cpp
+++ b/src/subsonic/subsonicrequest.cpp
@@ -30,7 +30,6 @@
 #include <QDateTime>
 #include <QImage>
 #include <QImageReader>
-#include <QNetworkAccessManager>
 #include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QSslConfiguration>
@@ -41,6 +40,7 @@
 
 #include "core/logging.h"
 #include "core/song.h"
+#include "core/networkaccessmanager.h"
 #include "core/networktimeouts.h"
 #include "utilities/strutils.h"
 #include "utilities/imageutils.h"
@@ -58,11 +58,10 @@ constexpr int kMaxConcurrentAlbumSongsRequests = 3;
 constexpr int kMaxConcurrentAlbumCoverRequests = 1;
 }  // namespace
 
-SubsonicRequest::SubsonicRequest(SubsonicService *service, SubsonicUrlHandler *url_handler, QObject *parent)
-    : SubsonicBaseRequest(service, parent),
+SubsonicRequest::SubsonicRequest(SubsonicService *service, SubsonicUrlHandler *url_handler, const SharedPtr<NetworkAccessManager> network, QObject *parent)
+    : SubsonicBaseRequest(service, network, parent),
       service_(service),
       url_handler_(url_handler),
-      network_(new QNetworkAccessManager(this)),
       timeouts_(new NetworkTimeouts(30000, this)),
       finished_(false),
       albums_requests_active_(0),
@@ -72,23 +71,20 @@ SubsonicRequest::SubsonicRequest(SubsonicService *service, SubsonicUrlHandler *u
       album_covers_requests_active_(0),
       album_covers_requested_(0),
       album_covers_received_(0),
-      no_results_(false) {
-
-  network_->setRedirectPolicy(QNetworkRequest::NoLessSafeRedirectPolicy);
-
-}
+      no_results_(false) {}
 
 SubsonicRequest::~SubsonicRequest() {
 
-  while (!replies_.isEmpty()) {
-    QNetworkReply *reply = replies_.takeFirst();
-    QObject::disconnect(reply, nullptr, this, nullptr);
-    if (reply->isRunning()) reply->abort();
-    reply->deleteLater();
-  }
+  AbortReplies(replies_);
+  AbortReplies(album_cover_replies_);
 
-  while (!album_cover_replies_.isEmpty()) {
-    QNetworkReply *reply = album_cover_replies_.takeFirst();
+}
+
+void SubsonicRequest::AbortReplies(QList<QNetworkReply*> &replies) {
+
+  // The replies are owned by the shared network access manager, which outlives this request, so they have to be aborted and deleted explicitly.
+  while (!replies.isEmpty()) {
+    QNetworkReply *reply = replies.takeFirst();
     QObject::disconnect(reply, nullptr, this, nullptr);
     if (reply->isRunning()) reply->abort();
     reply->deleteLater();
@@ -118,8 +114,8 @@ void SubsonicRequest::Reset() {
   cover_urls_.clear();
   errors_.clear();
   no_results_ = false;
-  replies_.clear();
-  album_cover_replies_.clear();
+  AbortReplies(replies_);
+  AbortReplies(album_cover_replies_);
 
 }
 
@@ -697,6 +693,8 @@ void SubsonicRequest::FlushAlbumCoverRequests() {
     QNetworkRequest network_request(request.url);
     network_request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
     network_request.setAttribute(QNetworkRequest::Http2AllowedAttribute, http2());
+    network_request.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysNetwork);
+    network_request.setAttribute(QNetworkRequest::CacheSaveControlAttribute, false);
 
     if (!verify_certificate()) {
       QSslConfiguration sslconfig = QSslConfiguration::defaultConfiguration();

--- a/src/subsonic/subsonicrequest.h
+++ b/src/subsonic/subsonicrequest.h
@@ -37,11 +37,12 @@
 #include <QUrl>
 #include <QJsonObject>
 
+#include "includes/shared_ptr.h"
 #include "core/song.h"
 #include "subsonicbaserequest.h"
 
-class QNetworkAccessManager;
 class QNetworkReply;
+class NetworkAccessManager;
 class SubsonicService;
 class SubsonicUrlHandler;
 class NetworkTimeouts;
@@ -50,7 +51,7 @@ class SubsonicRequest : public SubsonicBaseRequest {
   Q_OBJECT
 
  public:
-  explicit SubsonicRequest(SubsonicService *service, SubsonicUrlHandler *url_handler, QObject *parent = nullptr);
+  explicit SubsonicRequest(SubsonicService *service, SubsonicUrlHandler *url_handler, const SharedPtr<NetworkAccessManager> network, QObject *parent = nullptr);
   ~SubsonicRequest() override;
 
   void ReloadSettings();
@@ -105,12 +106,12 @@ class SubsonicRequest : public SubsonicBaseRequest {
   void AlbumCoverFinishCheck();
 
   void FinishCheck();
+  void AbortReplies(QList<QNetworkReply*> &replies);
   static void Warn(const QString &error, const QVariant &debug = QVariant());
   void Error(const QString &error, const QVariant &debug = QVariant()) override;
 
   SubsonicService *service_;
   SubsonicUrlHandler *url_handler_;
-  QNetworkAccessManager *network_;
   NetworkTimeouts *timeouts_;
 
   bool finished_;

--- a/src/subsonic/subsonicscrobblerequest.cpp
+++ b/src/subsonic/subsonicscrobblerequest.cpp
@@ -30,6 +30,7 @@
 #include <QJsonValue>
 
 #include "core/logging.h"
+#include "core/networkaccessmanager.h"
 #include "subsonicservice.h"
 #include "subsonicbaserequest.h"
 #include "subsonicscrobblerequest.h"
@@ -40,8 +41,8 @@ namespace {
 constexpr int kMaxConcurrentScrobbleRequests = 3;
 }
 
-SubsonicScrobbleRequest::SubsonicScrobbleRequest(SubsonicService *service, SubsonicUrlHandler *url_handler, QObject *parent)
-    : SubsonicBaseRequest(service, parent),
+SubsonicScrobbleRequest::SubsonicScrobbleRequest(SubsonicService *service, SubsonicUrlHandler *url_handler, const SharedPtr<NetworkAccessManager> network, QObject *parent)
+    : SubsonicBaseRequest(service, network, parent),
       service_(service),
       url_handler_(url_handler),
       scrobble_requests_active_(0) {}

--- a/src/subsonic/subsonicscrobblerequest.h
+++ b/src/subsonic/subsonicscrobblerequest.h
@@ -31,9 +31,11 @@
 #include <QString>
 #include <QStringList>
 
+#include "includes/shared_ptr.h"
 #include "subsonicbaserequest.h"
 
 class QNetworkReply;
+class NetworkAccessManager;
 class SubsonicService;
 class SubsonicUrlHandler;
 
@@ -41,7 +43,7 @@ class SubsonicScrobbleRequest : public SubsonicBaseRequest {
   Q_OBJECT
 
  public:
-  explicit SubsonicScrobbleRequest(SubsonicService *service, SubsonicUrlHandler *url_handler, QObject *parent = nullptr);
+  explicit SubsonicScrobbleRequest(SubsonicService *service, SubsonicUrlHandler *url_handler, const SharedPtr<NetworkAccessManager> network, QObject *parent = nullptr);
   ~SubsonicScrobbleRequest() override;
 
   void CreateScrobbleRequest(const QString &song_id, const bool submission, const QDateTime &start_time);

--- a/src/subsonic/subsonicservice.cpp
+++ b/src/subsonic/subsonicservice.cpp
@@ -20,7 +20,6 @@
 #include "config.h"
 
 #include <utility>
-#include <memory>
 
 #include <QtGlobal>
 #include <QObject>
@@ -30,7 +29,6 @@
 #include <QVariant>
 #include <QUrl>
 #include <QUrlQuery>
-#include <QNetworkAccessManager>
 #include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QSslConfiguration>
@@ -45,6 +43,7 @@
 #include "includes/shared_ptr.h"
 #include "core/logging.h"
 #include "core/database.h"
+#include "core/networkaccessmanager.h"
 #include "core/song.h"
 #include "core/settings.h"
 #include "core/urlhandlers.h"
@@ -58,7 +57,6 @@
 #include "constants/subsonicsettings.h"
 
 using namespace Qt::Literals::StringLiterals;
-using std::make_unique;
 using std::make_shared;
 
 const Song::Source SubsonicService::kSource = Song::Source::Subsonic;
@@ -72,10 +70,12 @@ constexpr int kMaxRedirects = 3;
 
 SubsonicService::SubsonicService(const SharedPtr<TaskManager> task_manager,
                                  const SharedPtr<Database> database,
+                                 const SharedPtr<NetworkAccessManager> network,
                                  const SharedPtr<UrlHandlers> url_handlers,
                                  const SharedPtr<AlbumCoverLoader> albumcover_loader,
                                  QObject *parent)
     : StreamingService(Song::Source::Subsonic, u"Subsonic"_s, u"subsonic"_s, QLatin1String(SubsonicSettings::kSettingsGroup), parent),
+      network_(network),
       url_handler_(new SubsonicUrlHandler(this)),
       collection_backend_(nullptr),
       collection_model_(nullptr),
@@ -142,9 +142,7 @@ void SubsonicService::SendPing() {
 
 void SubsonicService::SendPingWithCredentials(QUrl url, const QString &username, const QString &password, const SubsonicSettings::AuthMethod auth_method, const bool redirect) {
 
-  if (!network_ || !redirect) {
-    network_ = make_unique<QNetworkAccessManager>();
-    network_->setRedirectPolicy(QNetworkRequest::NoLessSafeRedirectPolicy);
+  if (!redirect) {
     ping_redirects_ = 0;
   }
 
@@ -195,6 +193,8 @@ void SubsonicService::SendPingWithCredentials(QUrl url, const QString &username,
   network_request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
   network_request.setHeader(QNetworkRequest::ContentTypeHeader, u"application/x-www-form-urlencoded"_s);
   network_request.setAttribute(QNetworkRequest::Http2AllowedAttribute, http2_);
+  network_request.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysNetwork);
+  network_request.setAttribute(QNetworkRequest::CacheSaveControlAttribute, false);
 
   errors_.clear();
   QNetworkReply *reply = network_->get(network_request);
@@ -387,7 +387,7 @@ void SubsonicService::Scrobble(const QString &song_id, const bool submission, co
 
   if (!scrobble_request_) {
     // We're doing requests every 30-240s the whole time, so keep reusing this instance
-    scrobble_request_.reset(new SubsonicScrobbleRequest(this, url_handler_), [](SubsonicScrobbleRequest *request) { request->deleteLater(); });
+    scrobble_request_.reset(new SubsonicScrobbleRequest(this, url_handler_, network_), [](SubsonicScrobbleRequest *request) { request->deleteLater(); });
   }
 
   scrobble_request_->CreateScrobbleRequest(song_id, submission, time);
@@ -417,7 +417,7 @@ void SubsonicService::GetSongs() {
   }
 
   ResetSongsRequest();
-  songs_request_.reset(new SubsonicRequest(this, url_handler_), [](SubsonicRequest *request) { request->deleteLater(); });
+  songs_request_.reset(new SubsonicRequest(this, url_handler_, network_), [](SubsonicRequest *request) { request->deleteLater(); });
   QObject::connect(&*songs_request_, &SubsonicRequest::Results, this, &SubsonicService::SongsResultsReceived);
   QObject::connect(&*songs_request_, &SubsonicRequest::UpdateStatus, this, &SubsonicService::SongsUpdateStatus);
   QObject::connect(&*songs_request_, &SubsonicRequest::ProgressSetMaximum, this, &SubsonicService::SongsProgressSetMaximum);

--- a/src/subsonic/subsonicservice.h
+++ b/src/subsonic/subsonicservice.h
@@ -32,11 +32,9 @@
 #include <QString>
 #include <QStringList>
 #include <QUrl>
-#include <QNetworkAccessManager>
 #include <QSslError>
 #include <QDateTime>
 
-#include "includes/scoped_ptr.h"
 #include "includes/shared_ptr.h"
 #include "constants/subsonicsettings.h"
 #include "core/song.h"
@@ -47,6 +45,7 @@ class QNetworkReply;
 
 class TaskManager;
 class Database;
+class NetworkAccessManager;
 class UrlHandlers;
 class AlbumCoverLoader;
 class SubsonicUrlHandler;
@@ -62,6 +61,7 @@ class SubsonicService : public StreamingService {
  public:
   explicit SubsonicService(const SharedPtr<TaskManager> task_manager,
                            const SharedPtr<Database> database,
+                           const SharedPtr<NetworkAccessManager> network,
                            const SharedPtr<UrlHandlers> url_handlers,
                            const SharedPtr<AlbumCoverLoader> albumcover_loader,
                            QObject *parent = nullptr);
@@ -110,7 +110,7 @@ class SubsonicService : public StreamingService {
  private:
   void PingError(const QString &error = QString(), const QVariant &debug = QVariant());
 
-  ScopedPtr<QNetworkAccessManager> network_;
+  const SharedPtr<NetworkAccessManager> network_;
   SubsonicUrlHandler *url_handler_;
 
   SharedPtr<CollectionBackend> collection_backend_;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Subsonic network request reliability by sharing a common network connection manager.
  - Prevented stale cached data from being used for Subsonic requests, including album artwork and service checks.
  - Ensured outstanding requests are properly cancelled and cleaned up when interrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->