### PR TITLE
Add option to save current playlist columns as default

### DIFF
--- a/src/constants/playlistsettings.h
+++ b/src/constants/playlistsettings.h
@@ -56,6 +56,10 @@ constexpr char kState[] = "state";
 constexpr char kColumnAlignments[] = "column_alignments";
 constexpr char kRatingLocked[] = "rating_locked";
 
+constexpr char kSavedDefaultStateVersion[] = "saved_default_state_version";
+constexpr char kSavedDefaultState[] = "saved_default_state";
+constexpr char kSavedDefaultColumnAlignments[] = "saved_default_column_alignments";
+
 constexpr char kLastSaveFilter[] = "last_save_filter";
 constexpr char kLastSavePath[] = "last_save_path";
 constexpr char kLastSaveExtension[] = "last_save_extension";

--- a/src/playlist/playlistheader.cpp
+++ b/src/playlist/playlistheader.cpp
@@ -48,6 +48,7 @@ PlaylistHeader::PlaylistHeader(Qt::Orientation orientation, PlaylistView *view, 
       menu_(new QMenu(this)),
       action_hide_(nullptr),
       action_reset_(nullptr),
+      action_save_as_default_(nullptr),
       action_stretch_(nullptr),
       action_rating_lock_(nullptr),
       action_align_left_(nullptr),
@@ -57,6 +58,7 @@ PlaylistHeader::PlaylistHeader(Qt::Orientation orientation, PlaylistView *view, 
   action_hide_ = menu_->addAction(tr("&Hide..."), this, &PlaylistHeader::HideCurrent);
   action_stretch_ = menu_->addAction(tr("&Stretch columns to fit window"), this, &PlaylistHeader::ToggleStretchEnabled);
   action_reset_ = menu_->addAction(tr("&Reset columns to default"), this, &PlaylistHeader::ResetColumns);
+  action_save_as_default_ = menu_->addAction(tr("Sa&ve current columns as default"), this, &PlaylistHeader::SaveColumnsAsDefault);
   action_rating_lock_ = menu_->addAction(tr("&Lock rating"), this, &PlaylistHeader::ToggleRatingEditStatus);
   action_rating_lock_->setCheckable(true);
   menu_->addSeparator();
@@ -171,6 +173,10 @@ void PlaylistHeader::enterEvent(QEnterEvent *e) {
 
 void PlaylistHeader::ResetColumns() {
   view_->ResetHeaderState();
+}
+
+void PlaylistHeader::SaveColumnsAsDefault() {
+  view_->SaveHeaderStateAsDefault();
 }
 
 void PlaylistHeader::ToggleRatingEditStatus() {

--- a/src/playlist/playlistheader.h
+++ b/src/playlist/playlistheader.h
@@ -56,6 +56,7 @@ class PlaylistHeader : public StretchHeaderView {
   void HideCurrent();
   void ToggleVisible(const int section);
   void ResetColumns();
+  void SaveColumnsAsDefault();
   void SetColumnAlignment(QAction *action);
   void ToggleRatingEditStatus();
 
@@ -69,6 +70,7 @@ class PlaylistHeader : public StretchHeaderView {
   QMenu *menu_;
   QAction *action_hide_;
   QAction *action_reset_;
+  QAction *action_save_as_default_;
   QAction *action_stretch_;
   QAction *action_rating_lock_;
   QAction *action_align_left_;

--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -348,11 +348,61 @@ void PlaylistView::SetHeaderState() {
 
 }
 
+bool PlaylistView::LoadSavedDefaultHeaderState() {
+
+  bool found = false;
+
+  Settings s;
+  s.beginGroup(PlaylistSettings::kSettingsGroup);
+  if (s.contains(PlaylistSettings::kSavedDefaultState) &&
+      s.contains(PlaylistSettings::kSavedDefaultColumnAlignments)) {
+    // Since we use serialized internal data structures, we cannot read anything but the current version.
+    const int saved_default_state_version = s.value(PlaylistSettings::kSavedDefaultStateVersion, PlaylistSettings::kDefaultStateVersion).toInt();
+    if (saved_default_state_version == kHeaderStateVersion) {
+      const QByteArray saved_default_state = s.value(PlaylistSettings::kSavedDefaultState).toByteArray();
+      if (!saved_default_state.isEmpty()) {
+        header_state_ = saved_default_state;
+        column_alignment_ = s.value(PlaylistSettings::kSavedDefaultColumnAlignments).value<ColumnAlignmentMap>();
+        found = true;
+      }
+    }
+  }
+  s.endGroup();
+
+  return found;
+
+}
+
 void PlaylistView::ResetHeaderState() {
 
-  set_initial_header_layout_ = true;
-  header_state_ = header_->ResetState();
+  header_state_.clear();
+
+  if (LoadSavedDefaultHeaderState()) {
+    // A user-saved default column layout exists: restore it instead of falling back to the built-in defaults.
+    set_initial_header_layout_ = false;
+  }
+  else {
+    set_initial_header_layout_ = true;
+    column_alignment_ = DefaultColumnAlignment();
+    header_state_ = header_->ResetState();
+  }
+
+  header_state_loaded_ = true;
+
   RestoreHeaderState();
+
+}
+
+void PlaylistView::SaveHeaderStateAsDefault() {
+
+  if (!header_state_loaded_ || read_only_settings_) return;
+
+  Settings s;
+  s.beginGroup(PlaylistSettings::kSettingsGroup);
+  s.setValue(PlaylistSettings::kSavedDefaultStateVersion, kHeaderStateVersion);
+  s.setValue(PlaylistSettings::kSavedDefaultState, header_->SaveState());
+  s.setValue(PlaylistSettings::kSavedDefaultColumnAlignments, QVariant::fromValue<ColumnAlignmentMap>(column_alignment_));
+  s.endGroup();
 
 }
 
@@ -362,6 +412,7 @@ void PlaylistView::RestoreHeaderState() {
 
   if (header_state_.isEmpty() || !header_->RestoreState(header_state_)) {
     set_initial_header_layout_ = true;
+    column_alignment_ = DefaultColumnAlignment();
   }
 
   if (set_initial_header_layout_) {

--- a/src/playlist/playlistview.h
+++ b/src/playlist/playlistview.h
@@ -107,6 +107,7 @@ class PlaylistView : public QTreeView {
   Qt::Alignment column_alignment(int section) const;
 
   void ResetHeaderState();
+  void SaveHeaderStateAsDefault();
 
   // QTreeView
   void setModel(QAbstractItemModel *model) override;
@@ -184,6 +185,7 @@ class PlaylistView : public QTreeView {
  private:
   void LoadHeaderState();
   void RestoreHeaderState();
+  bool LoadSavedDefaultHeaderState();
 
   void ReloadBarPixmaps();
   QList<QPixmap> LoadBarPixmap(const QString &filename, const bool keep_aspect_ratio);


### PR DESCRIPTION
Adds a "Save current columns as default" entry to the playlist header's right-click menu, next to "Reset columns to default".

It saves the current column order, widths, visibility, sort indicator and per-column text alignment to settings. "Reset columns to default" then restores this saved layout instead of falling back to the built-in default column layout, if one was saved. Behavior is unchanged when no default has been saved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to save the current playlist column layout as the default.
  * Resetting playlist columns now restores the saved layout when available.
  * Saved column alignments are preserved and restored automatically.
  * Reset continues to use the built-in layout when no compatible saved default exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->