### PR TITLE
Add shortcut to action "Show sidebar"

### DIFF
--- a/src/core/mainwindow.ui
+++ b/src/core/mainwindow.ui
@@ -871,6 +871,9 @@
    <property name="text">
     <string>Show sidebar</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+B</string>
+   </property>
   </action>
  </widget>
  <layoutdefault spacing="6" margin="11"/>


### PR DESCRIPTION
As described, this adds a shortcut (Ctrl + B) to be able to toggle the sidebar. I got tired of always going to the navigation bar -> tools -> show sidebar with my mouse and this seemed appropriate to fix that. Let me know if there's a problem with the keybind, alternatives could be for example Ctrl + Shift + S or Ctrl + Shift + B.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `Ctrl+B` keyboard shortcut for toggling sidebar visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->