### PR TITLE
Fix build with tagfetcher being disabled

### DIFF
--- a/src/settings/settingsdialog.cpp
+++ b/src/settings/settingsdialog.cpp
@@ -137,7 +137,9 @@ SettingsDialog::SettingsDialog(const SharedPtr<Player> player,
   AddPage(Page::Scrobbler, new ScrobblerSettingsPage(this, scrobbler, this), general);
   AddPage(Page::Covers, new CoversSettingsPage(this, cover_providers, this), general);
   AddPage(Page::Lyrics, new LyricsSettingsPage(this, lyrics_providers, this), general);
+#ifdef HAVE_TAGFETCHER
   AddPage(Page::Acoustid, new AcoustidSettingsPage(this, this), general);
+#endif
   AddPage(Page::Transcoding, new TranscoderSettingsPage(this, this), general);
   AddPage(Page::Proxy, new NetworkProxySettingsPage(this, this), general);
 


### PR DESCRIPTION
Fixes #2310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The AcoustID settings page is now shown only when tag-fetching support is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->