### PR TITLE
Use self-hosted oauth redirect for services not accepting a random lo…

### DIFF
--- a/src/core/oauthenticator.cpp
+++ b/src/core/oauthenticator.cpp
@@ -56,7 +56,6 @@ constexpr char kExpiresIn[] = "expires_in";
 constexpr char kLoginTime[] = "login_time";
 constexpr char kUserId[] = "user_id";
 constexpr char kCountryCode[] = "country_code";
-constexpr int kMaxPortInc = 20;
 }  // namespace
 
 OAuthenticator::OAuthenticator(const SharedPtr<NetworkAccessManager> network, QObject *parent)
@@ -65,7 +64,7 @@ OAuthenticator::OAuthenticator(const SharedPtr<NetworkAccessManager> network, QO
       timer_refresh_login_(new QTimer(this)),
       type_(Type::Authorization_Code),
       use_local_redirect_server_(true),
-      random_port_(true),
+      port_type_(PortType::SetToRedirectURL),
       expires_in_(0LL),
       login_time_(0LL),
       user_id_(0) {
@@ -140,9 +139,9 @@ void OAuthenticator::set_use_local_redirect_server(const bool use_local_redirect
 
 }
 
-void OAuthenticator::set_random_port(const bool random_port) {
+void OAuthenticator::set_port_type(const PortType port_type) {
 
-  random_port_ = random_port;
+  port_type_ = port_type;
 
 }
 
@@ -228,6 +227,33 @@ void OAuthenticator::StartRefreshLoginTimer() {
 
 }
 
+QUrl OAuthenticator::EffectiveRedirectUrl() const {
+
+  QUrl redirect_url(redirect_url_);
+
+  if (!local_redirect_server_.isNull()) {
+    switch (port_type_) {
+      case PortType::SetToRedirectURL:{
+        redirect_url.setPort(local_redirect_server_->port());
+        break;
+      }
+      case PortType::PassAsUrlParam:{
+        QUrlQuery redirect_url_query(redirect_url);
+        redirect_url_query.addQueryItem(u"port"_s, QString::number(local_redirect_server_->port()));
+        redirect_url.setQuery(redirect_url_query);
+        break;
+      }
+      case PortType::PassInState:{
+        // The port travels in the "state" parameter instead.
+        break;
+      }
+    }
+  }
+
+  return redirect_url;
+
+}
+
 void OAuthenticator::Authenticate() {
 
   if (client_id_.isEmpty()) {
@@ -244,32 +270,23 @@ void OAuthenticator::Authenticate() {
     return;
   }
 
-  QUrl redirect_url(redirect_url_);
+  if (!redirect_url_.isValid()) {
+    Q_EMIT AuthenticationFinished(false, tr("Invalid redirect URL"));
+    return;
+  }
 
   if (use_local_redirect_server_) {
     local_redirect_server_.reset(new LocalRedirectServer(this));
-    bool success = false;
-    if (random_port_) {
-      success = local_redirect_server_->Listen();
-    }
-    else {
-      const int max_port = redirect_url.port() + kMaxPortInc;
-      for (int port = redirect_url.port(); port < max_port; ++port) {
-        local_redirect_server_->set_port(port);
-        if (local_redirect_server_->Listen()) {
-          success = true;
-          break;
-        }
-      }
-    }
+    const bool success = local_redirect_server_->Listen();
     if (!success) {
       Q_EMIT AuthenticationFinished(false, local_redirect_server_->error());
       local_redirect_server_.reset();
       return;
     }
     QObject::connect(&*local_redirect_server_, &LocalRedirectServer::Finished, this, &OAuthenticator::RedirectArrived);
-    redirect_url.setPort(local_redirect_server_->port());
   }
+
+  const QUrl redirect_url = EffectiveRedirectUrl();
 
   code_verifier_ = Utilities::CryptographicRandomString(44);
   code_challenge_ = QString::fromLatin1(QCryptographicHash::hash(code_verifier_.toUtf8(), QCryptographicHash::Sha256).toBase64(QByteArray::Base64UrlEncoding));
@@ -277,9 +294,14 @@ void OAuthenticator::Authenticate() {
     code_challenge_.chop(1);
   }
 
+  state_ = code_challenge_;
+  if (port_type_ == PortType::PassInState && !local_redirect_server_.isNull()) {
+    state_ += u'-' + QString::number(local_redirect_server_->port());
+  }
+
   ParamList params = ParamList() << Param(u"response_type"_s, u"code"_s)
                                  << Param(u"redirect_uri"_s, redirect_url.toString())
-                                 << Param(u"state"_s, code_challenge_)
+                                 << Param(u"state"_s, state_)
                                  << Param(u"code_challenge_method"_s, u"S256"_s)
                                  << Param(u"code_challenge"_s, code_challenge_);
 
@@ -317,9 +339,7 @@ void OAuthenticator::RedirectArrived() {
   }
 
   if (local_redirect_server_->success()) {
-    QUrl redirect_url(redirect_url_);
-    redirect_url.setPort(local_redirect_server_->port());
-    AuthorizationUrlReceived(local_redirect_server_->request_url(), redirect_url);
+    AuthorizationUrlReceived(local_redirect_server_->request_url(), EffectiveRedirectUrl());
   }
   else {
     Q_EMIT AuthenticationFinished(false, local_redirect_server_->error());
@@ -369,8 +389,8 @@ void OAuthenticator::AuthorizationUrlReceived(const QUrl &request_url, const QUr
     return;
   }
 
-  if (url_query.queryItemValue(u"state"_s) != code_challenge_) {
-    Q_EMIT AuthenticationFinished(false, tr("Request URL has wrong state %1 != %2").arg(url_query.queryItemValue(u"state"_s), code_challenge_));
+  if (url_query.queryItemValue(u"state"_s) != state_) {
+    Q_EMIT AuthenticationFinished(false, tr("Request URL has wrong state %1 != %2").arg(url_query.queryItemValue(u"state"_s), state_));
     return;
   }
 

--- a/src/core/oauthenticator.h
+++ b/src/core/oauthenticator.h
@@ -49,6 +49,12 @@ class OAuthenticator : public QObject {
     Client_Credentials
   };
 
+  enum class PortType {
+    SetToRedirectURL,
+    PassAsUrlParam,
+    PassInState
+  };
+
   void set_settings_group(const QString &settings_group);
   void set_type(const Type type);
   void set_authorize_url(const QUrl &authorize_url);
@@ -58,7 +64,7 @@ class OAuthenticator : public QObject {
   void set_client_secret(const QString &client_secret);
   void set_scope(const QString &scope);
   void set_use_local_redirect_server(const bool use_local_redirect_server);
-  void set_random_port(const bool random_port);
+  void set_port_type(const PortType port_type);
 
   QString token_type() const { return token_type_; }
   QString access_token() const { return access_token_; }
@@ -84,6 +90,7 @@ class OAuthenticator : public QObject {
   void RequestAccessToken(const QString &code = QString(), const QUrl &redirect_url = QUrl());
   void RerefreshAccessToken();
   void AuthorizationUrlReceived(const QUrl &request_url, const QUrl &redirect_url);
+  QUrl EffectiveRedirectUrl() const;
 
  Q_SIGNALS:
   void Error(const QString &error);
@@ -108,10 +115,11 @@ class OAuthenticator : public QObject {
   QString client_secret_;
   QString scope_;
   bool use_local_redirect_server_;
-  bool random_port_;
+  PortType port_type_;
 
   QString code_verifier_;
   QString code_challenge_;
+  QString state_;
 
   QString token_type_;
   QString access_token_;

--- a/src/covermanager/opentidalcoverprovider.cpp
+++ b/src/covermanager/opentidalcoverprovider.cpp
@@ -85,7 +85,7 @@ OpenTidalCoverProvider::OpenTidalCoverProvider(const SharedPtr<NetworkAccessMana
   oauth_->set_type(OAuthenticator::Type::Client_Credentials);
   oauth_->set_access_token_url(QUrl(QLatin1String(kOAuthAccessTokenUrl)));
   oauth_->set_use_local_redirect_server(false);
-  oauth_->set_random_port(false);
+  oauth_->set_port_type(OAuthenticator::PortType::SetToRedirectURL);
   QObject::connect(oauth_, &OAuthenticator::AuthenticationFinished, this, &OpenTidalCoverProvider::OAuthFinished);
 
   timer_flush_requests_->setInterval(kRequestsDelay);

--- a/src/lyrics/geniuslyricsprovider.cpp
+++ b/src/lyrics/geniuslyricsprovider.cpp
@@ -58,7 +58,7 @@ namespace {
 constexpr char kSettingsGroup[] = "GeniusLyrics";
 constexpr char kOAuthAuthorizeUrl[] = "https://api.genius.com/oauth/authorize";
 constexpr char kOAuthAccessTokenUrl[] = "https://api.genius.com/oauth/token";
-constexpr char kOAuthRedirectUrl[] = "http://localhost:63111/";  // Genius does not accept a random port number. This port must match the URL of the ClientID.
+constexpr char kOAuthRedirectUrl[] = "https://oauth.strawberrymusicplayer.org/";
 constexpr char kOAuthScope[] = "me";
 constexpr char kUrlSearch[] = "https://api.genius.com/search/";
 
@@ -90,7 +90,7 @@ GeniusLyricsProvider::GeniusLyricsProvider(const SharedPtr<NetworkAccessManager>
   oauth_->set_access_token_url(QUrl(QLatin1String(kOAuthAccessTokenUrl)));
   oauth_->set_scope(QLatin1String(kOAuthScope));
   oauth_->set_use_local_redirect_server(true);
-  oauth_->set_random_port(false);
+  oauth_->set_port_type(OAuthenticator::PortType::PassInState);
 
   QObject::connect(oauth_, &OAuthenticator::AuthenticationFinished, this, &GeniusLyricsProvider::OAuthFinished);
 

--- a/src/scrobbler/listenbrainzscrobbler.cpp
+++ b/src/scrobbler/listenbrainzscrobbler.cpp
@@ -137,7 +137,7 @@ ListenBrainzScrobbler::ListenBrainzScrobbler(const SharedPtr<ScrobblerSettingsSe
   oauth_->set_access_token_url(QUrl(QLatin1String(kOAuthAccessTokenUrl)));
   oauth_->set_scope(QLatin1String(kOAuthScope));
   oauth_->set_use_local_redirect_server(true);
-  oauth_->set_random_port(true);
+  oauth_->set_port_type(OAuthenticator::PortType::SetToRedirectURL);
 
   QObject::connect(oauth_, &OAuthenticator::AuthenticationFinished, this, &ListenBrainzScrobbler::OAuthFinished);
 

--- a/src/spotify/spotifyservice.cpp
+++ b/src/spotify/spotifyservice.cpp
@@ -53,7 +53,7 @@ namespace {
 
 constexpr char kOAuthAuthorizeUrl[] = "https://accounts.spotify.com/authorize";
 constexpr char kOAuthAccessTokenUrl[] = "https://accounts.spotify.com/api/token";
-constexpr char kOAuthRedirectUrl[] = "http://127.0.0.1:63111";
+constexpr char kOAuthRedirectUrl[] = "https://oauth.strawberrymusicplayer.org/";
 constexpr char kOAuthScope[] = "user-follow-read user-follow-modify user-library-read user-library-modify streaming";
 constexpr char kArtistsSongsTable[] = "spotify_artists_songs";
 constexpr char kAlbumsSongsTable[] = "spotify_albums_songs";
@@ -124,7 +124,7 @@ SpotifyService::SpotifyService(const SharedPtr<TaskManager> task_manager,
   oauth_->set_access_token_url(QUrl(QLatin1String(kOAuthAccessTokenUrl)));
   oauth_->set_scope(QLatin1String(kOAuthScope));
   oauth_->set_use_local_redirect_server(true);
-  oauth_->set_random_port(false);
+  oauth_->set_port_type(OAuthenticator::PortType::PassInState);
   QObject::connect(oauth_, &OAuthenticator::AuthenticationFinished, this, &SpotifyService::OAuthFinished);
 
   // Backends

--- a/src/tidal/tidalservice.cpp
+++ b/src/tidal/tidalservice.cpp
@@ -130,7 +130,7 @@ TidalService::TidalService(const SharedPtr<TaskManager> task_manager,
   oauth_->set_access_token_url(QUrl(QLatin1String(kOAuthAccessTokenUrl)));
   oauth_->set_scope(QLatin1String(kOAuthScope));
   oauth_->set_use_local_redirect_server(false);
-  oauth_->set_random_port(false);
+  oauth_->set_port_type(OAuthenticator::PortType::SetToRedirectURL);
   QObject::connect(oauth_, &OAuthenticator::AuthenticationFinished, this, &TidalService::OAuthFinished);
 
   // Backends


### PR DESCRIPTION
…calhost port

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth sign-in now supports multiple redirect-port configurations for compatibility with different service requirements.
  * Supported music services can use hosted OAuth redirect endpoints.
  * OAuth authorization state can securely carry the local redirect port when needed.

* **Bug Fixes**
  * Improved validation and construction of OAuth redirect URLs and authorization state during authentication.
  * Streamlined local redirect server setup for more reliable sign-in flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->