### PR TITLE
Fix playlist item thread-safety issue between playlist model and backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -613,6 +613,7 @@ set(SOURCES
   src/playlist/playlistfilter.cpp
   src/playlist/playlistheader.cpp
   src/playlist/playlistitem.cpp
+  src/playlist/playlistitemsavedata.cpp
   src/playlist/songplaylistitem.cpp
   src/playlist/streamplaylistitem.cpp
   src/playlist/playlistitemmimedata.cpp

--- a/src/core/metatypes.cpp
+++ b/src/core/metatypes.cpp
@@ -49,6 +49,7 @@
 #include "engine/gstenginepipeline.h"
 #include "collection/collectiondirectory.h"
 #include "playlist/playlistitem.h"
+#include "playlist/playlistitemsavedata.h"
 #include "playlist/playlistsequence.h"
 #include "covermanager/albumcoverloaderresult.h"
 #include "covermanager/albumcoverfetcher.h"
@@ -117,6 +118,8 @@ void RegisterMetaTypes() {
   qRegisterMetaType<CollectionModel::Grouping>("CollectionModel::Grouping");
   qRegisterMetaType<PlaylistItemPtr>("PlaylistItemPtr");
   qRegisterMetaType<PlaylistItemPtrList>("PlaylistItemPtrList");
+  qRegisterMetaType<PlaylistItemSaveData>("PlaylistItemSaveData");
+  qRegisterMetaType<PlaylistItemSaveDataList>("PlaylistItemSaveDataList");
   qRegisterMetaType<PlaylistSequence::RepeatMode>("PlaylistSequence::RepeatMode");
   qRegisterMetaType<PlaylistSequence::ShuffleMode>("PlaylistSequence::ShuffleMode");
   qRegisterMetaType<AlbumCoverLoaderResult>("AlbumCoverLoaderResult");

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -74,6 +74,7 @@
 #include "queue/queue.h"
 #include "playlist.h"
 #include "playlistitem.h"
+#include "playlistitemsavedata.h"
 #include "playlistview.h"
 #include "playlistsequence.h"
 #include "playlistbackend.h"
@@ -1712,7 +1713,14 @@ void Playlist::Save() {
 
   if (!playlist_backend_ || is_loading_) return;
 
-  playlist_backend_->SavePlaylistAsync(id_, items_, last_played_row(), dynamic_playlist_);
+  // Snapshot the items here, on the playlist's own thread, rather than handing the items themselves to the database thread:
+  // saving is asynchronous and the model keeps mutating the items (inline tag edits, collection updates, stream metadata) while it runs.
+  PlaylistItemSaveDataList items_save_data;
+  items_save_data.reserve(items_.count());
+  for (int i = 0; i < items_.count(); i++) {
+    items_save_data << items_.at(i)->CreateSaveData();
+  }
+  playlist_backend_->SavePlaylistAsync(id_, items_save_data, last_played_row(), dynamic_playlist_);
 
 }
 

--- a/src/playlist/playlistbackend.cpp
+++ b/src/playlist/playlistbackend.cpp
@@ -49,6 +49,7 @@
 #include "collection/collectionbackend.h"
 #include "tagreader/tagreaderclient.h"
 #include "playlistitem.h"
+#include "playlistitemsavedata.h"
 #include "songplaylistitem.h"
 #include "playlistbackend.h"
 #include "playlistparsers/cueparser.h"
@@ -355,13 +356,13 @@ PlaylistItemPtr PlaylistBackend::RestoreCueData(PlaylistItemPtr item, SharedPtr<
 
 }
 
-void PlaylistBackend::SavePlaylistAsync(int playlist, const PlaylistItemPtrList &items, int last_played, PlaylistGeneratorPtr dynamic) {
+void PlaylistBackend::SavePlaylistAsync(const int playlist, const PlaylistItemSaveDataList &items, const int last_played, PlaylistGeneratorPtr dynamic) {
 
-  QMetaObject::invokeMethod(this, "SavePlaylist", Qt::QueuedConnection, Q_ARG(int, playlist), Q_ARG(PlaylistItemPtrList, items), Q_ARG(int, last_played), Q_ARG(PlaylistGeneratorPtr, dynamic));
+  QMetaObject::invokeMethod(this, "SavePlaylist", Qt::QueuedConnection, Q_ARG(int, playlist), Q_ARG(PlaylistItemSaveDataList, items), Q_ARG(int, last_played), Q_ARG(PlaylistGeneratorPtr, dynamic));
 
 }
 
-void PlaylistBackend::SavePlaylist(int playlist, const PlaylistItemPtrList &items, int last_played, PlaylistGeneratorPtr dynamic) {
+void PlaylistBackend::SavePlaylist(const int playlist, const PlaylistItemSaveDataList &items, const int last_played, PlaylistGeneratorPtr dynamic) {
 
   QMutexLocker l(database_->Mutex());
   QSqlDatabase db(database_->Connect());
@@ -382,13 +383,14 @@ void PlaylistBackend::SavePlaylist(int playlist, const PlaylistItemPtrList &item
   }
 
   // Save the new ones
-  for (int i = 0; i < items.count(); ++i) {
-    const PlaylistItemPtr item = items.at(i);
+  for (const PlaylistItemSaveData &item : items) {
     SqlQuery q(db);
     q.prepare(u"INSERT INTO playlist_items (playlist, type, uuid, collection_id, "_s + Song::kColumnSpec + u") VALUES (:playlist, :type, :uuid, :collection_id, "_s + Song::kBindSpec + u")"_s);
     q.BindValue(u":playlist"_s, playlist);
-    item->BindToQuery(&q);
-
+    q.BindValue(u":type"_s, static_cast<int>(item.source));
+    q.BindValue(u":uuid"_s, item.uuid.toString(QUuid::WithoutBraces));
+    q.BindValue(u":collection_id"_s, item.collection_id);
+    item.song.BindToQuery(&q);
     if (!q.Exec()) {
       database_->ReportErrors(q);
       return;

--- a/src/playlist/playlistbackend.h
+++ b/src/playlist/playlistbackend.h
@@ -35,6 +35,7 @@
 #include "core/song.h"
 #include "core/sqlrow.h"
 #include "playlistitem.h"
+#include "playlistitemsavedata.h"
 #include "smartplaylists/playlistgenerator.h"
 
 class QThread;
@@ -80,14 +81,14 @@ class PlaylistBackend : public QObject {
   void SetPlaylistUiPath(const int id, const QString &path);
 
   int CreatePlaylist(const QString &name, const QString &special_type);
-  void SavePlaylistAsync(const int playlist, const PlaylistItemPtrList &items, const int last_played, PlaylistGeneratorPtr dynamic);
+  void SavePlaylistAsync(const int playlist, const PlaylistItemSaveDataList &items, const int last_played, PlaylistGeneratorPtr dynamic);
   void RenamePlaylist(const int id, const QString &new_name);
   void FavoritePlaylist(const int id, bool is_favorite);
   void RemovePlaylist(const int id);
 
  public Q_SLOTS:
   void Exit();
-  void SavePlaylist(const int playlist, const PlaylistItemPtrList &items, const int last_played, PlaylistGeneratorPtr dynamic);
+  void SavePlaylist(const int playlist, const PlaylistItemSaveDataList &items, const int last_played, PlaylistGeneratorPtr dynamic);
 
  Q_SIGNALS:
   void ExitFinished();

--- a/src/playlist/playlistitem.cpp
+++ b/src/playlist/playlistitem.cpp
@@ -30,6 +30,7 @@
 #include "core/song.h"
 
 #include "playlistitem.h"
+#include "playlistitemsavedata.h"
 #include "songplaylistitem.h"
 #include "collection/collectionplaylistitem.h"
 #include "streaming/streamserviceplaylistitem.h"
@@ -116,13 +117,15 @@ void PlaylistItem::ClearStreamMetadata() {
   stream_song_ = Song();
 }
 
-void PlaylistItem::BindToQuery(SqlQuery *query) const {
+PlaylistItemSaveData PlaylistItem::CreateSaveData() const {
 
-  query->BindValue(u":type"_s, static_cast<int>(source_));
-  query->BindValue(u":uuid"_s, uuid_.toString(QUuid::WithoutBraces));
-  query->BindValue(u":collection_id"_s, DatabaseValue(DatabaseColumn::CollectionId));
+  PlaylistItemSaveData save_data;
+  save_data.source = source_;
+  save_data.uuid = uuid_;
+  save_data.collection_id = DatabaseValue(DatabaseColumn::CollectionId);
+  save_data.song = DatabaseSongMetadata();
 
-  DatabaseSongMetadata().BindToQuery(query);
+  return save_data;
 
 }
 

--- a/src/playlist/playlistitem.h
+++ b/src/playlist/playlistitem.h
@@ -37,6 +37,7 @@
 
 #include "includes/shared_ptr.h"
 #include "core/song.h"
+#include "playlistitemsavedata.h"
 
 class QAction;
 
@@ -90,7 +91,9 @@ class PlaylistItem {
   virtual void SetArtManual(const QUrl &cover_url) = 0;
 
   virtual bool InitFromQuery(const SqlRow &query) = 0;
-  void BindToQuery(SqlQuery *query) const;
+
+  // Must be called on the thread that owns this item; see PlaylistItemSaveData.
+  PlaylistItemSaveData CreateSaveData() const;
 
   // Identifies the most recent edit made to this item through the playlist (e.g. inline tag editing).
   // A caller starting an asynchronous write/reload round trip should capture the value returned by BumpSaveGeneration() and compare it against save_generation() once the round trip completes: a mismatch means a newer edit has since superseded it, so the (now stale) result must not be applied.

--- a/src/playlist/playlistitemsavedata.cpp
+++ b/src/playlist/playlistitemsavedata.cpp
@@ -1,0 +1,26 @@
+/*
+ * Strawberry Music Player
+ * Copyright 2026, Jonas Kvinge <jonas@jkvinge.net>
+ *
+ * Strawberry is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Strawberry is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Strawberry.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "config.h"
+
+#include "core/song.h"
+
+#include "playlistitemsavedata.h"
+
+PlaylistItemSaveData::PlaylistItemSaveData() : source(Song::Source::Unknown) {}

--- a/src/playlist/playlistitemsavedata.h
+++ b/src/playlist/playlistitemsavedata.h
@@ -1,0 +1,50 @@
+/*
+ * Strawberry Music Player
+ * Copyright 2026, Jonas Kvinge <jonas@jkvinge.net>
+ *
+ * Strawberry is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Strawberry is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Strawberry.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef PLAYLISTITEMSAVEDATA_H
+#define PLAYLISTITEMSAVEDATA_H
+
+#include "config.h"
+
+#include <QMetaType>
+#include <QList>
+#include <QVariant>
+#include <QUuid>
+
+#include "core/song.h"
+
+// Everything PlaylistBackend needs to write one row of a playlist.
+// PlaylistBackend runs in the database thread while the playlist model keeps mutating its items on its own thread (inline tag edits, collection updates, stream metadata),
+// so PlaylistItem::CreateSaveData() captures the values up front instead of letting the database thread read the items later.
+// Song is copy on write with an atomic reference count, so a copy taken on the playlist's thread can safely be read from the database thread.
+class PlaylistItemSaveData {
+ public:
+  explicit PlaylistItemSaveData();
+
+  Song::Source source;
+  QUuid uuid;
+  QVariant collection_id;
+  Song song;
+};
+using PlaylistItemSaveDataList = QList<PlaylistItemSaveData>;
+
+Q_DECLARE_METATYPE(PlaylistItemSaveData)
+Q_DECLARE_METATYPE(PlaylistItemSaveDataList)
+
+#endif  // PLAYLISTITEMSAVEDATA_H


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved playlist saving reliability by capturing item data before background database writes.
  - Preserved playlist sources, identifiers, collection details, and song metadata during persistence.
  - Reduced the risk of saving inconsistent playlist state while items are being modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->