### PR TITLE
Stop device lister thread after shutdown

### DIFF
--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -22,7 +22,10 @@
 #include "config.h"
 #include "version.h"
 
+#include <cstdlib>
+#include <cstdio>
 #include <cmath>
+
 #include <algorithm>
 #include <utility>
 #include <functional>
@@ -417,6 +420,7 @@ MainWindow::MainWindow(Application *app,
       was_minimized_(false),
       exit_(false),
       exit_count_(0),
+      exit_started_(false),
       playlists_loaded_(false),
       delete_files_(false) {
 
@@ -1429,8 +1433,17 @@ void MainWindow::Exit() {
   settings_dialog_.reset();
 
   if (exit_count_ > 1) {
-    exit_ = true;
-    QCoreApplication::quit();
+    // Asked to quit again. Never quit the event loop directly here: exec() would return with the subsystems still running in their own threads, and Application's destructor would then delete them from this thread.
+    if (exit_started_) {
+      // The shutdown is already running and is waiting for a subsystem that has not reported back, so there is nothing left to hurry along.
+      // Leave the process without unwinding rather than tearing down objects the subsystem threads are still using.
+      qLog(Warning) << "Exit requested again while shutting down, exiting immediately.";
+      std::fflush(nullptr);
+      std::_Exit(EXIT_SUCCESS);
+    }
+    // Still waiting for a fadeout to finish, so skip the rest of it and shut down now.
+    QObject::disconnect(&*app_->player()->engine(), &EngineBase::Finished, this, &MainWindow::DoExit);
+    DoExit();
   }
   else {
     if (app_->player()->engine()->is_fadeout_enabled()) {
@@ -1458,6 +1471,9 @@ void MainWindow::Exit() {
 }
 
 void MainWindow::DoExit() {
+
+  if (exit_started_) return;
+  exit_started_ = true;
 
   QObject::connect(app_, &Application::ExitFinished, this, &MainWindow::ExitFinished);
   app_->Exit();

--- a/src/core/mainwindow.h
+++ b/src/core/mainwindow.h
@@ -419,6 +419,7 @@ class MainWindow : public QMainWindow, public PlatformInterface {
   AlbumCoverImageResult album_cover_;
   bool exit_;
   int exit_count_;
+  bool exit_started_;
   bool playlists_loaded_;
   bool delete_files_;
   std::optional<CommandlineOptions> options_;

--- a/src/device/devicelister.cpp
+++ b/src/device/devicelister.cpp
@@ -2,7 +2,7 @@
  * Strawberry Music Player
  * This file was part of Clementine.
  * Copyright 2010, David Sansome <me@davidsansome.com>
- * Copyright 2018-2021, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2018-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -45,23 +45,38 @@ DeviceLister::DeviceLister(QObject *parent)
       original_thread_(nullptr),
       next_mount_request_id_(0) {
 
-  setObjectName(QLatin1String(QObject::metaObject()->className()));
-
   original_thread_ = thread();
 
 }
 
 DeviceLister::~DeviceLister() {
 
-  if (thread_) {
-    thread_->quit();
-    thread_->wait(1000);
-    thread_->deleteLater();
-  }
+  // Last resort: the thread should already have been stopped by whoever is destroying this lister, since by the time this runs the derived part of the object no longer exists.
+  StopThread();
+
+}
+
+void DeviceLister::StopThread() {
+
+  if (!thread_) return;
+
+  thread_->quit();
+
+  // Wait without a timeout, matching Application::~Application().
+  // Giving up on a thread that has not stopped is what turns a stuck lister into a crash: this object is freed regardless, and the thread goes on delivering queued events to freed memory.
+  thread_->wait();
+
+  // The thread has finished, so it can be deleted directly. deleteLater() would not do: this typically runs while the application is being torn down, with no event loop left to deliver the deletion.
+  delete thread_;
+  thread_ = nullptr;
 
 }
 
 void DeviceLister::Start() {
+
+  // Name the object after the concrete lister, which is only known once construction has finished (metaObject() resolves to DeviceLister while the base constructor runs).
+  // The thread takes the same name, which is what identifies it in a debugger or a backtrace.
+  setObjectName(QLatin1String(metaObject()->className()));
 
   thread_ = new QThread;
   thread_->setObjectName(objectName());

--- a/src/device/devicelister.h
+++ b/src/device/devicelister.h
@@ -2,7 +2,7 @@
  * Strawberry Music Player
  * This file was part of Clementine.
  * Copyright 2010, David Sansome <me@davidsansome.com>
- * Copyright 2018-2021, Jonas Kvinge <jonas@jkvinge.net>
+ * Copyright 2018-2026, Jonas Kvinge <jonas@jkvinge.net>
  *
  * Strawberry is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -45,6 +45,9 @@ class DeviceLister : public QObject {
 
   // Tries to start the thread and initialize the engine.  This object will be moved to the new thread.
   void Start();
+  // Stops the thread started by Start() and waits for it to finish. Safe to call more than once, and does nothing if the thread was never started.
+  // Call this before destroying the lister: once the destructor has started, the derived part of the object is gone while its thread may still be delivering events to it.
+  void StopThread();
   virtual void ExitAsync();
 
   // If two listers know about the same device, then the metadata will get taken from the one with the highest priority.

--- a/src/device/devicemanager.cpp
+++ b/src/device/devicemanager.cpp
@@ -152,6 +152,9 @@ DeviceManager::~DeviceManager() {
 
   for (DeviceLister *lister : std::as_const(listers_)) {
     lister->ShutDown();
+    // Stop the lister's thread before deleting it, so it is not still delivering events to the object once the derived destructor has run.
+    // Normally Exit() has already moved the lister back to this thread, but this destructor also runs when the event loop ended without that happening.
+    lister->StopThread();
     delete lister;
   }
   listers_.clear();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -430,6 +430,7 @@ int main(int argc, char *argv[]) {
 
 #ifdef HAVE_MPRIS2
   QObject::connect(&mpris2, &mpris::Mpris2::RaiseMainWindow, &w, &MainWindow::Raise);
+  QObject::connect(&mpris2, &mpris::Mpris2::ExitApplication, &w, &MainWindow::Exit);
 #endif
   QObject::connect(&single_app, &KDSingleApplication::messageReceived, &w, QOverload<const QByteArray&>::of(&MainWindow::CommandlineOptionsReceived));
 

--- a/src/mpris2/mpris2.cpp
+++ b/src/mpris2/mpris2.cpp
@@ -323,7 +323,7 @@ QStringList Mpris2::SupportedMimeTypes() const {
 
 void Mpris2::Raise() { Q_EMIT RaiseMainWindow(); }
 
-void Mpris2::Quit() { QCoreApplication::quit(); }
+void Mpris2::Quit() { Q_EMIT ExitApplication(); }
 
 QString Mpris2::PlaybackStatus() const {
   return PlaybackStatus(player_->GetState());

--- a/src/mpris2/mpris2.h
+++ b/src/mpris2/mpris2.h
@@ -224,6 +224,7 @@ class Mpris2 : public QObject {
   void TrackMetadataChanged(const QDBusObjectPath &track_id, const QVariantMap &metadata);
 
   void RaiseMainWindow();
+  void ExitApplication();
 
   // Playlist
   void PlaylistChanged(const MprisPlaylist &playlist);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device discovery shutdown to wait for background activity to finish cleanly.
  * Prevented resource leaks and unsafe cleanup when stopping device discovery.
  * Added safe handling for repeated shutdown requests and listers that were not started.
  * Improved application shutdown reliability when exiting through the media control interface.
  * Prevented repeated exit requests from causing inconsistent shutdown behavior.
  * Ensured shutdown requests follow the application’s normal exit flow for more consistent cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->