### PR TITLE
OAuthenticator: Make PKCE optional

### DIFF
--- a/src/core/oauthenticator.cpp
+++ b/src/core/oauthenticator.cpp
@@ -65,6 +65,7 @@ OAuthenticator::OAuthenticator(const SharedPtr<NetworkAccessManager> network, QO
       type_(Type::Authorization_Code),
       use_local_redirect_server_(true),
       port_type_(PortType::SetToRedirectURL),
+      use_pkce_(true),
       expires_in_(0LL),
       login_time_(0LL),
       user_id_(0) {
@@ -142,6 +143,12 @@ void OAuthenticator::set_use_local_redirect_server(const bool use_local_redirect
 void OAuthenticator::set_port_type(const PortType port_type) {
 
   port_type_ = port_type;
+
+}
+
+void OAuthenticator::set_use_pkce(const bool use_pkce) {
+
+  use_pkce_ = use_pkce;
 
 }
 
@@ -288,22 +295,28 @@ void OAuthenticator::Authenticate() {
 
   const QUrl redirect_url = EffectiveRedirectUrl();
 
-  code_verifier_ = Utilities::CryptographicRandomString(44);
-  code_challenge_ = QString::fromLatin1(QCryptographicHash::hash(code_verifier_.toUtf8(), QCryptographicHash::Sha256).toBase64(QByteArray::Base64UrlEncoding));
-  if (code_challenge_.lastIndexOf(u'=') == code_challenge_.length() - 1) {
-    code_challenge_.chop(1);
-  }
-
-  state_ = code_challenge_;
+  state_ = Utilities::CryptographicRandomString(32);
   if (port_type_ == PortType::PassInState && !local_redirect_server_.isNull()) {
     state_ += u'-' + QString::number(local_redirect_server_->port());
   }
 
+  if (use_pkce_) {
+    code_verifier_ = Utilities::CryptographicRandomString(44);
+    code_challenge_ = QString::fromLatin1(QCryptographicHash::hash(code_verifier_.toUtf8(), QCryptographicHash::Sha256).toBase64(QByteArray::Base64UrlEncoding | QByteArray::OmitTrailingEquals));
+  }
+  else {
+    code_verifier_.clear();
+    code_challenge_.clear();
+  }
+
   ParamList params = ParamList() << Param(u"response_type"_s, u"code"_s)
                                  << Param(u"redirect_uri"_s, redirect_url.toString())
-                                 << Param(u"state"_s, state_)
-                                 << Param(u"code_challenge_method"_s, u"S256"_s)
-                                 << Param(u"code_challenge"_s, code_challenge_);
+                                 << Param(u"state"_s, state_);
+
+  if (use_pkce_) {
+    params << Param(u"code_challenge_method"_s, u"S256"_s)
+           << Param(u"code_challenge"_s, code_challenge_);
+  }
 
   if (!client_id_.isEmpty()) {
     params << Param(u"client_id"_s, client_id_);

--- a/src/core/oauthenticator.h
+++ b/src/core/oauthenticator.h
@@ -65,6 +65,7 @@ class OAuthenticator : public QObject {
   void set_scope(const QString &scope);
   void set_use_local_redirect_server(const bool use_local_redirect_server);
   void set_port_type(const PortType port_type);
+  void set_use_pkce(const bool use_pkce);
 
   QString token_type() const { return token_type_; }
   QString access_token() const { return access_token_; }
@@ -116,10 +117,12 @@ class OAuthenticator : public QObject {
   QString scope_;
   bool use_local_redirect_server_;
   PortType port_type_;
+  bool use_pkce_;
+
+  QString state_;
 
   QString code_verifier_;
   QString code_challenge_;
-  QString state_;
 
   QString token_type_;
   QString access_token_;

--- a/src/covermanager/opentidalcoverprovider.cpp
+++ b/src/covermanager/opentidalcoverprovider.cpp
@@ -86,6 +86,8 @@ OpenTidalCoverProvider::OpenTidalCoverProvider(const SharedPtr<NetworkAccessMana
   oauth_->set_access_token_url(QUrl(QLatin1String(kOAuthAccessTokenUrl)));
   oauth_->set_use_local_redirect_server(false);
   oauth_->set_port_type(OAuthenticator::PortType::SetToRedirectURL);
+  oauth_->set_use_pkce(true);
+
   QObject::connect(oauth_, &OAuthenticator::AuthenticationFinished, this, &OpenTidalCoverProvider::OAuthFinished);
 
   timer_flush_requests_->setInterval(kRequestsDelay);

--- a/src/lyrics/geniuslyricsprovider.cpp
+++ b/src/lyrics/geniuslyricsprovider.cpp
@@ -91,6 +91,7 @@ GeniusLyricsProvider::GeniusLyricsProvider(const SharedPtr<NetworkAccessManager>
   oauth_->set_scope(QLatin1String(kOAuthScope));
   oauth_->set_use_local_redirect_server(true);
   oauth_->set_port_type(OAuthenticator::PortType::PassInState);
+  oauth_->set_use_pkce(true);
 
   QObject::connect(oauth_, &OAuthenticator::AuthenticationFinished, this, &GeniusLyricsProvider::OAuthFinished);
 

--- a/src/scrobbler/listenbrainzscrobbler.cpp
+++ b/src/scrobbler/listenbrainzscrobbler.cpp
@@ -138,6 +138,7 @@ ListenBrainzScrobbler::ListenBrainzScrobbler(const SharedPtr<ScrobblerSettingsSe
   oauth_->set_scope(QLatin1String(kOAuthScope));
   oauth_->set_use_local_redirect_server(true);
   oauth_->set_port_type(OAuthenticator::PortType::SetToRedirectURL);
+  oauth_->set_use_pkce(true);
 
   QObject::connect(oauth_, &OAuthenticator::AuthenticationFinished, this, &ListenBrainzScrobbler::OAuthFinished);
 

--- a/src/spotify/spotifyservice.cpp
+++ b/src/spotify/spotifyservice.cpp
@@ -125,6 +125,8 @@ SpotifyService::SpotifyService(const SharedPtr<TaskManager> task_manager,
   oauth_->set_scope(QLatin1String(kOAuthScope));
   oauth_->set_use_local_redirect_server(true);
   oauth_->set_port_type(OAuthenticator::PortType::PassInState);
+  oauth_->set_use_pkce(true);
+
   QObject::connect(oauth_, &OAuthenticator::AuthenticationFinished, this, &SpotifyService::OAuthFinished);
 
   // Backends

--- a/src/tidal/tidalservice.cpp
+++ b/src/tidal/tidalservice.cpp
@@ -131,6 +131,8 @@ TidalService::TidalService(const SharedPtr<TaskManager> task_manager,
   oauth_->set_scope(QLatin1String(kOAuthScope));
   oauth_->set_use_local_redirect_server(false);
   oauth_->set_port_type(OAuthenticator::PortType::SetToRedirectURL);
+  oauth_->set_use_pkce(true);
+
   QObject::connect(oauth_, &OAuthenticator::AuthenticationFinished, this, &TidalService::OAuthFinished);
 
   // Backends


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional PKCE support to OAuth authentication flows.
  - Enabled PKCE for Spotify, Tidal, ListenBrainz, Genius, and OpenTidal integrations.
  - Improved OAuth state generation and secure code challenge encoding.
  - Added a configuration option to control PKCE usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->