### PR TITLE
Clear OAuth session on invalid grant

### DIFF
--- a/src/core/oauthenticator.cpp
+++ b/src/core/oauthenticator.cpp
@@ -486,10 +486,18 @@ void OAuthenticator::AccessTokenRequestFinished(QNetworkReply *reply, const bool
       const QJsonDocument json_document = QJsonDocument::fromJson(data, &json_error);
       if (json_error.error == QJsonParseError::NoError && !json_document.isEmpty() && json_document.isObject()) {
         const QJsonObject json_object = json_document.object();
-        if (json_object.contains("error"_L1) && json_object.contains("error_description"_L1)) {
+        if (json_object.contains("error"_L1)) {
           const QString error = json_object["error"_L1].toString();
           const QString error_description = json_object["error_description"_L1].toString();
-          Q_EMIT AuthenticationFinished(false, QStringLiteral("%1 (%2)").arg(error, error_description));
+          // invalid_grant means the refresh token or authorization code is expired, revoked or otherwise unusable, so retrying with the same grant can never succeed.
+          // Clear the session to stop the same failure from being repeated on every startup, the user has to authenticate again.
+          const bool invalid_grant = error.compare("invalid_grant"_L1, Qt::CaseInsensitive) == 0;
+          if (invalid_grant) {
+            qLog(Error) << settings_group_ << "Authorization grant is no longer valid, clearing session.";
+            ClearSession();
+          }
+          const QString error_message = error_description.isEmpty() ? error : QStringLiteral("%1 (%2)").arg(error, error_description);
+          Q_EMIT AuthenticationFinished(false, error_message, invalid_grant);
           return;
         }
         qLog(Debug) << settings_group_ << "Unknown Json reply" << json_object;

--- a/src/core/oauthenticator.h
+++ b/src/core/oauthenticator.h
@@ -87,7 +87,7 @@ class OAuthenticator : public QObject {
 
  Q_SIGNALS:
   void Error(const QString &error);
-  void AuthenticationFinished(const bool success, const QString &error = QString());
+  void AuthenticationFinished(const bool success, const QString &error = QString(), const bool invalid_grant = false);
 
  private Q_SLOTS:
   void RedirectArrived();

--- a/src/covermanager/opentidalcoverprovider.cpp
+++ b/src/covermanager/opentidalcoverprovider.cpp
@@ -217,7 +217,9 @@ void OpenTidalCoverProvider::Login() {
 
 }
 
-void OpenTidalCoverProvider::OAuthFinished(const bool success, const QString &error) {
+void OpenTidalCoverProvider::OAuthFinished(const bool success, const QString &error, const bool invalid_grant) {
+
+  Q_UNUSED(invalid_grant);
 
   login_in_progress_ = false;
 

--- a/src/covermanager/opentidalcoverprovider.h
+++ b/src/covermanager/opentidalcoverprovider.h
@@ -120,7 +120,7 @@ class OpenTidalCoverProvider : public JsonCoverProvider {
   void Error(const QString &error, const QVariant &debug = QVariant()) override;
 
  private Q_SLOTS:
-  void OAuthFinished(const bool success, const QString &error = QString());
+  void OAuthFinished(const bool success, const QString &error = QString(), const bool invalid_grant = false);
   void FlushRequests();
   void HandleSearchReply(QNetworkReply *reply, OpenTidalCoverProvider::SearchRequestPtr search_request);
   void HandleAlbumCoverReply(QNetworkReply *reply, OpenTidalCoverProvider::SearchRequestPtr search_request, OpenTidalCoverProvider::AlbumCoverRequestPtr albumcover_request);

--- a/src/lyrics/geniuslyricsprovider.cpp
+++ b/src/lyrics/geniuslyricsprovider.cpp
@@ -186,7 +186,9 @@ QByteArray GeniusLyricsProvider::authorization_header() const {
 
 }
 
-void GeniusLyricsProvider::OAuthFinished(const bool success, const QString &error) {
+void GeniusLyricsProvider::OAuthFinished(const bool success, const QString &error, const bool invalid_grant) {
+
+  Q_UNUSED(invalid_grant);
 
   if (success) {
     qLog(Debug) << "Genius: Authentication was successful.";

--- a/src/lyrics/geniuslyricsprovider.h
+++ b/src/lyrics/geniuslyricsprovider.h
@@ -85,7 +85,7 @@ class GeniusLyricsProvider : public JsonLyricsProvider {
   void EndSearch(const int id, const LyricsSearchRequest &request, const LyricsSearchResults &results = LyricsSearchResults());
 
  private Q_SLOTS:
-  void OAuthFinished(const bool success, const QString &error);
+  void OAuthFinished(const bool success, const QString &error, const bool invalid_grant = false);
   void HandleSearchReply(QNetworkReply *reply, const int id);
   void HandleLyricReply(QNetworkReply *reply, const int search_id, const QUrl &url);
 

--- a/src/scrobbler/listenbrainzscrobbler.cpp
+++ b/src/scrobbler/listenbrainzscrobbler.cpp
@@ -184,7 +184,7 @@ void ListenBrainzScrobbler::Logout() {
 
 }
 
-void ListenBrainzScrobbler::OAuthFinished(const bool success, const QString &error) {
+void ListenBrainzScrobbler::OAuthFinished(const bool success, const QString &error, const bool invalid_grant) {
 
   if (success) {
     qLog(Debug) << "ListenBrainz: Authentication was successful, login expires in" << oauth_->expires_in();
@@ -193,6 +193,9 @@ void ListenBrainzScrobbler::OAuthFinished(const bool success, const QString &err
   }
   else {
     qLog(Debug) << "ListenBrainz: Authentication failed:" << error;
+    if (invalid_grant) {
+      qLog(Debug) << "ListenBrainz: Authorization grant is no longer valid; OAuth session was cleared and the user must authenticate again.";
+    }
     Q_EMIT AuthenticationComplete(false, error);
   }
 

--- a/src/scrobbler/listenbrainzscrobbler.h
+++ b/src/scrobbler/listenbrainzscrobbler.h
@@ -78,7 +78,7 @@ class ListenBrainzScrobbler : public ScrobblerService {
   void WriteCache() override { cache_->WriteCache(); }
 
  private Q_SLOTS:
-  void OAuthFinished(const bool success, const QString &error);
+  void OAuthFinished(const bool success, const QString &error = QString(), const bool invalid_grant = false);
   void UpdateNowPlayingRequestFinished(QNetworkReply *reply);
   void ScrobbleRequestFinished(QNetworkReply *reply, ScrobblerCacheItemPtrList cache_items);
   void LoveRequestFinished(QNetworkReply *reply);

--- a/src/spotify/spotifyservice.cpp
+++ b/src/spotify/spotifyservice.cpp
@@ -270,7 +270,9 @@ void SpotifyService::ClearSession() {
 
 }
 
-void SpotifyService::OAuthFinished(const bool success, const QString &error) {
+void SpotifyService::OAuthFinished(const bool success, const QString &error, const bool invalid_grant) {
+
+  Q_UNUSED(invalid_grant);
 
   if (success) {
     Q_EMIT LoginSuccess();

--- a/src/spotify/spotifyservice.h
+++ b/src/spotify/spotifyservice.h
@@ -107,7 +107,7 @@ class SpotifyService : public StreamingService {
 
  private Q_SLOTS:
   void ExitReceived();
-  void OAuthFinished(const bool success, const QString &error = QString());
+  void OAuthFinished(const bool success, const QString &error = QString(), const bool invalid_grant = false);
   void StartSearch();
   void ArtistsResultsReceived(const int id, const SongMap &songs, const QString &error);
   void AlbumsResultsReceived(const int id, const SongMap &songs, const QString &error);

--- a/src/tidal/tidalservice.cpp
+++ b/src/tidal/tidalservice.cpp
@@ -269,7 +269,9 @@ void TidalService::StartAuthorization(const QString &client_id) {
 
 }
 
-void TidalService::OAuthFinished(const bool success, const QString &error) {
+void TidalService::OAuthFinished(const bool success, const QString &error, const bool invalid_grant) {
+
+  Q_UNUSED(invalid_grant);
 
   if (success) {
     qLog(Debug) << "Tidal: Login successful" << "user id" << user_id();

--- a/src/tidal/tidalservice.h
+++ b/src/tidal/tidalservice.h
@@ -125,7 +125,7 @@ class TidalService : public StreamingService {
 
  private Q_SLOTS:
   void ExitReceived();
-  void OAuthFinished(const bool success, const QString &error);
+  void OAuthFinished(const bool success, const QString &error, const bool invalid_grant = false);
   void StartSearch();
   void ArtistsResultsReceived(const int id, const SongMap &songs, const QString &error);
   void AlbumsResultsReceived(const int id, const SongMap &songs, const QString &error);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid authentication grants are now detected reliably, regardless of capitalization.
  * Persisted authentication tokens and related settings are cleared after an invalid grant, preventing repeated authentication failures on startup.
  * ListenBrainz reports when its OAuth session has been cleared and authentication is required again, while other authentication failures continue to be handled normally.
  * Authentication errors now display clearer messages when no additional error description is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->